### PR TITLE
fix: add write permissions to production deploy workflow

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -8,6 +8,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: write
+
 jobs:
   validate:
     name: Validate Deployment


### PR DESCRIPTION
GitHub Actions needs contents:write to push to the production branch.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>