### PR TITLE
fix: use AUTH_SECRET in middleware for NextAuth v5 compatibility

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -46,7 +46,7 @@ export default async function middleware(request: NextRequest) {
   // Get the JWT token (works in Edge runtime)
   const token = await getToken({
     req: request,
-    secret: process.env.NEXTAUTH_SECRET,
+    secret: process.env.AUTH_SECRET || process.env.NEXTAUTH_SECRET,
   });
 
   // Redirect unauthenticated users from protected routes to signin


### PR DESCRIPTION
NextAuth v5 signs JWTs with AUTH_SECRET, but middleware was only checking NEXTAUTH_SECRET. Falls back to NEXTAUTH_SECRET for local dev.