### PR TITLE
feat: rebrand application from ReviewFlow to BrandsIQ

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # ===========================================
-# ReviewFlow Environment Variables
+# BrandsIQ Environment Variables
 # ===========================================
 # Copy this file to .env.local and fill in your values
 # NEVER commit .env.local to version control!

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -73,7 +73,7 @@ jobs:
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: reviewflow_test
+          POSTGRES_DB: brandsiq_test
         ports:
           - 5432:5432
         options: >-
@@ -109,14 +109,14 @@ jobs:
       - name: Apply migrations to test database
         run: npx prisma migrate deploy
         env:
-          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/reviewflow_test
-          DIRECT_URL: postgresql://postgres:postgres@localhost:5432/reviewflow_test
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/brandsiq_test
+          DIRECT_URL: postgresql://postgres:postgres@localhost:5432/brandsiq_test
 
       - name: Run all tests
         run: npm run test
         env:
-          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/reviewflow_test
-          DIRECT_URL: postgresql://postgres:postgres@localhost:5432/reviewflow_test
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/brandsiq_test
+          DIRECT_URL: postgresql://postgres:postgres@localhost:5432/brandsiq_test
           NEXTAUTH_SECRET: test-secret-for-ci
           NEXT_PUBLIC_APP_URL: http://localhost:3000
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -66,7 +66,7 @@ jobs:
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: reviewflow_test
+          POSTGRES_DB: brandsiq_test
         ports:
           - 5432:5432
         options: >-
@@ -94,14 +94,14 @@ jobs:
       - name: Apply database migrations to test database
         run: npx prisma migrate deploy
         env:
-          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/reviewflow_test
-          DIRECT_URL: postgresql://postgres:postgres@localhost:5432/reviewflow_test
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/brandsiq_test
+          DIRECT_URL: postgresql://postgres:postgres@localhost:5432/brandsiq_test
 
       - name: Run integration tests
         run: npm run test:integration
         env:
-          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/reviewflow_test
-          DIRECT_URL: postgresql://postgres:postgres@localhost:5432/reviewflow_test
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/brandsiq_test
+          DIRECT_URL: postgresql://postgres:postgres@localhost:5432/brandsiq_test
           NEXTAUTH_SECRET: test-secret-for-ci
           NEXT_PUBLIC_APP_URL: http://localhost:3000
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # ===========================================
-# ReviewFlow .gitignore
+# BrandsIQ .gitignore
 # ===========================================
 
 # Environment variables - Never commit secrets!

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-ReviewFlow is an AI-powered review response management platform for SMBs. It helps businesses respond to customer reviews across multiple platforms (Google, Amazon, Yelp, etc.) using Claude-generated, brand-aligned responses in 40+ languages.
+BrandsIQ is an AI-powered review response management platform for SMBs. It helps businesses respond to customer reviews across multiple platforms (Google, Amazon, Yelp, etc.) using Claude-generated, brand-aligned responses in 40+ languages.
 
 **Tech Stack:** Next.js 14 (App Router), TypeScript, Prisma 5.22, PostgreSQL (Supabase), NextAuth.js v5, shadcn/ui, Claude API, DeepSeek API
 

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,4 +1,4 @@
-# ReviewFlow Technical Decisions
+# BrandsIQ Technical Decisions
 
 **Purpose:** Document all significant technical decisions, architectural choices, and deviations from original specifications.
 
@@ -1225,7 +1225,7 @@ ORDER BY createdAt;
   - Added `check-e2e` job that verifies latest E2E staging run passed
   - Production deploy now depends on: validate → check-e2e → test → deploy
   - Blocks production deployment if E2E failed on staging
-- PR: prajeenv/ReviewFlow#6
+- PR: prajeenv/BrandsIQ#6
 
 **February 5, 2026**
 - Implemented Review Audit Trail:

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -1,4 +1,4 @@
-# ReviewFlow Implementation Guide
+# BrandsIQ Implementation Guide
 ## AI-Assisted Development with Claude Code
 
 **Project Status:** Phase 0 Complete ✅ | Ready for Phase 1 Development
@@ -13,7 +13,7 @@
 
 ---
 
-## What is ReviewFlow?
+## What is BrandsIQ?
 
 An AI-powered review response management platform that helps SMBs automatically generate personalized, on-brand responses to customer reviews across multiple platforms (Google Business, Amazon, Shopify, Trustpilot) with:
 
@@ -153,7 +153,7 @@ Open [`docs/phase-0/10_CLAUDE_CODE_PROMPTS.md`](docs/phase-0/10_CLAUDE_CODE_PROM
 ```bash
 # 1. Clone repository
 git clone <repository-url>
-cd reviewflow
+cd brandsiq
 
 # 2. Install dependencies
 npm install
@@ -304,7 +304,7 @@ Phase 1 MVP is complete when:
 ## Project Structure After Setup
 
 ```
-reviewflow/
+brandsiq/
 ├── IMPLEMENTATION.md              ← You are here
 ├── README.md                      ← Project overview
 ├── docs/

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,6 +1,6 @@
-# ReviewFlow Development Progress
+# BrandsIQ Development Progress
 
-**Project:** ReviewFlow - AI-Powered Review Response Management Platform  
+**Project:** BrandsIQ - AI-Powered Review Response Management Platform  
 **Started:** January 7, 2026  
 **Developer:** Prajeen  
 **Current Phase:** Phase 1 - Core MVP
@@ -250,7 +250,7 @@ Type Definitions	Re-exported Prisma types + custom composite types
 Utility Functions	11 database utilities including atomic credit operations
 Test Script	Database connection and CRUD test
 Documentation	PROMPT_2_OUTCOME.md
-Repository: https://github.com/prajeenv/ReviewFlow
+Repository: https://github.com/prajeenv/BrandsIQ
 
 Latest Commit: ea0483c - feat: Implement database schema with Prisma (Prompt 2)
 
@@ -307,7 +307,7 @@ Components	LoginForm, SignupForm with password strength indicator, SessionProvid
 Utilities	Email service (Resend), Rate limiting (Upstash/in-memory), Token management
 Middleware	Protected routes for /dashboard, /reviews, /settings, /api/*
 Security	Headers (X-Frame-Options, HSTS, etc.), bcrypt (12 rounds), rate limiting
-Repository: https://github.com/prajeenv/ReviewFlow
+Repository: https://github.com/prajeenv/BrandsIQ
 
 Commit: 4c90aa9 - feat: Implement complete authentication system (Prompt 3
 
@@ -837,7 +837,7 @@ Test the brand voice test panel with different review texts and tones
 - Updated `deploy-production.yml` — gates production deploy on latest E2E status
 - Scripts: `test:e2e`, `test:e2e:headed`
 
-**PR:** prajeenv/ReviewFlow#6
+**PR:** prajeenv/BrandsIQ#6
 
 ---
 

--- a/PROJECT_SUMMARY.md
+++ b/PROJECT_SUMMARY.md
@@ -1,14 +1,14 @@
-# ReviewFlow Project Summary
+# BrandsIQ Project Summary
 
 **Last Updated:** January 20, 2026
-**Repository:** https://github.com/prajeenv/ReviewFlow
+**Repository:** https://github.com/prajeenv/BrandsIQ
 **Current Status:** Prompt 9 Complete - Credit System & Sentiment Standardization
 
 ---
 
 ## Project Overview
 
-**ReviewFlow** is an AI-powered review response management platform for SMBs. It helps businesses respond to customer reviews across multiple platforms (Google, Amazon, Yelp, etc.) using AI-generated, brand-aligned responses in 40+ languages.
+**BrandsIQ** is an AI-powered review response management platform for SMBs. It helps businesses respond to customer reviews across multiple platforms (Google, Amazon, Yelp, etc.) using AI-generated, brand-aligned responses in 40+ languages.
 
 ### Core Loop
 Reviews added → AI generates response in same language → User edits (optional) → User approves → User publishes
@@ -116,7 +116,7 @@ Reviews added → AI generates response in same language → User edits (optiona
 ## Project Structure
 
 ```
-reviewflow/
+brandsiq/
 ├── docs/phase-0/           # Specification & outcome docs
 │   ├── CORE_SPECS.md       # Product overview, database schema, API contracts
 │   ├── SECURITY_AUTH.md    # NextAuth config, security requirements

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ReviewFlow
+# BrandsIQ
 ## AI-Powered Review Response Management Platform
 
 [![Next.js](https://img.shields.io/badge/Next.js-14-black)](https://nextjs.org/)
@@ -8,11 +8,11 @@
 
 > **Save 10+ hours per week** responding to customer reviews with AI-powered, on-brand responses in 40+ languages.
 
-ReviewFlow helps SMBs automatically generate personalized, brand-aligned responses to customer reviews across multiple platforms (Google Business, Amazon, Shopify, Trustpilot) with built-in sentiment analysis and multi-language support.
+BrandsIQ helps SMBs automatically generate personalized, brand-aligned responses to customer reviews across multiple platforms (Google Business, Amazon, Shopify, Trustpilot) with built-in sentiment analysis and multi-language support.
 
 ---
 
-## 🎯 Why ReviewFlow?
+## 🎯 Why BrandsIQ?
 
 **The Problem:**
 - Businesses spend 5-15 hours/week manually responding to reviews
@@ -102,8 +102,8 @@ ReviewFlow helps SMBs automatically generate personalized, brand-aligned respons
 
 1. **Clone the repository**
    ```bash
-   git clone https://github.com/yourusername/reviewflow.git
-   cd reviewflow
+   git clone https://github.com/yourusername/brandsiq.git
+   cd brandsiq
    ```
 
 2. **Install dependencies**
@@ -119,7 +119,7 @@ ReviewFlow helps SMBs automatically generate personalized, brand-aligned respons
    Edit `.env.local` with your credentials:
    ```bash
    # Database
-   DATABASE_URL="postgresql://user:password@host:5432/reviewflow"
+   DATABASE_URL="postgresql://user:password@host:5432/brandsiq"
    
    # NextAuth
    NEXTAUTH_URL="http://localhost:3000"
@@ -187,7 +187,7 @@ Comprehensive documentation is available in the `docs/` directory:
 ## 🏗 Project Structure
 
 ```
-reviewflow/
+brandsiq/
 ├── src/
 │   ├── app/                      # Next.js 14 App Router
 │   │   ├── (auth)/               # Authentication pages
@@ -484,8 +484,8 @@ Contributions are welcome! Please follow these steps:
 ## 📞 Support
 
 - **Documentation:** Check `docs/` folder first
-- **Issues:** [GitHub Issues](https://github.com/yourusername/reviewflow/issues)
-- **Discussions:** [GitHub Discussions](https://github.com/yourusername/reviewflow/discussions)
+- **Issues:** [GitHub Issues](https://github.com/yourusername/brandsiq/issues)
+- **Discussions:** [GitHub Discussions](https://github.com/yourusername/brandsiq/discussions)
 
 ---
 
@@ -548,6 +548,6 @@ Contributions are welcome! Please follow these steps:
 
 **Built with ❤️ using AI-assisted development**
 
-[Documentation](docs/) • [Implementation Guide](IMPLEMENTATION.md) • [Report Bug](https://github.com/yourusername/reviewflow/issues) • [Request Feature](https://github.com/yourusername/reviewflow/issues)
+[Documentation](docs/) • [Implementation Guide](IMPLEMENTATION.md) • [Report Bug](https://github.com/yourusername/brandsiq/issues) • [Request Feature](https://github.com/yourusername/brandsiq/issues)
 
 </div>

--- a/docs/CI-CD/brandsiq-cicd-guide-v2.md
+++ b/docs/CI-CD/brandsiq-cicd-guide-v2.md
@@ -1,13 +1,13 @@
-# ReviewFlow CI/CD Pipeline — Complete Setup Guide (v2)
+# BrandsIQ CI/CD Pipeline — Complete Setup Guide (v2)
 
 ## Overview
 
-This guide walks you through setting up a professional CI/CD pipeline for ReviewFlow, starting from scratch.
+This guide walks you through setting up a professional CI/CD pipeline for BrandsIQ, starting from scratch.
 
 **Your Stack:** Next.js + TypeScript + Supabase + Google OAuth + Upstash Redis + Vercel
 
 **Current State:**
-- ReviewFlow code exists locally and on GitHub
+- BrandsIQ code exists locally and on GitHub
 - Supabase project exists with tables (created by Claude Code)
 - Vercel account exists but NO project set up yet
 - No test cases written yet (that's okay — we set up the pipeline first)
@@ -37,7 +37,7 @@ You'll use **both** the dashboard (browser) and CLI (terminal) for different pur
 **Dashboard** = configuration and monitoring (point and click)
 **CLI** = automation and reproducibility (commands that can run in CI/CD)
 
-The CLIs run on **your local machine** (in your terminal, inside the ReviewFlow project folder). They talk to the cloud services via API. During CI/CD, the same CLI commands run on GitHub's servers automatically.
+The CLIs run on **your local machine** (in your terminal, inside the BrandsIQ project folder). They talk to the cloud services via API. During CI/CD, the same CLI commands run on GitHub's servers automatically.
 
 ---
 
@@ -71,7 +71,7 @@ vercel --version
 ```
 
 Also make sure you have:
-- [ ] ReviewFlow repo on GitHub
+- [ ] BrandsIQ repo on GitHub
 - [ ] Node.js 18+ installed locally
 - [ ] Access to your Supabase dashboard
 - [ ] Access to your Vercel dashboard
@@ -82,12 +82,12 @@ Also make sure you have:
 
 Your tables were created by Claude Code directly in Supabase. Right now, the schema exists only in the Supabase cloud — it's not tracked in your codebase. This phase fixes that.
 
-**Where:** Run all commands in your terminal, inside your ReviewFlow project folder.
+**Where:** Run all commands in your terminal, inside your BrandsIQ project folder.
 
 ### Step 1.1: Initialize Supabase in your repo
 
 ```bash
-cd reviewflow    # or wherever your project folder is
+cd brandsiq    # or wherever your project folder is
 supabase init
 ```
 
@@ -101,7 +101,7 @@ supabase link --project-ref <your-project-ref>
 
 **Where to find your project ref:**
 1. Go to Supabase Dashboard (https://supabase.com/dashboard)
-2. Click on your ReviewFlow project
+2. Click on your BrandsIQ project
 3. Go to Project Settings (gear icon) → General
 4. Copy the "Reference ID" — it looks something like `abcdefghijklmnop`
 
@@ -123,7 +123,7 @@ Create a file called `supabase/seed.sql` with fake test data. This gets loaded i
 
 ```sql
 -- Example: Insert test data for staging/testing
--- Customize this based on your actual ReviewFlow tables
+-- Customize this based on your actual BrandsIQ tables
 INSERT INTO public.reviews (id, title, content, rating, created_at)
 VALUES
   ('test-1', 'Great product', 'Really loved using this', 5, now()),
@@ -164,7 +164,7 @@ You have a Vercel account but no project. Let's set it up.
 
 1. Go to Vercel Dashboard (https://vercel.com/dashboard)
 2. Click **"Add New..."** → **"Project"**
-3. Import your ReviewFlow GitHub repository
+3. Import your BrandsIQ GitHub repository
 4. Vercel will auto-detect it as a Next.js project
 5. **Don't add environment variables yet** — we'll do that in Phase 3
 6. Click **Deploy** — it will likely fail or show a broken app (that's fine, no env vars yet)
@@ -181,7 +181,7 @@ By default, Vercel treats `main` as the production branch. We want `main` to be 
 - Pushes to `main` → Vercel creates a **Preview deployment** (this becomes your staging)
 - Pushes to `production` branch → Vercel creates a **Production deployment**
 
-**Nothing else is needed in Vercel for staging.** Vercel's built-in Preview deployment feature + the staging-specific environment variables you set in Phase 3 together create your staging environment. No separate Vercel project or special configuration required. Vercel generates a unique URL for each Preview deploy (like `reviewflow-abc123.vercel.app`). If you want a consistent staging URL, you can optionally assign one under Settings → Domains later.
+**Nothing else is needed in Vercel for staging.** Vercel's built-in Preview deployment feature + the staging-specific environment variables you set in Phase 3 together create your staging environment. No separate Vercel project or special configuration required. Vercel generates a unique URL for each Preview deploy (like `brandsiq-abc123.vercel.app`). If you want a consistent staging URL, you can optionally assign one under Settings → Domains later.
 
 ### Step 2.3: Create the `production` branch in GitHub
 
@@ -203,7 +203,7 @@ Either method works. The branch just needs to exist on GitHub.
 ### Step 2.4: Get Vercel IDs for GitHub Actions
 
 ```bash
-# In your terminal, inside the ReviewFlow project
+# In your terminal, inside the BrandsIQ project
 vercel link
 ```
 
@@ -240,18 +240,18 @@ You'll reuse this same token for any future project's CI/CD pipeline.
 
 1. Go to Supabase Dashboard (https://supabase.com/dashboard)
 2. Click **New Project** (same account, same organization)
-3. Name: `reviewflow-staging`
+3. Name: `brandsiq-staging`
 4. Region: **same region** as your production project
 5. Set a database password — **save it securely**
 6. Wait for it to provision
 
 **You now have two Supabase projects in your account:**
-- `reviewflow` (or whatever you named it) → production
-- `reviewflow-staging` → staging
+- `brandsiq` (or whatever you named it) → production
+- `brandsiq-staging` → staging
 
 ### Step 3.2: Apply your schema to the staging database
 
-**Run this in your terminal** (on your local machine, inside the ReviewFlow folder):
+**Run this in your terminal** (on your local machine, inside the BrandsIQ folder):
 
 ```bash
 # Link to the STAGING project
@@ -280,13 +280,13 @@ supabase link --project-ref <production-project-ref>
 **Simplest approach:** Create a second free Redis database in Upstash.
 
 1. Go to Upstash Console (https://console.upstash.com/)
-2. Create a new Redis database: `reviewflow-staging`
+2. Create a new Redis database: `brandsiq-staging`
 3. Same region as your app
 4. Note the REST URL and REST Token
 
 ### Step 3.5: Set environment variables in Vercel
 
-Go to Vercel Dashboard → your ReviewFlow project → **Settings** → **Environment Variables**
+Go to Vercel Dashboard → your BrandsIQ project → **Settings** → **Environment Variables**
 
 For **each** variable, you'll add it twice — once for Preview (staging) and once for Production.
 
@@ -334,7 +334,7 @@ Go to Supabase Dashboard → your project → Settings → API
 
 ### Step 4.1: Install testing dependencies
 
-Run in your terminal, inside the ReviewFlow project:
+Run in your terminal, inside the BrandsIQ project:
 
 ```bash
 npm install --save-dev vitest @testing-library/react @testing-library/jest-dom jsdom @vitest/coverage-v8 @vitejs/plugin-react
@@ -517,7 +517,7 @@ jobs:
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: reviewflow_test
+          POSTGRES_DB: brandsiq_test
         ports:
           - 5432:5432
         options: >-
@@ -542,19 +542,19 @@ jobs:
       - name: Apply database migrations to test database
         run: |
           for f in supabase/migrations/*.sql; do
-            PGPASSWORD=postgres psql -h localhost -U postgres -d reviewflow_test -f "$f"
+            PGPASSWORD=postgres psql -h localhost -U postgres -d brandsiq_test -f "$f"
           done
 
       - name: Seed test data
         run: |
           if [ -f supabase/seed.sql ]; then
-            PGPASSWORD=postgres psql -h localhost -U postgres -d reviewflow_test -f supabase/seed.sql
+            PGPASSWORD=postgres psql -h localhost -U postgres -d brandsiq_test -f supabase/seed.sql
           fi
 
       - name: Run integration tests
         run: npm run test:integration
         env:
-          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/reviewflow_test
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/brandsiq_test
           NEXTAUTH_SECRET: test-secret-for-ci
           NEXT_PUBLIC_APP_URL: http://localhost:3000
 
@@ -647,7 +647,7 @@ jobs:
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: reviewflow_test
+          POSTGRES_DB: brandsiq_test
         ports:
           - 5432:5432
         options: >-
@@ -680,13 +680,13 @@ jobs:
       - name: Apply migrations to test database
         run: |
           for f in supabase/migrations/*.sql; do
-            PGPASSWORD=postgres psql -h localhost -U postgres -d reviewflow_test -f "$f"
+            PGPASSWORD=postgres psql -h localhost -U postgres -d brandsiq_test -f "$f"
           done
 
       - name: Run all tests
         run: npm run test
         env:
-          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/reviewflow_test
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/brandsiq_test
           NEXTAUTH_SECRET: test-secret-for-ci
           NEXT_PUBLIC_APP_URL: http://localhost:3000
 
@@ -756,7 +756,7 @@ Add each of these one by one:
 | Secret Name | What It Is | Where to Find It |
 |---|---|---|
 | SUPABASE_ACCESS_TOKEN | Your personal Supabase API token | Supabase Dashboard → click your avatar (bottom left) → Account → Access Tokens → Generate new token |
-| STAGING_SUPABASE_PROJECT_REF | Staging project reference ID | Supabase Dashboard → reviewflow-staging → Settings → General → Reference ID |
+| STAGING_SUPABASE_PROJECT_REF | Staging project reference ID | Supabase Dashboard → brandsiq-staging → Settings → General → Reference ID |
 | STAGING_SUPABASE_DB_PASSWORD | Staging database password | The password you set when creating the staging project |
 | PROD_SUPABASE_PROJECT_REF | Production project reference ID | Supabase Dashboard → your original project → Settings → General → Reference ID |
 | PROD_SUPABASE_DB_PASSWORD | Production database password | The password you set when creating your original project |
@@ -840,7 +840,7 @@ Your daily workflow:
 ## File Structure After Setup
 
 ```
-reviewflow/
+brandsiq/
 ├── .github/
 │   └── workflows/
 │       ├── pr-checks.yml           <- PR quality gate
@@ -881,7 +881,7 @@ reviewflow/
 
 ## Tips
 
-- **You can hand this document to Claude Code** for each phase and say "help me execute Phase X for ReviewFlow"
+- **You can hand this document to Claude Code** for each phase and say "help me execute Phase X for BrandsIQ"
 - **If a workflow fails**, check the Actions tab for error logs. Usually it's a missing secret or wrong project ref.
 - **Your first PR after setup** is the best test. Create a small change, open a PR, and watch the Actions tab.
 - **Test cases come later.** Pipeline works immediately with linting and type checks. Add tests at your own pace.

--- a/docs/CI-CD/brandsiq-cicd-guide-v3.md
+++ b/docs/CI-CD/brandsiq-cicd-guide-v3.md
@@ -1,15 +1,15 @@
-# ReviewFlow CI/CD Pipeline — Complete Setup Guide (v3)
+# BrandsIQ CI/CD Pipeline — Complete Setup Guide (v3)
 
 > **v3 Changes from v2:** Fixed migration strategy (Prisma instead of Supabase CLI), corrected environment variables to match actual `.env.example`, fixed Vitest path alias, added missing `prisma generate` steps in CI, added `--max-warnings 0` for ESLint strictness, added `type-check` script, safer production merge strategy. See [Changelog](#changelog-v2--v3) at the bottom for full diff.
 
 ## Overview
 
-This guide walks you through setting up a professional CI/CD pipeline for ReviewFlow, starting from scratch.
+This guide walks you through setting up a professional CI/CD pipeline for BrandsIQ, starting from scratch.
 
 **Your Stack:** Next.js 14 + TypeScript + Prisma + Supabase (PostgreSQL) + Google OAuth + Upstash Redis + Vercel
 
 **Current State:**
-- ReviewFlow code exists locally and on GitHub
+- BrandsIQ code exists locally and on GitHub
 - Supabase project exists with tables (managed by Prisma via `db push`)
 - Database schema is defined in `prisma/schema.prisma` but **no migration files exist yet** — Phase 1 creates the baseline migration
 - Vercel account exists but NO project set up yet
@@ -39,7 +39,7 @@ You'll use **both** the dashboard (browser) and CLI (terminal) for different pur
 **Dashboard** = configuration and monitoring (point and click)
 **CLI** = automation and reproducibility (commands that can run in CI/CD)
 
-The CLIs run on **your local machine** (in your terminal, inside the ReviewFlow project folder). They talk to the cloud services via API. During CI/CD, the same CLI commands run on GitHub's servers automatically.
+The CLIs run on **your local machine** (in your terminal, inside the BrandsIQ project folder). They talk to the cloud services via API. During CI/CD, the same CLI commands run on GitHub's servers automatically.
 
 ---
 
@@ -69,12 +69,12 @@ vercel --version
 ```
 
 Also make sure you have:
-- [ ] ReviewFlow repo on GitHub
+- [ ] BrandsIQ repo on GitHub
 - [ ] Node.js 18+ installed locally
 - [ ] Access to your Supabase dashboard
 - [ ] Access to your Vercel dashboard
 
-> **Note:** You do NOT need the Supabase CLI. ReviewFlow uses Prisma for all database migrations. Prisma is already a project dependency.
+> **Note:** You do NOT need the Supabase CLI. BrandsIQ uses Prisma for all database migrations. Prisma is already a project dependency.
 
 ---
 
@@ -82,7 +82,7 @@ Also make sure you have:
 
 Your schema is defined in `prisma/schema.prisma`, but there are no migration files yet — you've been using `prisma db push` to sync the schema directly. The CI/CD pipeline uses `prisma migrate deploy`, which requires migration files. This phase creates the initial baseline migration.
 
-**Where:** Run all commands in your terminal, inside your ReviewFlow project folder.
+**Where:** Run all commands in your terminal, inside your BrandsIQ project folder.
 
 ### Step 1.1: Create the baseline migration
 
@@ -139,7 +139,7 @@ You have a Vercel account but no project. Let's set it up.
 
 1. Go to Vercel Dashboard (https://vercel.com/dashboard)
 2. Click **"Add New..."** → **"Project"**
-3. Import your ReviewFlow GitHub repository
+3. Import your BrandsIQ GitHub repository
 4. Vercel will auto-detect it as a Next.js project
 5. **Don't add environment variables yet** — we'll do that in Phase 3
 6. Click **Deploy** — it will likely fail or show a broken app (that's fine, no env vars yet)
@@ -156,7 +156,7 @@ By default, Vercel treats `main` as the production branch. We want `main` to be 
 - Pushes to `main` → Vercel creates a **Preview deployment** (this becomes your staging)
 - Pushes to `production` branch → Vercel creates a **Production deployment**
 
-**Nothing else is needed in Vercel for staging.** Vercel's built-in Preview deployment feature + the staging-specific environment variables you set in Phase 3 together create your staging environment. No separate Vercel project or special configuration required. Vercel generates a unique URL for each Preview deploy (like `reviewflow-abc123.vercel.app`). If you want a consistent staging URL, you can optionally assign one under Settings → Domains later.
+**Nothing else is needed in Vercel for staging.** Vercel's built-in Preview deployment feature + the staging-specific environment variables you set in Phase 3 together create your staging environment. No separate Vercel project or special configuration required. Vercel generates a unique URL for each Preview deploy (like `brandsiq-abc123.vercel.app`). If you want a consistent staging URL, you can optionally assign one under Settings → Domains later.
 
 ### Step 2.3: Create the `production` branch in GitHub
 
@@ -178,7 +178,7 @@ Either method works. The branch just needs to exist on GitHub.
 ### Step 2.4: Get Vercel IDs for GitHub Actions
 
 ```bash
-# In your terminal, inside the ReviewFlow project
+# In your terminal, inside the BrandsIQ project
 vercel link
 ```
 
@@ -215,24 +215,24 @@ You'll reuse this same token for any future project's CI/CD pipeline.
 
 1. Go to Supabase Dashboard (https://supabase.com/dashboard)
 2. Click **New Project** (same account, same organization)
-3. Name: `reviewflow-staging`
+3. Name: `brandsiq-staging`
 4. Region: **same region** as your production project
 5. Set a database password — **save it securely**
 6. Wait for it to provision
 
 **You now have two Supabase projects in your account:**
-- `reviewflow` (or whatever you named it) → production
-- `reviewflow-staging` → staging
+- `brandsiq` (or whatever you named it) → production
+- `brandsiq-staging` → staging
 
 ### Step 3.2: Apply your schema to the staging database
 
-Get the staging database connection strings from Supabase Dashboard → `reviewflow-staging` → Settings → Database → Connection string.
+Get the staging database connection strings from Supabase Dashboard → `brandsiq-staging` → Settings → Database → Connection string.
 
 You need two URLs:
 - **Pooler URL** (port 6543, with `?pgbouncer=true`) → this is `DATABASE_URL`
 - **Direct URL** (port 5432) → this is `DIRECT_URL`
 
-**Run this in your terminal** (on your local machine, inside the ReviewFlow folder):
+**Run this in your terminal** (on your local machine, inside the BrandsIQ folder):
 
 ```bash
 # Temporarily set the staging database URL and apply migrations
@@ -249,20 +249,20 @@ This applies all existing migrations to the staging database. Now staging has th
 2. Under **Authorized redirect URIs**, add your staging URL:
    - `https://<your-staging-url>/api/auth/callback/google`
 
-> **Note:** ReviewFlow uses NextAuth.js for OAuth, not Supabase Auth. The redirect URI points to your Next.js app, not Supabase.
+> **Note:** BrandsIQ uses NextAuth.js for OAuth, not Supabase Auth. The redirect URI points to your Next.js app, not Supabase.
 
 ### Step 3.4: Configure Upstash Redis for staging
 
 **Simplest approach:** Create a second free Redis database in Upstash.
 
 1. Go to Upstash Console (https://console.upstash.com/)
-2. Create a new Redis database: `reviewflow-staging`
+2. Create a new Redis database: `brandsiq-staging`
 3. Same region as your app
 4. Note the REST URL and REST Token
 
 ### Step 3.5: Set environment variables in Vercel
 
-Go to Vercel Dashboard → your ReviewFlow project → **Settings** → **Environment Variables**
+Go to Vercel Dashboard → your BrandsIQ project → **Settings** → **Environment Variables**
 
 For **each** variable, you'll add it twice — once for Preview (staging) and once for Production.
 
@@ -318,7 +318,7 @@ Go to Supabase Dashboard → your project → Settings → Database → Connecti
 
 ### Step 4.1: Install testing dependencies
 
-Run in your terminal, inside the ReviewFlow project:
+Run in your terminal, inside the BrandsIQ project:
 
 ```bash
 npm install --save-dev vitest @testing-library/react @testing-library/jest-dom jsdom @vitest/coverage-v8 @vitejs/plugin-react
@@ -529,7 +529,7 @@ jobs:
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: reviewflow_test
+          POSTGRES_DB: brandsiq_test
         ports:
           - 5432:5432
         options: >-
@@ -557,14 +557,14 @@ jobs:
       - name: Apply database migrations to test database
         run: npx prisma migrate deploy
         env:
-          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/reviewflow_test
-          DIRECT_URL: postgresql://postgres:postgres@localhost:5432/reviewflow_test
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/brandsiq_test
+          DIRECT_URL: postgresql://postgres:postgres@localhost:5432/brandsiq_test
 
       - name: Run integration tests
         run: npm run test:integration
         env:
-          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/reviewflow_test
-          DIRECT_URL: postgresql://postgres:postgres@localhost:5432/reviewflow_test
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/brandsiq_test
+          DIRECT_URL: postgresql://postgres:postgres@localhost:5432/brandsiq_test
           NEXTAUTH_SECRET: test-secret-for-ci
           NEXT_PUBLIC_APP_URL: http://localhost:3000
 
@@ -660,7 +660,7 @@ jobs:
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: reviewflow_test
+          POSTGRES_DB: brandsiq_test
         ports:
           - 5432:5432
         options: >-
@@ -696,14 +696,14 @@ jobs:
       - name: Apply migrations to test database
         run: npx prisma migrate deploy
         env:
-          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/reviewflow_test
-          DIRECT_URL: postgresql://postgres:postgres@localhost:5432/reviewflow_test
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/brandsiq_test
+          DIRECT_URL: postgresql://postgres:postgres@localhost:5432/brandsiq_test
 
       - name: Run all tests
         run: npm run test
         env:
-          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/reviewflow_test
-          DIRECT_URL: postgresql://postgres:postgres@localhost:5432/reviewflow_test
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/brandsiq_test
+          DIRECT_URL: postgresql://postgres:postgres@localhost:5432/brandsiq_test
           NEXTAUTH_SECRET: test-secret-for-ci
           NEXT_PUBLIC_APP_URL: http://localhost:3000
 
@@ -775,8 +775,8 @@ Add each of these one by one:
 
 | Secret Name          | What It Is                                   | Where to Find It                                                                                                             |
 | -------------------- | -------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| STAGING_DATABASE_URL | Staging Supabase pooler connection string    | Supabase Dashboard → reviewflow-staging → Settings → Database → Connection string (port 6543, append `?pgbouncer=true`)      |
-| STAGING_DIRECT_URL   | Staging Supabase direct connection string    | Supabase Dashboard → reviewflow-staging → Settings → Database → Connection string (port 5432)                                |
+| STAGING_DATABASE_URL | Staging Supabase pooler connection string    | Supabase Dashboard → brandsiq-staging → Settings → Database → Connection string (port 6543, append `?pgbouncer=true`)      |
+| STAGING_DIRECT_URL   | Staging Supabase direct connection string    | Supabase Dashboard → brandsiq-staging → Settings → Database → Connection string (port 5432)                                |
 | PROD_DATABASE_URL    | Production Supabase pooler connection string | Supabase Dashboard → your production project → Settings → Database → Connection string (port 6543, append `?pgbouncer=true`) |
 | PROD_DIRECT_URL      | Production Supabase direct connection string | Supabase Dashboard → your production project → Settings → Database → Connection string (port 5432)                           |
 | VERCEL_TOKEN         | Vercel API token                             | Created in Phase 2, Step 2.5                                                                                                 |
@@ -862,7 +862,7 @@ Your daily workflow:
 ## File Structure After Setup
 
 ```
-reviewflow/
+brandsiq/
 ├── .github/
 │   └── workflows/
 │       ├── pr-checks.yml           <- PR quality gate
@@ -904,7 +904,7 @@ reviewflow/
 
 ## Tips
 
-- **You can hand this document to Claude Code** for each phase and say "help me execute Phase X for ReviewFlow"
+- **You can hand this document to Claude Code** for each phase and say "help me execute Phase X for BrandsIQ"
 - **If a workflow fails**, check the Actions tab for error logs. Usually it's a missing secret or wrong connection string.
 - **Your first PR after setup** is the best test. Create a small change, open a PR, and watch the Actions tab.
 - **Test cases come later.** Pipeline works immediately with linting and type checks. Add tests at your own pace.
@@ -928,7 +928,7 @@ reviewflow/
 | **Production merge** | `git merge main --no-edit` | `git merge main --ff-only` | Fast-forward only is safer. Fails loudly if branches diverged instead of creating a potentially broken merge. |
 | **Staging workflow name** | "Deploy to Staging" | "Staging — Apply Migrations" | More accurate. The workflow only applies DB migrations. Vercel handles the actual app deploy via Git integration. |
 | **GitHub secrets** | `SUPABASE_ACCESS_TOKEN`, `STAGING_SUPABASE_PROJECT_REF`, `STAGING_SUPABASE_DB_PASSWORD`, `PROD_SUPABASE_PROJECT_REF`, `PROD_SUPABASE_DB_PASSWORD` | `STAGING_DATABASE_URL`, `STAGING_DIRECT_URL`, `PROD_DATABASE_URL`, `PROD_DIRECT_URL` | Prisma connects via connection string directly — no Supabase CLI auth needed. Fewer secrets, simpler setup. |
-| **OAuth redirect URI** | `https://<ref>.supabase.co/auth/v1/callback` | `https://<staging-url>/api/auth/callback/google` | ReviewFlow uses NextAuth.js, not Supabase Auth. Redirect URI points to Next.js app. |
+| **OAuth redirect URI** | `https://<ref>.supabase.co/auth/v1/callback` | `https://<staging-url>/api/auth/callback/google` | BrandsIQ uses NextAuth.js, not Supabase Auth. Redirect URI points to Next.js app. |
 | **Prerequisites** | Install Supabase CLI + Vercel CLI | Install Vercel CLI only | Supabase CLI not needed. Prisma is already a project dependency. |
 | **`DIRECT_URL` in CI tests** | Not included | Added alongside `DATABASE_URL` | Prisma requires `DIRECT_URL` for migrations (defined in `schema.prisma`). Missing it causes migration failures. |
 | **Integration test migrations** | Raw SQL via `psql` loop over `supabase/migrations/*.sql` | `npx prisma migrate deploy` | Prisma handles migration ordering, state tracking, and application. Raw SQL doesn't track migration state. |

--- a/docs/DOCUMENTATION_ROADMAP.md
+++ b/docs/DOCUMENTATION_ROADMAP.md
@@ -2,7 +2,7 @@
 
 **Version:** 1.0  
 **Last Updated:** January 2025  
-**Product:** ReviewFlow (AI Review Management Platform)
+**Product:** BrandsIQ (AI Review Management Platform)
 
 ---
 
@@ -47,7 +47,7 @@
 ### Contents:
 
 ```markdown
-# ReviewFlow: AI Review Management Platform
+# BrandsIQ: AI Review Management Platform
 
 ## Who Uses It
 - Local businesses (restaurants, retail, services) managing Google/Yelp reviews
@@ -1838,7 +1838,7 @@ export async function GET() {
 ```bash
 GOOGLE_OAUTH_CLIENT_ID="..."
 GOOGLE_OAUTH_CLIENT_SECRET="..."
-GOOGLE_OAUTH_REDIRECT_URI="https://app.reviewflow.com/api/integrations/google/callback"
+GOOGLE_OAUTH_REDIRECT_URI="https://app.brandsiq.app/api/integrations/google/callback"
 ```
 
 ### Feature Flag
@@ -2295,7 +2295,7 @@ Allow user to export:
 ## Legal Request Handling
 
 ### Law Enforcement Requests
-1. Receive request via security@reviewflow.com
+1. Receive request via security@brandsiq.app
 2. Verify legitimacy (legal team)
 3. Extract requested data
 4. Log access
@@ -2719,7 +2719,7 @@ At 100% of quota:
 
 ## Overview
 
-Allow third-party developers to integrate with ReviewFlow.
+Allow third-party developers to integrate with BrandsIQ.
 
 ## Authentication
 

--- a/docs/phase-0/CLAUDE_CODE_PROMPTS.md
+++ b/docs/phase-0/CLAUDE_CODE_PROMPTS.md
@@ -1,9 +1,9 @@
-# ReviewFlow: Claude Code Implementation Prompts
+# BrandsIQ: Claude Code Implementation Prompts
 ## Complete Development Sequence for MVP Phase 1
 
 **Version:** 2.0 (Regenerated from condensed documentation)  
 **Created:** January 2026  
-**Purpose:** Step-by-step prompts for Claude Code to implement ReviewFlow MVP  
+**Purpose:** Step-by-step prompts for Claude Code to implement BrandsIQ MVP  
 **Timeline:** 14 days (2 weeks)  
 **Tech Stack:** Next.js 14, TypeScript, Prisma, Supabase, NextAuth.js, Tailwind CSS, shadcn/ui
 
@@ -50,7 +50,7 @@ Review the 3 condensed documentation files to understand the complete project sc
 ## Prompt
 
 ```
-I'm building ReviewFlow, an AI-powered review response management platform for SMBs. 
+I'm building BrandsIQ, an AI-powered review response management platform for SMBs. 
 I've completed Phase 0 documentation condensed into 3 files.
 
 Please review all 3 documentation files and create an implementation plan that includes:
@@ -128,13 +128,13 @@ Reference: `docs/phase-0/CORE_SPECS.md` (tech stack section)
 ## Prompt
 
 ```
-Set up the ReviewFlow project from scratch with all necessary configurations.
+Set up the BrandsIQ project from scratch with all necessary configurations.
 
 **Tasks:**
 
 1. **Initialize Next.js Project**
    ```bash
-   npx create-next-app@latest reviewflow \
+   npx create-next-app@latest brandsiq \
      --typescript \
      --tailwind \
      --app \
@@ -186,7 +186,7 @@ Set up the ReviewFlow project from scratch with all necessary configurations.
 
 6. **Create Folder Structure**
    ```
-   reviewflow/
+   brandsiq/
      src/
        app/
          (auth)/
@@ -239,7 +239,7 @@ Set up the ReviewFlow project from scratch with all necessary configurations.
    Update `tsconfig.json` with strict mode and path aliases.
 
 8. **Configure Tailwind**
-   Add custom colors for ReviewFlow brand (indigo/blue theme).
+   Add custom colors for BrandsIQ brand (indigo/blue theme).
 
 9. **Create .gitignore**
    Ensure `.env.local`, `node_modules/`, `.next/` are ignored.

--- a/docs/phase-0/CORE_SPECS.md
+++ b/docs/phase-0/CORE_SPECS.md
@@ -1,11 +1,11 @@
-# ReviewFlow: Core Specifications (Condensed)
+# BrandsIQ: Core Specifications (Condensed)
 **Version:** 1.0 | **Phase:** MVP | **Timeline:** Weeks 1-2
 
 ---
 
 ## Product Overview
 
-**ReviewFlow** = AI-powered review response management platform for SMBs. Supports 40+ languages, multiple platforms (Google, Amazon, Shopify, Trustpilot, etc.), generates brand-aligned responses using Claude AI.
+**BrandsIQ** = AI-powered review response management platform for SMBs. Supports 40+ languages, multiple platforms (Google, Amazon, Shopify, Trustpilot, etc.), generates brand-aligned responses using Claude AI.
 
 **Core Loop:**
 Reviews added → AI generates response in same language → User edits (optional) → User approves → User publishes

--- a/docs/phase-0/IMPLEMENTATION_GUIDE.md
+++ b/docs/phase-0/IMPLEMENTATION_GUIDE.md
@@ -1,4 +1,4 @@
-# ReviewFlow: Implementation Guide (Condensed)
+# BrandsIQ: Implementation Guide (Condensed)
 **Version:** 1.0 | **Phase:** MVP | **Focus:** User Flows, Multi-Language, Sentiment, Edge Cases
 
 ---

--- a/docs/phase-0/PROMPT_0_OUTCOME.md
+++ b/docs/phase-0/PROMPT_0_OUTCOME.md
@@ -6,7 +6,7 @@
 
 ## Executive Summary
 
-Prompt 0 validated the Phase 0 specifications and created a comprehensive implementation plan for ReviewFlow. All technology choices were confirmed as compatible, the 11-prompt sequence was validated as logical, and potential challenges were identified with mitigations.
+Prompt 0 validated the Phase 0 specifications and created a comprehensive implementation plan for BrandsIQ. All technology choices were confirmed as compatible, the 11-prompt sequence was validated as logical, and potential challenges were identified with mitigations.
 
 ---
 
@@ -43,7 +43,7 @@ Prompt 0 validated the Phase 0 specifications and created a comprehensive implem
 ### Approved Folder Structure
 
 ```
-reviewflow/
+brandsiq/
 ├── app/                          # Next.js 14 App Router
 │   ├── (auth)/                   # Auth route group
 │   │   ├── auth/
@@ -302,7 +302,7 @@ NEXT_PUBLIC_APP_URL="http://localhost:3000"
 **Prompt 1: Project Setup & Configuration**
 
 Once all API keys are obtained, proceed with:
-1. `npx create-next-app@latest reviewflow`
+1. `npx create-next-app@latest brandsiq`
 2. Install all dependencies
 3. Configure TypeScript, Tailwind, ESLint
 4. Set up shadcn/ui

--- a/docs/phase-0/PROMPT_1_OUTCOME.md
+++ b/docs/phase-0/PROMPT_1_OUTCOME.md
@@ -6,7 +6,7 @@
 
 ## Executive Summary
 
-Prompt 1 successfully set up the ReviewFlow project from scratch with all necessary configurations. The project is now ready for development with a working `npm run dev` command.
+Prompt 1 successfully set up the BrandsIQ project from scratch with all necessary configurations. The project is now ready for development with a working `npm run dev` command.
 
 ---
 
@@ -15,7 +15,7 @@ Prompt 1 successfully set up the ReviewFlow project from scratch with all necess
 ### Project Initialization
 - [x] Initialized Next.js 14.2.35 with App Router
 - [x] Configured TypeScript 5.x with strict mode
-- [x] Set up Tailwind CSS 3.4 with ReviewFlow brand colors
+- [x] Set up Tailwind CSS 3.4 with BrandsIQ brand colors
 - [x] Created src/ directory structure
 
 ### Dependencies Installed
@@ -53,7 +53,7 @@ Prompt 1 successfully set up the ReviewFlow project from scratch with all necess
 ### Folder Structure Created
 
 ```
-reviewflow/
+brandsiq/
 ├── src/
 │   ├── app/
 │   │   ├── (auth)/
@@ -165,7 +165,7 @@ reviewflow/
    npm run dev
    ```
    - Visit http://localhost:3000
-   - Verify landing page loads with ReviewFlow branding
+   - Verify landing page loads with BrandsIQ branding
    - Check "Sign In" and "Get Started" links work
 
 2. **Page Routes**

--- a/docs/phase-0/PROMPT_3_OUTCOME.md
+++ b/docs/phase-0/PROMPT_3_OUTCOME.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-Implemented the complete authentication system for ReviewFlow using NextAuth.js v5 (beta) with email/password credentials and Google OAuth support. The system includes email verification, password reset flows, rate limiting, and protected routes.
+Implemented the complete authentication system for BrandsIQ using NextAuth.js v5 (beta) with email/password credentials and Google OAuth support. The system includes email verification, password reset flows, rate limiting, and protected routes.
 
 ---
 

--- a/docs/phase-0/SECURITY_AUTH.md
+++ b/docs/phase-0/SECURITY_AUTH.md
@@ -1,4 +1,4 @@
-# ReviewFlow: Security & Authentication (Condensed)
+# BrandsIQ: Security & Authentication (Condensed)
 **Version:** 1.0 | **Phase:** MVP | **Focus:** NextAuth.js, Security, GDPR
 
 ---
@@ -16,7 +16,7 @@ npm install -D @types/bcryptjs
 # .env.local
 NEXTAUTH_URL="http://localhost:3000"
 NEXTAUTH_SECRET="<generate with: openssl rand -base64 32>"
-DATABASE_URL="postgresql://user:password@host:5432/reviewflow"
+DATABASE_URL="postgresql://user:password@host:5432/brandsiq"
 RESEND_API_KEY="re_..."
 GOOGLE_CLIENT_ID="123456789-abcdefg.apps.googleusercontent.com"
 GOOGLE_CLIENT_SECRET="GOCSPX-abc123def456"
@@ -232,11 +232,11 @@ export async function sendVerificationEmail(email: string, token: string) {
   const verificationUrl = `${process.env.NEXTAUTH_URL}/auth/verify-email?token=${token}`;
   
   await resend.emails.send({
-    from: "ReviewFlow <noreply@reviewflow.com>",
+    from: "BrandsIQ <noreply@brandsiq.app>",
     to: email,
     subject: "Verify your email address",
     html: `
-      <h1>Welcome to ReviewFlow!</h1>
+      <h1>Welcome to BrandsIQ!</h1>
       <p>Please verify your email address by clicking the link below:</p>
       <a href="${verificationUrl}">Verify Email</a>
       <p>This link expires in 24 hours.</p>
@@ -248,7 +248,7 @@ export async function sendPasswordResetEmail(email: string, token: string) {
   const resetUrl = `${process.env.NEXTAUTH_URL}/auth/reset-password?token=${token}`;
   
   await resend.emails.send({
-    from: "ReviewFlow <noreply@reviewflow.com>",
+    from: "BrandsIQ <noreply@brandsiq.app>",
     to: email,
     subject: "Reset your password",
     html: `
@@ -405,7 +405,7 @@ export async function GET(req: Request) {
   // Return as JSON download
   return NextResponse.json(userData, {
     headers: {
-      "Content-Disposition": `attachment; filename="reviewflow-data-${userId}.json"`,
+      "Content-Disposition": `attachment; filename="brandsiq-data-${userId}.json"`,
       "Content-Type": "application/json"
     }
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "reviewflow",
+  "name": "brandsiq",
   "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "reviewflow",
+      "name": "brandsiq",
       "version": "1.0.1",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "reviewflow",
+  "name": "brandsiq",
   "version": "1.0.1",
   "private": true,
   "description": "AI-powered review response management platform for SMBs",
@@ -30,7 +30,7 @@
     "nextjs",
     "typescript"
   ],
-  "author": "ReviewFlow",
+  "author": "BrandsIQ",
   "license": "MIT",
   "dependencies": {
     "@anthropic-ai/sdk": "^0.71.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from '@playwright/test';
 
 /**
- * Playwright E2E test configuration for ReviewFlow
+ * Playwright E2E test configuration for BrandsIQ
  *
  * Tests run against the staging URL after deployment.
  * Set STAGING_URL env var to override the default.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,5 +1,5 @@
 // ===========================================
-// ReviewFlow Prisma Schema
+// BrandsIQ Prisma Schema
 // Database: Supabase PostgreSQL
 // ===========================================
 

--- a/prisma/secure-tables.sql
+++ b/prisma/secure-tables.sql
@@ -1,5 +1,5 @@
 -- ============================================
--- ReviewFlow: Disable Supabase API Access for All Tables
+-- BrandsIQ: Disable Supabase API Access for All Tables
 -- ============================================
 -- This script revokes ALL permissions from anon and authenticated roles.
 -- Since we use Prisma (with postgres/service_role) for all database

--- a/src/app/(auth)/auth/signin/page.tsx
+++ b/src/app/(auth)/auth/signin/page.tsx
@@ -4,8 +4,8 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { LoginForm } from "@/components/auth";
 
 export const metadata: Metadata = {
-  title: "Sign In - ReviewFlow",
-  description: "Sign in to your ReviewFlow account",
+  title: "Sign In - BrandsIQ",
+  description: "Sign in to your BrandsIQ account",
 };
 
 function LoginFormWrapper() {

--- a/src/app/(auth)/auth/signup/page.tsx
+++ b/src/app/(auth)/auth/signup/page.tsx
@@ -4,8 +4,8 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { SignupForm } from "@/components/auth";
 
 export const metadata: Metadata = {
-  title: "Sign Up - ReviewFlow",
-  description: "Create your ReviewFlow account",
+  title: "Sign Up - BrandsIQ",
+  description: "Create your BrandsIQ account",
 };
 
 function SignupFormWrapper() {
@@ -17,13 +17,13 @@ export default function SignUpPage() {
     <Card>
       <CardHeader className="space-y-1 text-center">
         <div className="flex justify-center mb-4">
-          <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-primary text-primary-foreground text-xl font-bold">
-            R
+          <div className="flex h-12 items-center justify-center rounded-lg bg-primary text-primary-foreground text-xl font-bold px-3">
+            IQ
           </div>
         </div>
         <CardTitle className="text-2xl font-bold">Create an account</CardTitle>
         <CardDescription>
-          Get started with ReviewFlow for free
+          Get started with BrandsIQ for free
         </CardDescription>
       </CardHeader>
       <CardContent>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,8 +7,8 @@ import "./globals.css";
 
 export const metadata: Metadata = {
   title: {
-    default: "ReviewFlow - AI-Powered Review Response Management",
-    template: "%s | ReviewFlow",
+    default: "BrandsIQ - AI-Powered Review Response Management",
+    template: "%s | BrandsIQ",
   },
   description:
     "Save 10+ hours per week responding to customer reviews with AI-powered, brand-aligned responses in 40+ languages.",
@@ -19,20 +19,20 @@ export const metadata: Metadata = {
     "brand voice",
     "multi-language",
   ],
-  authors: [{ name: "ReviewFlow" }],
-  creator: "ReviewFlow",
+  authors: [{ name: "BrandsIQ" }],
+  creator: "BrandsIQ",
   openGraph: {
     type: "website",
     locale: "en_US",
     url: process.env.NEXT_PUBLIC_APP_URL,
-    title: "ReviewFlow - AI-Powered Review Response Management",
+    title: "BrandsIQ - AI-Powered Review Response Management",
     description:
       "Save 10+ hours per week responding to customer reviews with AI-powered, brand-aligned responses in 40+ languages.",
-    siteName: "ReviewFlow",
+    siteName: "BrandsIQ",
   },
   twitter: {
     card: "summary_large_image",
-    title: "ReviewFlow - AI-Powered Review Response Management",
+    title: "BrandsIQ - AI-Powered Review Response Management",
     description:
       "Save 10+ hours per week responding to customer reviews with AI-powered, brand-aligned responses in 40+ languages.",
   },

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,10 +8,10 @@ export default function HomePage() {
       <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
         <div className="container flex h-16 items-center justify-between">
           <div className="flex items-center gap-2">
-            <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-brand-500 text-white font-bold">
-              R
+            <div className="flex h-8 items-center justify-center rounded-lg bg-brand-500 text-white font-bold px-2 text-sm">
+              IQ
             </div>
-            <span className="text-xl font-bold">ReviewFlow</span>
+            <span className="text-xl font-bold">BrandsIQ</span>
           </div>
           <nav className="flex items-center gap-4">
             <Link
@@ -322,13 +322,13 @@ export default function HomePage() {
       <footer className="border-t py-8">
         <div className="container flex flex-col items-center justify-between gap-4 md:flex-row">
           <div className="flex items-center gap-2">
-            <div className="flex h-6 w-6 items-center justify-center rounded bg-brand-500 text-white text-xs font-bold">
-              R
+            <div className="flex h-6 items-center justify-center rounded bg-brand-500 text-white text-xs font-bold px-1.5">
+              IQ
             </div>
-            <span className="text-sm font-medium">ReviewFlow</span>
+            <span className="text-sm font-medium">BrandsIQ</span>
           </div>
           <p className="text-sm text-muted-foreground">
-            &copy; {new Date().getFullYear()} ReviewFlow. All rights reserved.
+            &copy; {new Date().getFullYear()} BrandsIQ. All rights reserved.
           </p>
         </div>
       </footer>

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -29,7 +29,7 @@ const plans: Plan[] = [
   {
     tier: "FREE",
     name: "Free",
-    description: "Perfect for trying out ReviewFlow",
+    description: "Perfect for trying out BrandsIQ",
     price: 0,
     credits: TIER_LIMITS.FREE.credits,
     sentimentQuota: TIER_LIMITS.FREE.sentimentQuota,
@@ -239,7 +239,7 @@ export default function PricingPage() {
             <div>
               <h3 className="font-semibold mb-2">What languages are supported?</h3>
               <p className="text-muted-foreground text-sm">
-                ReviewFlow supports 40+ languages including English, Spanish, French, German,
+                BrandsIQ supports 40+ languages including English, Spanish, French, German,
                 Japanese, Chinese, Arabic, and many more. Responses are generated natively in
                 the detected language.
               </p>

--- a/src/components/dashboard/DashboardHeader.tsx
+++ b/src/components/dashboard/DashboardHeader.tsx
@@ -55,7 +55,7 @@ export function DashboardHeader({ onMenuClick, tier = "FREE" }: DashboardHeaderP
           <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary">
             <Sparkles className="h-5 w-5 text-primary-foreground" />
           </div>
-          <span className="font-bold">ReviewFlow</span>
+          <span className="font-bold">BrandsIQ</span>
         </Link>
 
         {/* Spacer */}

--- a/src/components/dashboard/Sidebar.tsx
+++ b/src/components/dashboard/Sidebar.tsx
@@ -48,7 +48,7 @@ export function Sidebar({ isOpen = true, onClose, isMobile = false }: SidebarPro
           <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary">
             <Sparkles className="h-5 w-5 text-primary-foreground" />
           </div>
-          <span className="text-xl font-bold">ReviewFlow</span>
+          <span className="text-xl font-bold">BrandsIQ</span>
         </Link>
         {isMobile && onClose && (
           <Button variant="ghost" size="icon" onClick={onClose} className="lg:hidden">
@@ -88,7 +88,7 @@ export function Sidebar({ isOpen = true, onClose, isMobile = false }: SidebarPro
       {/* Footer */}
       <div className="border-t p-4">
         <p className="text-xs text-muted-foreground text-center">
-          ReviewFlow v1.0
+          BrandsIQ v1.0
         </p>
       </div>
     </>

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -15,7 +15,7 @@ const badgeVariants = cva(
         destructive:
           "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
         outline: "text-foreground",
-        // Custom variants for ReviewFlow
+        // Custom variants for BrandsIQ
         positive:
           "border-transparent bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-100",
         neutral:

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,5 +1,5 @@
 /**
- * Application constants for ReviewFlow
+ * Application constants for BrandsIQ
  */
 
 // Review platforms supported

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { PLATFORMS, SENTIMENTS, RESPONSE_TONES, VALIDATION_LIMITS } from "./constants";
 
 /**
- * Zod validation schemas for ReviewFlow
+ * Zod validation schemas for BrandsIQ
  */
 
 // Auth schemas

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,5 @@
 /**
- * Type definitions for ReviewFlow
+ * Type definitions for BrandsIQ
  */
 
 export * from "./api";

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -17,7 +17,7 @@ const config: Config = {
     },
     extend: {
       colors: {
-        // ReviewFlow Brand Colors (Indigo/Blue theme)
+        // BrandsIQ Brand Colors (Indigo/Blue theme)
         brand: {
           50: "#eef2ff",
           100: "#e0e7ff",

--- a/tests/e2e/landing.spec.ts
+++ b/tests/e2e/landing.spec.ts
@@ -5,7 +5,7 @@ test.describe('Landing Page', () => {
     await page.goto('/');
 
     // Check page title
-    await expect(page).toHaveTitle(/ReviewFlow/);
+    await expect(page).toHaveTitle(/BrandsIQ/);
 
     // Hero heading visible
     await expect(page.locator('h1')).toContainText('Respond to Reviews');

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -1,5 +1,5 @@
 /**
- * Shared test fixtures for ReviewFlow tests
+ * Shared test fixtures for BrandsIQ tests
  */
 
 export const TEST_USER = {


### PR DESCRIPTION
## Summary
Full application-wide rebrand from **ReviewFlow** to **BrandsIQ** after domain change to `brandsiq.app`. Builds on PR #11 (email rebrand).

## Changes

### Source code (user-facing)
- Landing page, auth pages, pricing, dashboard header/sidebar
- All Next.js metadata (title, description, OpenGraph, Twitter)
- Logo icon: `R` → `IQ` with updated width styling

### Configuration
- `package.json`: `name: "reviewflow"` → `"brandsiq"`, author updated
- `.env.example`, `.gitignore`, `tailwind.config.ts`, `playwright.config.ts`
- `prisma/schema.prisma`, `prisma/secure-tables.sql` comments
- Regenerated `package-lock.json`

### CI/CD
- Test database renamed: `reviewflow_test` → `brandsiq_test` in `pr-checks.yml` and `deploy-production.yml`

### Tests
- E2E landing page title assertion
- Fixture file comments

### Documentation
- All root docs: `README.md`, `CLAUDE.md`, `DECISIONS.md`, `PROGRESS.md`, `PROJECT_SUMMARY.md`, `IMPLEMENTATION.md`
- All `docs/phase-0/*.md` files
- Renamed CI-CD guide files: `reviewflow-cicd-guide-v{2,3}.md` → `brandsiq-cicd-guide-v{2,3}.md`

## Verification
- [x] TypeScript type check passes
- [x] ESLint passes
- [x] Email unit tests pass (12/12)
- [x] `grep ReviewFlow` in `src/` returns 0 matches
- [ ] E2E tests against staging (runs after merge to main)

## Follow-up (out of scope)
- GitHub repository rename: `prajeenv/ReviewFlow` → `prajeenv/BrandsIQ` (user does manually on GitHub)
- Update git remote URL locally after rename
- Vercel staging URL stays unchanged (brandsiq.app is production custom domain only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)