### PR TITLE
fix: add manual pageview tracking for PostHog

### DIFF
--- a/src/components/providers/PostHogProvider.tsx
+++ b/src/components/providers/PostHogProvider.tsx
@@ -1,16 +1,41 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, Suspense } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
 import posthog from "posthog-js";
 import { PostHogProvider as PHProvider } from "posthog-js/react";
+
+function PostHogPageView() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    if (pathname && posthog) {
+      let url = window.origin + pathname;
+      if (searchParams.toString()) {
+        url = url + "?" + searchParams.toString();
+      }
+      posthog.capture("$pageview", { $current_url: url });
+    }
+  }, [pathname, searchParams]);
+
+  return null;
+}
 
 export function PostHogProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     posthog.init(process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN as string, {
       api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
-      capture_pageview: false, // We'll capture manually to avoid double-counting with App Router
+      capture_pageview: false, // Manually captured via PostHogPageView for App Router
     });
   }, []);
 
-  return <PHProvider client={posthog}>{children}</PHProvider>;
+  return (
+    <PHProvider client={posthog}>
+      <Suspense fallback={null}>
+        <PostHogPageView />
+      </Suspense>
+      {children}
+    </PHProvider>
+  );
 }


### PR DESCRIPTION
## Summary
- Add `PostHogPageView` component that captures `$pageview` on every App Router route change
- Fixes missing pageview data in PostHog dashboard
- Wrapped in `Suspense` boundary as required by `useSearchParams`

## Test plan
- [x] Build passes
- [ ] Verify pageview events appear in PostHog after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)