### PR TITLE
fix: restore default Sentry integrations for server and edge

### DIFF
--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -5,5 +5,4 @@ Sentry.init({
   enabled: process.env.NODE_ENV === "production",
   environment: process.env.NODE_ENV,
   tracesSampleRate: 0,
-  integrations: [],
 });

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -5,5 +5,4 @@ Sentry.init({
   enabled: process.env.NODE_ENV === "production",
   environment: process.env.NODE_ENV,
   tracesSampleRate: 0,
-  integrations: [],
 });


### PR DESCRIPTION
## Summary
Fixes server-side errors not reaching Sentry. The `integrations: []` empty array in `sentry.server.config.ts` and `sentry.edge.config.ts` was replacing the SDK's default integrations, disabling the HTTP and Node instrumentation Sentry needs to auto-capture unhandled errors thrown from App Router route handlers.

The client config keeps `integrations: []` intentionally to skip tracing/replay (we don't want those). On server/edge we omit the field entirely to preserve defaults.

## How this was discovered
After merging prajeenv/BrandsIQ#27 and deploying to production:
- Client-side test (`/sentry-example-page` button click) ✓ errors reached Sentry
- Server-side test (`GET /api/sentry-example-api`) ✗ HTTP 500 returned but no event in Sentry
- Vercel env vars (`NEXT_PUBLIC_SENTRY_DSN` and `SENTRY_DSN`) were both confirmed set

Root cause: the empty integrations array removed the auto-instrumentation needed to capture thrown errors in route handlers.

## Test plan
- [x] Build passes (`npm run build`)
- [ ] After merge + deploy: `curl https://<prod>/api/sentry-example-api` → verify event in Sentry EU dashboard tagged with `runtime: node`

🤖 Generated with [Claude Code](https://claude.com/claude-code)