### PR TITLE
fix: flush Sentry buffer in API routes for Vercel serverless

### DIFF
--- a/src/app/api/sentry-example-api/route.ts
+++ b/src/app/api/sentry-example-api/route.ts
@@ -1,5 +1,15 @@
+import * as Sentry from "@sentry/nextjs";
+
 export const dynamic = "force-dynamic";
 
 export async function GET() {
-  throw new Error("Sentry server test error");
+  try {
+    throw new Error("Sentry server test error");
+  } catch (error) {
+    Sentry.captureException(error);
+    // Required on Vercel serverless: Lambda shuts down before Sentry's
+    // background flush completes. Must await flush to force event send.
+    await Sentry.flush(2000);
+    throw error;
+  }
 }


### PR DESCRIPTION
## Summary
Fixes server-side errors still not reaching Sentry after prajeenv/BrandsIQ#28 was merged.

## Root cause
On Vercel's Lambda-based serverless runtime, the function terminates immediately after returning a response — before Sentry's background task can send the buffered error event. The error is captured correctly, but the HTTP request to Sentry's ingest endpoint is killed mid-flight when Lambda shuts down.

This is a well-documented Sentry + Vercel issue ([sentry-javascript#3917](https://github.com/getsentry/sentry-javascript/issues/3917)) and Sentry's own [Next.js usage guide](https://docs.sentry.io/platforms/javascript/guides/nextjs/usage/) recommends manual flushing.

## Fix
Wrap the example API route in try/catch, explicitly call `Sentry.captureException`, then `await Sentry.flush(2000)` before re-throwing. The flush forces buffered events to send before Lambda terminates.

## Note on real API routes
All existing API routes (`/api/reviews`, `/api/credits`, etc.) already use try/catch to return structured 4xx responses — they are not affected by this issue for handled errors. If any route starts re-throwing uncaught errors in the future, it will need the same flush treatment.

## Test plan
- [x] Build passes
- [ ] After merge + deploy: `curl https://www.brandsiq.app/api/sentry-example-api` → verify event in Sentry EU dashboard tagged with `runtime: node`

🤖 Generated with [Claude Code](https://claude.com/claude-code)