### PR TITLE
debug: add diagnostic logs to trace Sentry server init

### DIFF
--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console -- temporary diagnostic logging, will be reverted */
 import * as Sentry from "@sentry/nextjs";
 
 console.log("[sentry-debug] server config loading", {

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -1,8 +1,18 @@
 import * as Sentry from "@sentry/nextjs";
 
+console.log("[sentry-debug] server config loading", {
+  hasDsn: !!process.env.SENTRY_DSN,
+  dsnPrefix: process.env.SENTRY_DSN?.substring(0, 20),
+  nodeEnv: process.env.NODE_ENV,
+  vercelEnv: process.env.VERCEL_ENV,
+});
+
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   enabled: process.env.NODE_ENV === "production",
   environment: process.env.NODE_ENV,
   tracesSampleRate: 0,
+  debug: true,
 });
+
+console.log("[sentry-debug] server config initialized");

--- a/src/app/api/sentry-example-api/route.ts
+++ b/src/app/api/sentry-example-api/route.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console -- temporary diagnostic logging, will be reverted */
 import * as Sentry from "@sentry/nextjs";
 
 export const dynamic = "force-dynamic";

--- a/src/app/api/sentry-example-api/route.ts
+++ b/src/app/api/sentry-example-api/route.ts
@@ -3,13 +3,23 @@ import * as Sentry from "@sentry/nextjs";
 export const dynamic = "force-dynamic";
 
 export async function GET() {
+  console.log("[sentry-debug] route handler invoked", {
+    hasDsn: !!process.env.SENTRY_DSN,
+    clientReady: !!Sentry.getClient(),
+    nodeEnv: process.env.NODE_ENV,
+  });
+
   try {
     throw new Error("Sentry server test error");
   } catch (error) {
-    Sentry.captureException(error);
+    console.log("[sentry-debug] calling captureException");
+    const eventId = Sentry.captureException(error);
+    console.log("[sentry-debug] captureException returned", { eventId });
     // Required on Vercel serverless: Lambda shuts down before Sentry's
     // background flush completes. Must await flush to force event send.
-    await Sentry.flush(2000);
+    console.log("[sentry-debug] awaiting flush");
+    const flushed = await Sentry.flush(2000);
+    console.log("[sentry-debug] flush returned", { flushed });
     throw error;
   }
 }


### PR DESCRIPTION
## Summary
Temporary diagnostic PR to investigate why server-side errors from `/api/sentry-example-api` are not reaching Sentry on production, despite the flush fix in prajeenv/BrandsIQ#29.

## Logs added
1. **On server startup** (`sentry.server.config.ts`) — logs whether `SENTRY_DSN` is set, its prefix, and `NODE_ENV`/`VERCEL_ENV`. Confirms whether `instrumentation.ts` is loading the config file at all.
2. **On route handler entry** (`/api/sentry-example-api`) — logs whether the Sentry client is ready (`Sentry.getClient()` truthy).
3. **After capture/flush** — logs the event ID from `captureException` and the boolean return from `flush()`.
4. **Sentry `debug: true`** — surfaces SDK-internal errors in Vercel function logs.

## Test plan
After merge + deploy:
1. Hit `https://www.brandsiq.app/api/sentry-example-api`
2. Open Vercel dashboard → project → Deployments → latest → Runtime Logs
3. Filter by `/api/sentry-example-api` or `sentry-debug`
4. Share the log output so we can diagnose the root cause

## Cleanup
This PR will be **reverted** once the root cause is identified and a proper fix is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)