### PR TITLE
fix: enable experimental.instrumentationHook for Next.js 14

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -28,6 +28,10 @@ const nextConfig = {
     serverActions: {
       bodySizeLimit: "2mb",
     },
+    // Required in Next.js 14.2 to enable instrumentation.ts hook.
+    // Without this, Sentry server/edge configs never load.
+    // Promoted to stable in Next.js 15 — can be removed after upgrade.
+    instrumentationHook: true,
   },
 
   // Security headers

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -1,19 +1,8 @@
-/* eslint-disable no-console -- temporary diagnostic logging, will be reverted */
 import * as Sentry from "@sentry/nextjs";
-
-console.log("[sentry-debug] server config loading", {
-  hasDsn: !!process.env.SENTRY_DSN,
-  dsnPrefix: process.env.SENTRY_DSN?.substring(0, 20),
-  nodeEnv: process.env.NODE_ENV,
-  vercelEnv: process.env.VERCEL_ENV,
-});
 
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   enabled: process.env.NODE_ENV === "production",
   environment: process.env.NODE_ENV,
   tracesSampleRate: 0,
-  debug: true,
 });
-
-console.log("[sentry-debug] server config initialized");

--- a/src/app/api/sentry-example-api/route.ts
+++ b/src/app/api/sentry-example-api/route.ts
@@ -1,26 +1,15 @@
-/* eslint-disable no-console -- temporary diagnostic logging, will be reverted */
 import * as Sentry from "@sentry/nextjs";
 
 export const dynamic = "force-dynamic";
 
 export async function GET() {
-  console.log("[sentry-debug] route handler invoked", {
-    hasDsn: !!process.env.SENTRY_DSN,
-    clientReady: !!Sentry.getClient(),
-    nodeEnv: process.env.NODE_ENV,
-  });
-
   try {
     throw new Error("Sentry server test error");
   } catch (error) {
-    console.log("[sentry-debug] calling captureException");
-    const eventId = Sentry.captureException(error);
-    console.log("[sentry-debug] captureException returned", { eventId });
+    Sentry.captureException(error);
     // Required on Vercel serverless: Lambda shuts down before Sentry's
     // background flush completes. Must await flush to force event send.
-    console.log("[sentry-debug] awaiting flush");
-    const flushed = await Sentry.flush(2000);
-    console.log("[sentry-debug] flush returned", { flushed });
+    await Sentry.flush(2000);
     throw error;
   }
 }


### PR DESCRIPTION
## Summary
**Root cause of Sentry server-side events not reaching the dashboard.**

In Next.js 14.2, `instrumentation.ts` is not loaded by default. You must explicitly opt in with `experimental.instrumentationHook: true` in `next.config.mjs`. Without it, Next.js never calls the `register()` function in `instrumentation.ts`, so `sentry.server.config.ts` is never imported and Sentry's server client is never initialized.

This flag was promoted to stable in Next.js 15 and can be removed on upgrade.

## Evidence
Diagnostic logs from the debug PR (prajeenv/BrandsIQ#30) showed:
```
[sentry-debug] route handler invoked { hasDsn: true, clientReady: false, nodeEnv: 'production' }
[sentry-debug] captureException returned { eventId: '21e745...' }
[sentry-debug] flush returned { flushed: false }
```

- `hasDsn: true` → env var was present ✓
- `clientReady: false` → Sentry server client was **never initialized** ✗
- `flushed: false` → nothing to flush, confirming no active client
- **No** `[sentry-debug] server config loading` log → confirming `sentry.server.config.ts` never ran

## Changes
1. **`next.config.mjs`** — add `experimental.instrumentationHook: true` with a comment explaining it can be removed in Next 15
2. **`sentry.server.config.ts`** — revert diagnostic `console.log` and `debug: true`
3. **`src/app/api/sentry-example-api/route.ts`** — revert diagnostic `console.log`

## Reference
https://nextjs.org/docs/14/pages/api-reference/next-config-js/instrumentationHook

## Test plan
- [x] `npm run lint:strict` passes
- [x] `npm run build` passes
- [ ] After merge + deploy: `curl https://www.brandsiq.app/api/sentry-example-api` → verify event appears in Sentry EU dashboard tagged with `runtime: node`

🤖 Generated with [Claude Code](https://claude.com/claude-code)