### PR TITLE
debug: trace instrumentation.ts register() execution

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,12 +1,26 @@
+/* eslint-disable no-console -- temporary diagnostic logging */
 import * as Sentry from "@sentry/nextjs";
 
+console.log("[sentry-debug] instrumentation.ts module evaluated", {
+  nextRuntime: process.env.NEXT_RUNTIME,
+  nodeEnv: process.env.NODE_ENV,
+});
+
 export async function register() {
+  console.log("[sentry-debug] register() called", {
+    nextRuntime: process.env.NEXT_RUNTIME,
+  });
+
   if (process.env.NEXT_RUNTIME === "nodejs") {
+    console.log("[sentry-debug] importing sentry.server.config");
     await import("./sentry.server.config");
+    console.log("[sentry-debug] sentry.server.config imported");
   }
 
   if (process.env.NEXT_RUNTIME === "edge") {
+    console.log("[sentry-debug] importing sentry.edge.config");
     await import("./sentry.edge.config");
+    console.log("[sentry-debug] sentry.edge.config imported");
   }
 }
 

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -1,8 +1,19 @@
+/* eslint-disable no-console -- temporary diagnostic logging */
 import * as Sentry from "@sentry/nextjs";
+
+console.log("[sentry-debug] sentry.server.config.ts evaluating", {
+  hasDsn: !!process.env.SENTRY_DSN,
+  nodeEnv: process.env.NODE_ENV,
+});
 
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   enabled: process.env.NODE_ENV === "production",
   environment: process.env.NODE_ENV,
   tracesSampleRate: 0,
+  debug: true,
+});
+
+console.log("[sentry-debug] Sentry.init completed", {
+  clientReady: !!Sentry.getClient(),
 });

--- a/src/app/api/sentry-example-api/route.ts
+++ b/src/app/api/sentry-example-api/route.ts
@@ -1,15 +1,23 @@
+/* eslint-disable no-console -- temporary diagnostic logging */
 import * as Sentry from "@sentry/nextjs";
 
 export const dynamic = "force-dynamic";
 
 export async function GET() {
+  console.log("[sentry-debug] route handler invoked", {
+    hasDsn: !!process.env.SENTRY_DSN,
+    clientReady: !!Sentry.getClient(),
+    nodeEnv: process.env.NODE_ENV,
+    nextRuntime: process.env.NEXT_RUNTIME,
+  });
+
   try {
-    throw new Error("Sentry server test error");
+    throw new Error("Sentry server test error v2");
   } catch (error) {
-    Sentry.captureException(error);
-    // Required on Vercel serverless: Lambda shuts down before Sentry's
-    // background flush completes. Must await flush to force event send.
-    await Sentry.flush(2000);
+    const eventId = Sentry.captureException(error);
+    console.log("[sentry-debug] captureException returned", { eventId });
+    const flushed = await Sentry.flush(2000);
+    console.log("[sentry-debug] flush returned", { flushed });
     throw error;
   }
 }


### PR DESCRIPTION
## Summary
Second diagnostic PR. The `experimental.instrumentationHook: true` fix in prajeenv/BrandsIQ#31 was not sufficient — server errors are still not reaching Sentry.

## Logs added
1. **`instrumentation.ts` top-level** — confirms the file is loaded at all
2. **`register()` entry** — confirms Next.js is calling the hook
3. **Before/after dynamic import** — confirms `sentry.server.config` import succeeds
4. **`sentry.server.config.ts` top-level** — confirms the import ran
5. **After `Sentry.init`** — confirms client creation (`Sentry.getClient()`)
6. **Route handler entry** — confirms client survived to request time

Also enables Sentry `debug: true` for SDK-internal errors.

## Expected outcomes
After deploy + hit `/api/sentry-example-api`, the Vercel logs should reveal exactly which step fails. Possible findings:

- No logs at all from `instrumentation.ts` → Next.js still isn't loading the hook despite the flag
- `register()` called but wrong `NEXT_RUNTIME` → the conditional is skipping the import
- Import succeeds but `clientReady: false` after init → Sentry SDK internal issue

## Cleanup
Will be reverted once root cause is identified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)