### PR TITLE
chore: revert diagnostic console logs added during Sentry debugging

### DIFF
--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -1,19 +1,8 @@
-/* eslint-disable no-console -- temporary diagnostic logging */
 import * as Sentry from "@sentry/nextjs";
-
-console.log("[sentry-debug] sentry.server.config.ts evaluating", {
-  hasDsn: !!process.env.SENTRY_DSN,
-  nodeEnv: process.env.NODE_ENV,
-});
 
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   enabled: process.env.NODE_ENV === "production",
   environment: process.env.NODE_ENV,
   tracesSampleRate: 0,
-  debug: true,
-});
-
-console.log("[sentry-debug] Sentry.init completed", {
-  clientReady: !!Sentry.getClient(),
 });

--- a/src/app/api/sentry-example-api/route.ts
+++ b/src/app/api/sentry-example-api/route.ts
@@ -1,23 +1,15 @@
-/* eslint-disable no-console -- temporary diagnostic logging */
 import * as Sentry from "@sentry/nextjs";
 
 export const dynamic = "force-dynamic";
 
 export async function GET() {
-  console.log("[sentry-debug] route handler invoked", {
-    hasDsn: !!process.env.SENTRY_DSN,
-    clientReady: !!Sentry.getClient(),
-    nodeEnv: process.env.NODE_ENV,
-    nextRuntime: process.env.NEXT_RUNTIME,
-  });
-
   try {
-    throw new Error("Sentry server test error v2");
+    throw new Error("Sentry server test error");
   } catch (error) {
-    const eventId = Sentry.captureException(error);
-    console.log("[sentry-debug] captureException returned", { eventId });
-    const flushed = await Sentry.flush(2000);
-    console.log("[sentry-debug] flush returned", { flushed });
+    Sentry.captureException(error);
+    // Required on Vercel serverless: Lambda shuts down before Sentry's
+    // background flush completes. Must await flush to force event send.
+    await Sentry.flush(2000);
     throw error;
   }
 }

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,26 +1,12 @@
-/* eslint-disable no-console -- temporary diagnostic logging */
 import * as Sentry from "@sentry/nextjs";
 
-console.log("[sentry-debug] instrumentation.ts module evaluated", {
-  nextRuntime: process.env.NEXT_RUNTIME,
-  nodeEnv: process.env.NODE_ENV,
-});
-
 export async function register() {
-  console.log("[sentry-debug] register() called", {
-    nextRuntime: process.env.NEXT_RUNTIME,
-  });
-
   if (process.env.NEXT_RUNTIME === "nodejs") {
-    console.log("[sentry-debug] importing sentry.server.config");
     await import("../sentry.server.config");
-    console.log("[sentry-debug] sentry.server.config imported");
   }
 
   if (process.env.NEXT_RUNTIME === "edge") {
-    console.log("[sentry-debug] importing sentry.edge.config");
     await import("../sentry.edge.config");
-    console.log("[sentry-debug] sentry.edge.config imported");
   }
 }
 


### PR DESCRIPTION
## Summary
Cleanup PR. Removes the temporary `[sentry-debug]` console.log statements and the `debug: true` Sentry flag added across three debug PRs (prajeenv/BrandsIQ#30, prajeenv/BrandsIQ#32, prajeenv/BrandsIQ#33) while investigating why server-side errors were not reaching Sentry.

Root cause was identified and fixed in prajeenv/BrandsIQ#33 — `instrumentation.ts` must be inside `src/` when a `src/` directory is used. Server-side error capture is now confirmed working in Sentry EU dashboard (both client and server test errors visible).

## Files reverted
- `src/instrumentation.ts` — remove top-level and `register()` logs
- `sentry.server.config.ts` — remove logs, remove `debug: true`
- `src/app/api/sentry-example-api/route.ts` — remove logs, restore original error message

## Kept
The example test page (`/sentry-example-page`) and API route (`/api/sentry-example-api`) are **kept** so they can be used for future verification (e.g. after future deploys or config changes). They're harmless — only trigger errors when explicitly visited.

## Test plan
- [x] `npm run lint:strict` passes
- [x] `npx tsc --noEmit` passes
- [ ] After merge + deploy: hit `/api/sentry-example-api` → verify event still reaches Sentry (i.e. the revert didn't break anything)

🤖 Generated with [Claude Code](https://claude.com/claude-code)