### PR TITLE
test: expand test coverage with 134 new component and API tests

### DIFF
--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,5 +1,14 @@
 import '@testing-library/jest-dom';
 
+// Polyfill ResizeObserver for Radix UI components (Slider, etc.) in jsdom
+if (typeof global.ResizeObserver === 'undefined') {
+  global.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}
+
 // Set default environment variables for tests (prevents failures in CI)
 process.env.NEXTAUTH_URL = process.env.NEXTAUTH_URL || 'http://localhost:3000';
 process.env.AUTH_SECRET = process.env.AUTH_SECRET || 'test-secret-for-vitest-unit-tests';

--- a/tests/unit/api/sentiment/sentiment-usage.test.ts
+++ b/tests/unit/api/sentiment/sentiment-usage.test.ts
@@ -1,0 +1,275 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Hoisted mocks
+const { mockPrisma, mockSession, mockNullSession } = vi.hoisted(() => {
+  const mockPrisma = {
+    sentimentUsage: {
+      count: vi.fn(),
+      findMany: vi.fn(),
+    },
+    review: {
+      groupBy: vi.fn(),
+    },
+    user: {
+      findUnique: vi.fn(),
+    },
+  };
+
+  const mockSession = {
+    user: { id: "user_1", email: "test@example.com", name: "Test", tier: "FREE" },
+    expires: new Date(Date.now() + 86400000).toISOString(),
+  };
+
+  const mockNullSession = null;
+
+  return { mockPrisma, mockSession, mockNullSession };
+});
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: mockPrisma,
+}));
+
+import { GET } from "@/app/api/sentiment/usage/route";
+import { auth } from "@/lib/auth";
+import { parseResponse } from "../../../helpers/api-test-helpers";
+import { NextRequest } from "next/server";
+
+function createNextRequest(path: string, params?: Record<string, string>): NextRequest {
+  const url = new URL(path, "http://localhost:3000");
+  if (params) {
+    for (const [key, value] of Object.entries(params)) {
+      url.searchParams.set(key, value);
+    }
+  }
+  return new NextRequest(url);
+}
+
+describe("GET /api/sentiment/usage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(auth).mockResolvedValue(mockSession as any);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    vi.mocked(auth).mockResolvedValue(mockNullSession as any);
+
+    const request = createNextRequest("/api/sentiment/usage");
+    const response = await GET(request);
+    const result = await parseResponse(response);
+
+    expect(result.status).toBe(401);
+    expect(result.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns sentiment usage history with pagination", async () => {
+    const mockRecords = [
+      {
+        id: "su_1",
+        userId: "user_1",
+        reviewId: "rev_1",
+        sentiment: "positive",
+        details: JSON.stringify({ reviewId: "rev_1", platform: "Google", rating: 5 }),
+        createdAt: new Date(),
+        review: {
+          id: "rev_1",
+          platform: "Google",
+          rating: 5,
+          reviewText: "Great product, very satisfied!",
+        },
+      },
+    ];
+
+    mockPrisma.sentimentUsage.count.mockResolvedValue(1);
+    mockPrisma.sentimentUsage.findMany.mockResolvedValue(mockRecords);
+    mockPrisma.review.groupBy.mockResolvedValue([
+      { sentiment: "positive", _count: { sentiment: 5 } },
+      { sentiment: "negative", _count: { sentiment: 2 } },
+      { sentiment: "neutral", _count: { sentiment: 3 } },
+    ]);
+    mockPrisma.user.findUnique.mockResolvedValue({
+      tier: "FREE",
+      sentimentCredits: 30,
+      sentimentResetDate: new Date("2026-03-01"),
+    });
+
+    const request = createNextRequest("/api/sentiment/usage");
+    const response = await GET(request);
+    const result = await parseResponse(response);
+
+    expect(result.status).toBe(200);
+    expect(result.body.success).toBe(true);
+    expect(result.body.data.usage).toHaveLength(1);
+    expect(result.body.data.usage[0].sentiment).toBe("positive");
+    expect(result.body.data.usage[0].platform).toBe("Google");
+    expect(result.body.data.pagination.page).toBe(1);
+    expect(result.body.data.pagination.totalCount).toBe(1);
+  });
+
+  it("returns sentiment distribution percentages", async () => {
+    mockPrisma.sentimentUsage.count.mockResolvedValue(0);
+    mockPrisma.sentimentUsage.findMany.mockResolvedValue([]);
+    mockPrisma.review.groupBy.mockResolvedValue([
+      { sentiment: "positive", _count: { sentiment: 6 } },
+      { sentiment: "negative", _count: { sentiment: 2 } },
+      { sentiment: "neutral", _count: { sentiment: 2 } },
+    ]);
+    mockPrisma.user.findUnique.mockResolvedValue({
+      tier: "FREE",
+      sentimentCredits: 25,
+      sentimentResetDate: new Date("2026-03-01"),
+    });
+
+    const request = createNextRequest("/api/sentiment/usage");
+    const response = await GET(request);
+    const result = await parseResponse(response);
+
+    expect(result.body.data.distribution.positive).toBe(60);
+    expect(result.body.data.distribution.negative).toBe(20);
+    expect(result.body.data.distribution.neutral).toBe(20);
+    expect(result.body.data.distribution.total).toBe(10);
+  });
+
+  it("applies sentiment filter", async () => {
+    mockPrisma.sentimentUsage.count.mockResolvedValue(0);
+    mockPrisma.sentimentUsage.findMany.mockResolvedValue([]);
+    mockPrisma.review.groupBy.mockResolvedValue([]);
+    mockPrisma.user.findUnique.mockResolvedValue({
+      tier: "FREE",
+      sentimentCredits: 35,
+      sentimentResetDate: new Date("2026-03-01"),
+    });
+
+    const request = createNextRequest("/api/sentiment/usage", { sentiment: "positive" });
+    const response = await GET(request);
+    const result = await parseResponse(response);
+
+    expect(result.status).toBe(200);
+    // Verify sentiment filter was passed to count and findMany
+    expect(mockPrisma.sentimentUsage.count).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          sentiment: "positive",
+        }),
+      })
+    );
+  });
+
+  it("applies date range filters", async () => {
+    mockPrisma.sentimentUsage.count.mockResolvedValue(0);
+    mockPrisma.sentimentUsage.findMany.mockResolvedValue([]);
+    mockPrisma.review.groupBy.mockResolvedValue([]);
+    mockPrisma.user.findUnique.mockResolvedValue({
+      tier: "FREE",
+      sentimentCredits: 35,
+      sentimentResetDate: new Date("2026-03-01"),
+    });
+
+    const request = createNextRequest("/api/sentiment/usage", {
+      startDate: "2026-01-01",
+      endDate: "2026-01-31",
+    });
+    const response = await GET(request);
+    const result = await parseResponse(response);
+
+    expect(result.status).toBe(200);
+    expect(mockPrisma.sentimentUsage.count).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          createdAt: expect.objectContaining({
+            gte: expect.any(Date),
+            lte: expect.any(Date),
+          }),
+        }),
+      })
+    );
+  });
+
+  it("returns quota information from user tier", async () => {
+    mockPrisma.sentimentUsage.count.mockResolvedValue(0);
+    mockPrisma.sentimentUsage.findMany.mockResolvedValue([]);
+    mockPrisma.review.groupBy.mockResolvedValue([]);
+    mockPrisma.user.findUnique.mockResolvedValue({
+      tier: "FREE",
+      sentimentCredits: 30,
+      sentimentResetDate: new Date("2026-03-01"),
+    });
+
+    const request = createNextRequest("/api/sentiment/usage");
+    const response = await GET(request);
+    const result = await parseResponse(response);
+
+    expect(result.body.data.quota.remaining).toBe(30);
+    expect(result.body.data.quota.total).toBe(35); // FREE tier total
+    expect(result.body.data.quota.used).toBe(5); // 35 - 30
+  });
+
+  it("falls back to details JSON when review is deleted", async () => {
+    const mockRecords = [
+      {
+        id: "su_2",
+        userId: "user_1",
+        reviewId: null, // Review was deleted
+        sentiment: "negative",
+        details: JSON.stringify({
+          reviewId: "rev_deleted",
+          platform: "Amazon",
+          rating: 2,
+        }),
+        createdAt: new Date(),
+        review: null, // FK is null
+      },
+    ];
+
+    mockPrisma.sentimentUsage.count.mockResolvedValue(1);
+    mockPrisma.sentimentUsage.findMany.mockResolvedValue(mockRecords);
+    mockPrisma.review.groupBy.mockResolvedValue([]);
+    mockPrisma.user.findUnique.mockResolvedValue({
+      tier: "FREE",
+      sentimentCredits: 35,
+      sentimentResetDate: new Date("2026-03-01"),
+    });
+
+    const request = createNextRequest("/api/sentiment/usage");
+    const response = await GET(request);
+    const result = await parseResponse(response);
+
+    expect(result.body.data.usage[0].reviewId).toBe("rev_deleted");
+    expect(result.body.data.usage[0].platform).toBe("Amazon");
+    expect(result.body.data.usage[0].rating).toBe(2);
+    expect(result.body.data.usage[0].isDeleted).toBe(true);
+    expect(result.body.data.usage[0].preview).toBeNull();
+  });
+
+  it("respects pagination params", async () => {
+    mockPrisma.sentimentUsage.count.mockResolvedValue(50);
+    mockPrisma.sentimentUsage.findMany.mockResolvedValue([]);
+    mockPrisma.review.groupBy.mockResolvedValue([]);
+    mockPrisma.user.findUnique.mockResolvedValue({
+      tier: "FREE",
+      sentimentCredits: 35,
+      sentimentResetDate: new Date("2026-03-01"),
+    });
+
+    const request = createNextRequest("/api/sentiment/usage", { page: "2", limit: "10" });
+    const response = await GET(request);
+    const result = await parseResponse(response);
+
+    expect(result.body.data.pagination.page).toBe(2);
+    expect(result.body.data.pagination.limit).toBe(10);
+    expect(result.body.data.pagination.totalPages).toBe(5);
+    expect(result.body.data.pagination.hasNextPage).toBe(true);
+    expect(result.body.data.pagination.hasPrevPage).toBe(true);
+
+    // Verify skip/take used correctly
+    expect(mockPrisma.sentimentUsage.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        skip: 10,
+        take: 10,
+      })
+    );
+  });
+});

--- a/tests/unit/api/sentiment/sentiment-usage.test.ts
+++ b/tests/unit/api/sentiment/sentiment-usage.test.ts
@@ -59,7 +59,7 @@ describe("GET /api/sentiment/usage", () => {
 
     const request = createNextRequest("/api/sentiment/usage");
     const response = await GET(request);
-    const result = await parseResponse(response);
+    const result = await parseResponse<any>(response);
 
     expect(result.status).toBe(401);
     expect(result.body.error.code).toBe("UNAUTHORIZED");
@@ -98,7 +98,7 @@ describe("GET /api/sentiment/usage", () => {
 
     const request = createNextRequest("/api/sentiment/usage");
     const response = await GET(request);
-    const result = await parseResponse(response);
+    const result = await parseResponse<any>(response);
 
     expect(result.status).toBe(200);
     expect(result.body.success).toBe(true);
@@ -125,7 +125,7 @@ describe("GET /api/sentiment/usage", () => {
 
     const request = createNextRequest("/api/sentiment/usage");
     const response = await GET(request);
-    const result = await parseResponse(response);
+    const result = await parseResponse<any>(response);
 
     expect(result.body.data.distribution.positive).toBe(60);
     expect(result.body.data.distribution.negative).toBe(20);
@@ -145,7 +145,7 @@ describe("GET /api/sentiment/usage", () => {
 
     const request = createNextRequest("/api/sentiment/usage", { sentiment: "positive" });
     const response = await GET(request);
-    const result = await parseResponse(response);
+    const result = await parseResponse<any>(response);
 
     expect(result.status).toBe(200);
     // Verify sentiment filter was passed to count and findMany
@@ -173,7 +173,7 @@ describe("GET /api/sentiment/usage", () => {
       endDate: "2026-01-31",
     });
     const response = await GET(request);
-    const result = await parseResponse(response);
+    const result = await parseResponse<any>(response);
 
     expect(result.status).toBe(200);
     expect(mockPrisma.sentimentUsage.count).toHaveBeenCalledWith(
@@ -200,7 +200,7 @@ describe("GET /api/sentiment/usage", () => {
 
     const request = createNextRequest("/api/sentiment/usage");
     const response = await GET(request);
-    const result = await parseResponse(response);
+    const result = await parseResponse<any>(response);
 
     expect(result.body.data.quota.remaining).toBe(30);
     expect(result.body.data.quota.total).toBe(35); // FREE tier total
@@ -235,7 +235,7 @@ describe("GET /api/sentiment/usage", () => {
 
     const request = createNextRequest("/api/sentiment/usage");
     const response = await GET(request);
-    const result = await parseResponse(response);
+    const result = await parseResponse<any>(response);
 
     expect(result.body.data.usage[0].reviewId).toBe("rev_deleted");
     expect(result.body.data.usage[0].platform).toBe("Amazon");
@@ -256,7 +256,7 @@ describe("GET /api/sentiment/usage", () => {
 
     const request = createNextRequest("/api/sentiment/usage", { page: "2", limit: "10" });
     const response = await GET(request);
-    const result = await parseResponse(response);
+    const result = await parseResponse<any>(response);
 
     expect(result.body.data.pagination.page).toBe(2);
     expect(result.body.data.pagination.limit).toBe(10);

--- a/tests/unit/components/auth/login-form.test.tsx
+++ b/tests/unit/components/auth/login-form.test.tsx
@@ -1,0 +1,160 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockPush = vi.fn();
+const mockRefresh = vi.fn();
+const mockSignIn = vi.fn();
+
+vi.mock("next/link", () => ({
+  default: ({ children, href, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush, replace: vi.fn(), back: vi.fn(), refresh: mockRefresh }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => "/auth/signin",
+}));
+vi.mock("next-auth/react", () => ({
+  signIn: (...args: any[]) => mockSignIn(...args),
+}));
+
+import { LoginForm } from "@/components/auth/LoginForm";
+
+describe("LoginForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders email and password inputs", () => {
+    render(<LoginForm />);
+
+    expect(screen.getByLabelText("Email")).toBeInTheDocument();
+    expect(screen.getByLabelText("Password")).toBeInTheDocument();
+  });
+
+  it("renders Sign in button", () => {
+    render(<LoginForm />);
+
+    expect(screen.getByRole("button", { name: "Sign in" })).toBeInTheDocument();
+  });
+
+  it("renders Google OAuth button", () => {
+    render(<LoginForm />);
+
+    expect(
+      screen.getByRole("button", { name: /continue with google/i })
+    ).toBeInTheDocument();
+  });
+
+  it("renders Forgot password link", () => {
+    render(<LoginForm />);
+
+    const link = screen.getByRole("link", { name: /forgot password/i });
+    expect(link).toHaveAttribute("href", "/auth/forgot-password");
+  });
+
+  it("renders Sign up link", () => {
+    render(<LoginForm />);
+
+    const link = screen.getByRole("link", { name: /sign up/i });
+    expect(link).toHaveAttribute("href", "/auth/signup");
+  });
+
+  it("toggles password visibility on eye icon click", () => {
+    render(<LoginForm />);
+
+    const passwordInput = screen.getByLabelText("Password");
+    expect(passwordInput).toHaveAttribute("type", "password");
+
+    // Find the toggle button (visually hidden button near the password field)
+    const toggleButtons = screen.getAllByRole("button");
+    const toggleBtn = toggleButtons.find(
+      (btn) => btn.querySelector("svg") && btn.closest(".relative")
+    );
+    expect(toggleBtn).toBeDefined();
+    fireEvent.click(toggleBtn!);
+
+    expect(passwordInput).toHaveAttribute("type", "text");
+  });
+
+  it("calls signIn with credentials on form submit", async () => {
+    mockSignIn.mockResolvedValueOnce({ error: null });
+
+    render(<LoginForm />);
+
+    fireEvent.change(screen.getByLabelText("Email"), {
+      target: { value: "test@example.com" },
+    });
+    fireEvent.change(screen.getByLabelText("Password"), {
+      target: { value: "Password123" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Sign in" }));
+
+    await waitFor(() => {
+      expect(mockSignIn).toHaveBeenCalledWith("credentials", {
+        email: "test@example.com",
+        password: "Password123",
+        redirect: false,
+      });
+    });
+  });
+
+  it("shows error message on failed login", async () => {
+    mockSignIn.mockResolvedValueOnce({ error: "CredentialsSignin" });
+
+    render(<LoginForm />);
+
+    fireEvent.change(screen.getByLabelText("Email"), {
+      target: { value: "test@example.com" },
+    });
+    fireEvent.change(screen.getByLabelText("Password"), {
+      target: { value: "wrong" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Sign in" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Invalid email or password.")
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("redirects to dashboard on successful login", async () => {
+    mockSignIn.mockResolvedValueOnce({ error: null });
+
+    render(<LoginForm />);
+
+    fireEvent.change(screen.getByLabelText("Email"), {
+      target: { value: "test@example.com" },
+    });
+    fireEvent.change(screen.getByLabelText("Password"), {
+      target: { value: "Password123" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Sign in" }));
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/dashboard");
+    });
+  });
+
+  it("uses custom callbackUrl when provided", async () => {
+    mockSignIn.mockResolvedValueOnce({ error: null });
+
+    render(<LoginForm callbackUrl="/settings" />);
+
+    fireEvent.change(screen.getByLabelText("Email"), {
+      target: { value: "test@example.com" },
+    });
+    fireEvent.change(screen.getByLabelText("Password"), {
+      target: { value: "Password123" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Sign in" }));
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/settings");
+    });
+  });
+});

--- a/tests/unit/components/auth/signup-form.test.tsx
+++ b/tests/unit/components/auth/signup-form.test.tsx
@@ -1,0 +1,209 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockPush = vi.fn();
+const mockSignIn = vi.fn();
+
+vi.mock("next/link", () => ({
+  default: ({ children, href, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush, replace: vi.fn(), back: vi.fn(), refresh: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => "/auth/signup",
+}));
+vi.mock("next-auth/react", () => ({
+  signIn: (...args: any[]) => mockSignIn(...args),
+}));
+
+import { SignupForm } from "@/components/auth/SignupForm";
+
+describe("SignupForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn();
+  });
+
+  it("renders name, email, and password inputs", () => {
+    render(<SignupForm />);
+
+    expect(screen.getByLabelText("Name")).toBeInTheDocument();
+    expect(screen.getByLabelText("Email")).toBeInTheDocument();
+    expect(screen.getByLabelText("Password")).toBeInTheDocument();
+  });
+
+  it("renders Create account button", () => {
+    render(<SignupForm />);
+
+    expect(
+      screen.getByRole("button", { name: "Create account" })
+    ).toBeInTheDocument();
+  });
+
+  it("renders Google OAuth button", () => {
+    render(<SignupForm />);
+
+    expect(
+      screen.getByRole("button", { name: /continue with google/i })
+    ).toBeInTheDocument();
+  });
+
+  it("renders Sign in link", () => {
+    render(<SignupForm />);
+
+    const link = screen.getByRole("link", { name: /sign in/i });
+    expect(link).toHaveAttribute("href", "/auth/signin");
+  });
+
+  it("renders Terms and Privacy links", () => {
+    render(<SignupForm />);
+
+    expect(
+      screen.getByRole("link", { name: /terms of service/i })
+    ).toHaveAttribute("href", "/terms");
+    expect(
+      screen.getByRole("link", { name: /privacy policy/i })
+    ).toHaveAttribute("href", "/privacy");
+  });
+
+  describe("password strength indicator", () => {
+    it("shows password strength when typing password", () => {
+      render(<SignupForm />);
+
+      fireEvent.change(screen.getByLabelText("Password"), {
+        target: { value: "ab" },
+      });
+
+      expect(screen.getByText("Password strength:")).toBeInTheDocument();
+      expect(screen.getByText("Weak")).toBeInTheDocument();
+    });
+
+    it('shows "Strong" for password meeting all criteria', () => {
+      render(<SignupForm />);
+
+      fireEvent.change(screen.getByLabelText("Password"), {
+        target: { value: "StrongPass1" },
+      });
+
+      expect(screen.getByText("Strong")).toBeInTheDocument();
+    });
+
+    it("shows password requirement checklist", () => {
+      render(<SignupForm />);
+
+      fireEvent.change(screen.getByLabelText("Password"), {
+        target: { value: "test" },
+      });
+
+      expect(screen.getByText("At least 8 characters")).toBeInTheDocument();
+      expect(screen.getByText("One uppercase letter")).toBeInTheDocument();
+      expect(screen.getByText("One lowercase letter")).toBeInTheDocument();
+      expect(screen.getByText("One number")).toBeInTheDocument();
+    });
+  });
+
+  it("toggles password visibility", () => {
+    render(<SignupForm />);
+
+    const passwordInput = screen.getByLabelText("Password");
+    expect(passwordInput).toHaveAttribute("type", "password");
+
+    const toggleButtons = screen.getAllByRole("button");
+    const toggleBtn = toggleButtons.find(
+      (btn) => btn.querySelector("svg") && btn.closest(".relative")
+    );
+    expect(toggleBtn).toBeDefined();
+    fireEvent.click(toggleBtn!);
+
+    expect(passwordInput).toHaveAttribute("type", "text");
+  });
+
+  it("calls signup API on form submit", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          success: true,
+          data: { message: "Account created" },
+        }),
+    });
+
+    render(<SignupForm />);
+
+    fireEvent.change(screen.getByLabelText("Name"), {
+      target: { value: "Test User" },
+    });
+    fireEvent.change(screen.getByLabelText("Email"), {
+      target: { value: "test@example.com" },
+    });
+    fireEvent.change(screen.getByLabelText("Password"), {
+      target: { value: "StrongPass1" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create account" }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/auth/signup",
+        expect.objectContaining({ method: "POST" })
+      );
+    });
+  });
+
+  it("shows success state after successful signup", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ success: true }),
+    });
+
+    render(<SignupForm />);
+
+    fireEvent.change(screen.getByLabelText("Name"), {
+      target: { value: "Test User" },
+    });
+    fireEvent.change(screen.getByLabelText("Email"), {
+      target: { value: "test@example.com" },
+    });
+    fireEvent.change(screen.getByLabelText("Password"), {
+      target: { value: "StrongPass1" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create account" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Check your email")).toBeInTheDocument();
+      expect(
+        screen.getByText(/we've sent a verification link/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows error message on failed signup", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: false,
+      json: () =>
+        Promise.resolve({
+          error: { message: "Email already exists" },
+        }),
+    });
+
+    render(<SignupForm />);
+
+    fireEvent.change(screen.getByLabelText("Name"), {
+      target: { value: "Test User" },
+    });
+    fireEvent.change(screen.getByLabelText("Email"), {
+      target: { value: "test@example.com" },
+    });
+    fireEvent.change(screen.getByLabelText("Password"), {
+      target: { value: "StrongPass1" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create account" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Email already exists")).toBeInTheDocument();
+    });
+  });
+});

--- a/tests/unit/components/dashboard/out-of-credits-dialog.test.tsx
+++ b/tests/unit/components/dashboard/out-of-credits-dialog.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("next/link", () => ({
+  default: ({ children, href, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+import { OutOfCreditsDialog } from "@/components/dashboard/OutOfCreditsDialog";
+
+describe("OutOfCreditsDialog", () => {
+  const defaultProps = {
+    open: true,
+    onOpenChange: vi.fn(),
+    creditsRemaining: 0,
+    creditsTotal: 15,
+    resetDate: "2026-02-15T00:00:00Z",
+    actionType: "generate" as const,
+  };
+
+  it("renders dialog title", () => {
+    render(<OutOfCreditsDialog {...defaultProps} />);
+
+    expect(
+      screen.getByText(/you're out of response credits/i)
+    ).toBeInTheDocument();
+  });
+
+  it('shows "Response generation" text for generate actionType', () => {
+    render(<OutOfCreditsDialog {...defaultProps} actionType="generate" />);
+
+    expect(
+      screen.getByText(/response generation requires 1 credit/i)
+    ).toBeInTheDocument();
+  });
+
+  it('shows "Regeneration" text for regenerate actionType', () => {
+    render(<OutOfCreditsDialog {...defaultProps} actionType="regenerate" />);
+
+    expect(
+      screen.getByText(/regeneration requires 1 credit/i)
+    ).toBeInTheDocument();
+  });
+
+  it("shows credits remaining info", () => {
+    render(<OutOfCreditsDialog {...defaultProps} />);
+
+    expect(screen.getByText("Credits remaining")).toBeInTheDocument();
+    expect(screen.getByText("0 of 15")).toBeInTheDocument();
+  });
+
+  it("shows reset date", () => {
+    render(<OutOfCreditsDialog {...defaultProps} />);
+
+    expect(screen.getByText("Resets on")).toBeInTheDocument();
+  });
+
+  it("renders Upgrade Plan link to /pricing", () => {
+    render(<OutOfCreditsDialog {...defaultProps} />);
+
+    const link = screen.getByRole("link", { name: /upgrade plan/i });
+    expect(link).toHaveAttribute("href", "/pricing");
+  });
+
+  it("calls onOpenChange(false) when Close button is clicked", () => {
+    render(<OutOfCreditsDialog {...defaultProps} />);
+
+    // Get the explicit "Close" text button (not the dialog X button)
+    const closeButtons = screen.getAllByRole("button", { name: /close/i });
+    const textCloseBtn = closeButtons.find(
+      (btn) => btn.textContent?.trim() === "Close"
+    );
+    expect(textCloseBtn).toBeDefined();
+    fireEvent.click(textCloseBtn!);
+
+    expect(defaultProps.onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("does not render when open is false", () => {
+    render(<OutOfCreditsDialog {...defaultProps} open={false} />);
+
+    expect(
+      screen.queryByText(/you're out of response credits/i)
+    ).not.toBeInTheDocument();
+  });
+});

--- a/tests/unit/components/providers/credits-provider.test.tsx
+++ b/tests/unit/components/providers/credits-provider.test.tsx
@@ -1,0 +1,143 @@
+import { render, screen, act, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { CreditsProvider, useCredits } from "@/components/providers/CreditsProvider";
+
+// Test component that consumes the context
+function TestConsumer() {
+  const ctx = useCredits();
+  return (
+    <div>
+      <span data-testid="credits">{ctx.credits}</span>
+      <span data-testid="creditsTotal">{ctx.creditsTotal}</span>
+      <span data-testid="tier">{ctx.tier}</span>
+      <span data-testid="sentimentCredits">{ctx.sentimentCredits}</span>
+      <button onClick={() => ctx.setCredits(5)}>Set Credits</button>
+      <button onClick={() => ctx.refreshCredits()}>Refresh</button>
+    </div>
+  );
+}
+
+describe("CreditsProvider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn();
+  });
+
+  it("provides default values when no initial props", () => {
+    render(
+      <CreditsProvider>
+        <TestConsumer />
+      </CreditsProvider>
+    );
+
+    expect(screen.getByTestId("credits")).toHaveTextContent("0");
+    expect(screen.getByTestId("creditsTotal")).toHaveTextContent("15");
+    expect(screen.getByTestId("tier")).toHaveTextContent("FREE");
+    expect(screen.getByTestId("sentimentCredits")).toHaveTextContent("0");
+  });
+
+  it("provides initial values from props", () => {
+    render(
+      <CreditsProvider
+        initialCredits={10}
+        initialCreditsTotal={30}
+        initialTier="STARTER"
+        initialSentimentCredits={100}
+      >
+        <TestConsumer />
+      </CreditsProvider>
+    );
+
+    expect(screen.getByTestId("credits")).toHaveTextContent("10");
+    expect(screen.getByTestId("creditsTotal")).toHaveTextContent("30");
+    expect(screen.getByTestId("tier")).toHaveTextContent("STARTER");
+    expect(screen.getByTestId("sentimentCredits")).toHaveTextContent("100");
+  });
+
+  it("updates credits via setCredits", () => {
+    render(
+      <CreditsProvider initialCredits={10}>
+        <TestConsumer />
+      </CreditsProvider>
+    );
+
+    act(() => {
+      screen.getByText("Set Credits").click();
+    });
+
+    expect(screen.getByTestId("credits")).toHaveTextContent("5");
+  });
+
+  it("refreshes credits from /api/dashboard/stats", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      json: () =>
+        Promise.resolve({
+          success: true,
+          data: {
+            credits: { remaining: 8, total: 15, resetDate: null },
+            sentiment: { remaining: 20, total: 35, resetDate: null },
+            tier: "FREE",
+          },
+        }),
+    });
+
+    render(
+      <CreditsProvider initialCredits={15}>
+        <TestConsumer />
+      </CreditsProvider>
+    );
+
+    act(() => {
+      screen.getByText("Refresh").click();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("credits")).toHaveTextContent("8");
+      expect(screen.getByTestId("sentimentCredits")).toHaveTextContent("20");
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith("/api/dashboard/stats");
+  });
+
+  it("handles refresh failure gracefully", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error("Network error")
+    );
+
+    render(
+      <CreditsProvider initialCredits={10}>
+        <TestConsumer />
+      </CreditsProvider>
+    );
+
+    act(() => {
+      screen.getByText("Refresh").click();
+    });
+
+    await waitFor(() => {
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "Failed to refresh credits:",
+        expect.any(Error)
+      );
+    });
+
+    // Credits should remain unchanged
+    expect(screen.getByTestId("credits")).toHaveTextContent("10");
+
+    consoleSpy.mockRestore();
+  });
+});
+
+describe("useCredits hook", () => {
+  it("throws when used outside CreditsProvider", () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(() => render(<TestConsumer />)).toThrow(
+      "useCredits must be used within a CreditsProvider"
+    );
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/tests/unit/components/reviews/response-editor.test.tsx
+++ b/tests/unit/components/reviews/response-editor.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { ResponseEditor } from "@/components/reviews/ResponseEditor";
+
+describe("ResponseEditor", () => {
+  const defaultProps = {
+    initialText: "Hello world",
+    onSave: vi.fn(),
+    onCancel: vi.fn(),
+  };
+
+  it("renders textarea with initial text", () => {
+    render(<ResponseEditor {...defaultProps} />);
+
+    const textarea = screen.getByPlaceholderText("Edit your response...");
+    expect(textarea).toHaveValue("Hello world");
+  });
+
+  it("shows character count", () => {
+    render(<ResponseEditor {...defaultProps} />);
+
+    expect(screen.getByText(/11/)).toBeInTheDocument();
+    expect(screen.getByText(/500 characters/)).toBeInTheDocument();
+  });
+
+  it("disables Save button when text is unchanged", () => {
+    render(<ResponseEditor {...defaultProps} />);
+
+    const saveBtn = screen.getByRole("button", { name: /save changes/i });
+    expect(saveBtn).toBeDisabled();
+  });
+
+  it("enables Save button when text changes", () => {
+    render(<ResponseEditor {...defaultProps} />);
+
+    const textarea = screen.getByPlaceholderText("Edit your response...");
+    fireEvent.change(textarea, { target: { value: "Updated text" } });
+
+    const saveBtn = screen.getByRole("button", { name: /save changes/i });
+    expect(saveBtn).not.toBeDisabled();
+  });
+
+  it("disables Save button when text exceeds max limit", () => {
+    render(<ResponseEditor {...defaultProps} />);
+
+    const textarea = screen.getByPlaceholderText("Edit your response...");
+    fireEvent.change(textarea, { target: { value: "A".repeat(501) } });
+
+    const saveBtn = screen.getByRole("button", { name: /save changes/i });
+    expect(saveBtn).toBeDisabled();
+  });
+
+  it("disables Save button when text is empty", () => {
+    render(<ResponseEditor {...defaultProps} />);
+
+    const textarea = screen.getByPlaceholderText("Edit your response...");
+    fireEvent.change(textarea, { target: { value: "   " } });
+
+    const saveBtn = screen.getByRole("button", { name: /save changes/i });
+    expect(saveBtn).toBeDisabled();
+  });
+
+  it("calls onCancel when Cancel button is clicked", () => {
+    render(<ResponseEditor {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(defaultProps.onCancel).toHaveBeenCalled();
+  });
+
+  it("shows over-limit warning text", () => {
+    render(<ResponseEditor {...defaultProps} />);
+
+    const textarea = screen.getByPlaceholderText("Edit your response...");
+    fireEvent.change(textarea, { target: { value: "A".repeat(510) } });
+
+    expect(screen.getByText(/10 over limit/)).toBeInTheDocument();
+  });
+
+  it("shows keyboard shortcut hint text", () => {
+    render(<ResponseEditor {...defaultProps} />);
+
+    expect(screen.getByText(/ctrl\+enter to save/i)).toBeInTheDocument();
+  });
+});

--- a/tests/unit/components/reviews/response-panel.test.tsx
+++ b/tests/unit/components/reviews/response-panel.test.tsx
@@ -1,0 +1,229 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock modules before importing component
+vi.mock("next/link", () => ({
+  default: ({ children, href, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn(), refresh: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => "/dashboard",
+}));
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+const mockRefreshCredits = vi.fn();
+vi.mock("@/components/providers/CreditsProvider", () => ({
+  useCredits: () => ({
+    credits: 10,
+    creditsTotal: 15,
+    creditsResetDate: "2026-02-15T00:00:00Z",
+    refreshCredits: mockRefreshCredits,
+  }),
+}));
+
+import { ResponsePanel } from "@/components/reviews/ResponsePanel";
+
+const mockResponse = {
+  id: "resp_1",
+  responseText: "Thank you for your wonderful review!",
+  isEdited: false,
+  editedAt: null,
+  creditsUsed: 1,
+  toneUsed: "professional",
+  generationModel: "claude-sonnet-4-20250514",
+  isPublished: false,
+  publishedAt: null,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+  totalCreditsUsed: 2,
+  versions: [],
+};
+
+const mockEditedResponse = {
+  ...mockResponse,
+  isEdited: true,
+  editedAt: new Date().toISOString(),
+  creditsUsed: 0,
+};
+
+const mockPublishedResponse = {
+  ...mockResponse,
+  isPublished: true,
+  publishedAt: new Date().toISOString(),
+};
+
+describe("ResponsePanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset fetch mock
+    global.fetch = vi.fn();
+  });
+
+  describe("empty state (no response)", () => {
+    it('renders "No response generated yet" when response is null', () => {
+      render(<ResponsePanel reviewId="rev_1" response={null} />);
+
+      expect(screen.getByText("No response generated yet.")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /generate response/i })
+      ).toBeInTheDocument();
+    });
+
+    it("shows credit cost text for generation", () => {
+      render(<ResponsePanel reviewId="rev_1" response={null} />);
+
+      expect(screen.getByText(/uses 1 credit/i)).toBeInTheDocument();
+    });
+
+    it("calls generate endpoint on button click", async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        json: () =>
+          Promise.resolve({
+            success: true,
+            data: {
+              response: {
+                id: "resp_new",
+                responseText: "Generated response text",
+                toneUsed: "professional",
+                creditsUsed: 1,
+                generationModel: "claude-sonnet-4-20250514",
+                createdAt: new Date().toISOString(),
+              },
+            },
+          }),
+      });
+
+      render(<ResponsePanel reviewId="rev_1" response={null} />);
+      fireEvent.click(
+        screen.getByRole("button", { name: /generate response/i })
+      );
+
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalledWith("/api/reviews/rev_1/generate", expect.objectContaining({ method: "POST" }));
+      });
+    });
+
+    it("shows OutOfCreditsDialog on INSUFFICIENT_CREDITS error", async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        json: () =>
+          Promise.resolve({
+            success: false,
+            error: { code: "INSUFFICIENT_CREDITS", message: "No credits" },
+          }),
+      });
+
+      render(<ResponsePanel reviewId="rev_1" response={null} />);
+      fireEvent.click(screen.getByRole("button", { name: /generate response/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/you're out of response credits/i)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("with existing response", () => {
+    it("renders response text", () => {
+      render(<ResponsePanel reviewId="rev_1" response={mockResponse} />);
+
+      expect(
+        screen.getByText("Thank you for your wonderful review!")
+      ).toBeInTheDocument();
+    });
+
+    it('shows "Generated" badge for non-edited response', () => {
+      render(<ResponsePanel reviewId="rev_1" response={mockResponse} />);
+
+      expect(screen.getByText("Generated")).toBeInTheDocument();
+      expect(screen.getByText("professional tone")).toBeInTheDocument();
+    });
+
+    it('shows "Edited" badge for edited response', () => {
+      render(<ResponsePanel reviewId="rev_1" response={mockEditedResponse} />);
+
+      expect(screen.getByText("Edited")).toBeInTheDocument();
+      expect(screen.queryByText("Generated")).not.toBeInTheDocument();
+    });
+
+    it('shows "Approved" badge for published response', () => {
+      render(<ResponsePanel reviewId="rev_1" response={mockPublishedResponse} />);
+
+      expect(screen.getByText("Approved")).toBeInTheDocument();
+    });
+
+    it("shows total credits used badge", () => {
+      render(<ResponsePanel reviewId="rev_1" response={mockResponse} />);
+
+      expect(screen.getByText("2 credits used")).toBeInTheDocument();
+    });
+
+    it("renders Copy, Edit, Regenerate, and Approve buttons", () => {
+      render(<ResponsePanel reviewId="rev_1" response={mockResponse} />);
+
+      expect(screen.getByRole("button", { name: /copy/i })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /^edit$/i })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /regenerate/i })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /approve/i })).toBeInTheDocument();
+    });
+
+    it("hides Approve button when response is already published", () => {
+      render(<ResponsePanel reviewId="rev_1" response={mockPublishedResponse} />);
+
+      expect(screen.queryByRole("button", { name: /approve/i })).not.toBeInTheDocument();
+    });
+
+    it("calls publish endpoint when Approve is clicked", async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        json: () =>
+          Promise.resolve({
+            success: true,
+            data: {
+              response: { publishedAt: new Date().toISOString() },
+            },
+          }),
+      });
+
+      render(<ResponsePanel reviewId="rev_1" response={mockResponse} />);
+      fireEvent.click(screen.getByRole("button", { name: /approve/i }));
+
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalledWith("/api/reviews/rev_1/publish", expect.objectContaining({ method: "POST" }));
+      });
+    });
+  });
+
+  describe("version history", () => {
+    it("does not render version history when versions is empty", () => {
+      render(<ResponsePanel reviewId="rev_1" response={mockResponse} />);
+
+      expect(screen.queryByText(/version history/i)).not.toBeInTheDocument();
+    });
+
+    it("renders version history section when versions exist", () => {
+      const responseWithVersions = {
+        ...mockResponse,
+        versions: [
+          {
+            id: "ver_1",
+            responseText: "Old response",
+            toneUsed: "friendly",
+            creditsUsed: 1,
+            isEdited: false,
+            createdAt: new Date().toISOString(),
+            originalCreatedAt: new Date().toISOString(),
+          },
+        ],
+      };
+
+      render(<ResponsePanel reviewId="rev_1" response={responseWithVersions} />);
+
+      expect(screen.getByText(/version history/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/tests/unit/components/reviews/response-version-history.test.tsx
+++ b/tests/unit/components/reviews/response-version-history.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { ResponseVersionHistory } from "@/components/reviews/ResponseVersionHistory";
+
+const mockVersions = [
+  {
+    id: "ver_1",
+    responseText: "First version of the response",
+    toneUsed: "professional",
+    creditsUsed: 1,
+    isEdited: false,
+    createdAt: new Date().toISOString(),
+    originalCreatedAt: new Date(Date.now() - 3600000).toISOString(),
+  },
+  {
+    id: "ver_2",
+    responseText: "This was manually edited by the user",
+    toneUsed: "professional",
+    creditsUsed: 0,
+    isEdited: true,
+    createdAt: new Date().toISOString(),
+    originalCreatedAt: new Date(Date.now() - 7200000).toISOString(),
+  },
+];
+
+describe("ResponseVersionHistory", () => {
+  it("returns null when versions is empty", () => {
+    const { container } = render(<ResponseVersionHistory versions={[]} />);
+
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders collapsible trigger with version count", () => {
+    render(<ResponseVersionHistory versions={mockVersions} />);
+
+    expect(screen.getByText("Version History (2)")).toBeInTheDocument();
+  });
+
+  it("expands to show versions on trigger click", () => {
+    render(<ResponseVersionHistory versions={mockVersions} />);
+
+    // Click to expand
+    fireEvent.click(screen.getByText("Version History (2)"));
+
+    // Version content should now be visible
+    expect(
+      screen.getByText("First version of the response")
+    ).toBeInTheDocument();
+  });
+
+  it('shows "Generated" badge for non-edited versions', () => {
+    render(<ResponseVersionHistory versions={mockVersions} />);
+    fireEvent.click(screen.getByText("Version History (2)"));
+
+    expect(screen.getByText("Generated")).toBeInTheDocument();
+  });
+
+  it('shows "Edited" badge for edited versions', () => {
+    render(<ResponseVersionHistory versions={mockVersions} />);
+    fireEvent.click(screen.getByText("Version History (2)"));
+
+    expect(screen.getByText("Edited")).toBeInTheDocument();
+  });
+
+  it("shows tone badge for generated versions", () => {
+    render(<ResponseVersionHistory versions={mockVersions} />);
+    fireEvent.click(screen.getByText("Version History (2)"));
+
+    expect(screen.getByText("professional")).toBeInTheDocument();
+  });
+
+  it("shows credit count for generated versions", () => {
+    render(<ResponseVersionHistory versions={mockVersions} />);
+    fireEvent.click(screen.getByText("Version History (2)"));
+
+    expect(screen.getByText("1 credit")).toBeInTheDocument();
+  });
+
+  it('shows "Show more" for long version text', () => {
+    const longVersions = [
+      {
+        ...mockVersions[0],
+        responseText: "A".repeat(200),
+      },
+    ];
+
+    render(<ResponseVersionHistory versions={longVersions} />);
+    fireEvent.click(screen.getByText("Version History (1)"));
+
+    expect(screen.getByText("Show more")).toBeInTheDocument();
+  });
+});

--- a/tests/unit/components/reviews/review-card.test.tsx
+++ b/tests/unit/components/reviews/review-card.test.tsx
@@ -1,0 +1,200 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("next/link", () => ({
+  default: ({ children, href, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn(), refresh: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => "/dashboard",
+}));
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import { ReviewCard, type ReviewCardData } from "@/components/reviews/ReviewCard";
+
+const baseReview: ReviewCardData = {
+  id: "rev_1",
+  platform: "Google",
+  reviewText: "Great product, very satisfied with my purchase!",
+  rating: 5,
+  reviewerName: "John D.",
+  reviewDate: new Date().toISOString(),
+  detectedLanguage: "English",
+  sentiment: "positive",
+  createdAt: new Date().toISOString(),
+  response: null,
+};
+
+const reviewWithResponse: ReviewCardData = {
+  ...baseReview,
+  response: {
+    id: "resp_1",
+    responseText: "Thank you for your kind words!",
+    isEdited: false,
+    isPublished: false,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    totalCreditsUsed: 1,
+  },
+};
+
+describe("ReviewCard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn();
+  });
+
+  describe("rendering", () => {
+    it("renders review text", () => {
+      render(<ReviewCard review={baseReview} />);
+
+      expect(
+        screen.getByText("Great product, very satisfied with my purchase!")
+      ).toBeInTheDocument();
+    });
+
+    it("renders platform badge", () => {
+      render(<ReviewCard review={baseReview} />);
+
+      expect(screen.getByText("Google")).toBeInTheDocument();
+    });
+
+    it("renders rating star with number", () => {
+      render(<ReviewCard review={baseReview} />);
+
+      expect(screen.getByText("5")).toBeInTheDocument();
+    });
+
+    it("renders reviewer name", () => {
+      render(<ReviewCard review={baseReview} />);
+
+      expect(screen.getByText(/by John D\./)).toBeInTheDocument();
+    });
+
+    it("renders positive sentiment badge", () => {
+      render(<ReviewCard review={baseReview} />);
+
+      expect(screen.getByText("positive")).toBeInTheDocument();
+    });
+
+    it("renders negative sentiment badge with correct styling", () => {
+      const negativeReview = { ...baseReview, sentiment: "negative" };
+      render(<ReviewCard review={negativeReview} />);
+
+      const badge = screen.getByText("negative");
+      expect(badge).toBeInTheDocument();
+    });
+
+    it("renders neutral sentiment badge", () => {
+      const neutralReview = { ...baseReview, sentiment: "neutral" };
+      render(<ReviewCard review={neutralReview} />);
+
+      expect(screen.getByText("neutral")).toBeInTheDocument();
+    });
+
+    it('shows "Sentiment" warning indicator when sentiment is null', () => {
+      const noSentimentReview = { ...baseReview, sentiment: null };
+      render(<ReviewCard review={noSentimentReview} />);
+
+      expect(screen.getByText("Sentiment")).toBeInTheDocument();
+    });
+
+    it("shows language badge for non-English reviews", () => {
+      const spanishReview = { ...baseReview, detectedLanguage: "Spanish" };
+      render(<ReviewCard review={spanishReview} />);
+
+      expect(screen.getByText("Spanish")).toBeInTheDocument();
+    });
+
+    it("does not show language badge for English reviews", () => {
+      render(<ReviewCard review={baseReview} />);
+
+      // English badge should not be rendered
+      expect(screen.queryByText("English")).not.toBeInTheDocument();
+    });
+
+    it('shows "Responded" badge when response exists', () => {
+      render(<ReviewCard review={reviewWithResponse} />);
+
+      expect(screen.getByText("Responded")).toBeInTheDocument();
+    });
+
+    it("does not show Responded badge when no response", () => {
+      render(<ReviewCard review={baseReview} />);
+
+      expect(screen.queryByText("Responded")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("response preview", () => {
+    it("renders AI Response preview when response exists", () => {
+      render(<ReviewCard review={reviewWithResponse} />);
+
+      expect(screen.getByText("AI Response:")).toBeInTheDocument();
+      expect(
+        screen.getByText("Thank you for your kind words!")
+      ).toBeInTheDocument();
+    });
+
+    it("shows credits used in response preview", () => {
+      render(<ReviewCard review={reviewWithResponse} />);
+
+      expect(screen.getByText(/1 credit used/)).toBeInTheDocument();
+    });
+
+    it("does not render response preview when no response", () => {
+      render(<ReviewCard review={baseReview} />);
+
+      expect(screen.queryByText("AI Response:")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("text expansion", () => {
+    it('shows "Show more" button for long review text', () => {
+      const longReview = {
+        ...baseReview,
+        reviewText: "A".repeat(200),
+      };
+      render(<ReviewCard review={longReview} />);
+
+      expect(screen.getByText("Show more")).toBeInTheDocument();
+    });
+
+    it("does not show Show more for short review text", () => {
+      render(<ReviewCard review={baseReview} />);
+
+      expect(screen.queryByText("Show more")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("actions", () => {
+    it("renders actions dropdown menu trigger", () => {
+      render(<ReviewCard review={baseReview} />);
+
+      expect(screen.getByRole("button", { name: /actions/i })).toBeInTheDocument();
+    });
+
+    it("has correct link to review detail page", () => {
+      render(<ReviewCard review={baseReview} />);
+
+      const link = screen.getByRole("link", { name: baseReview.reviewText });
+      expect(link).toHaveAttribute("href", "/dashboard/reviews/rev_1");
+    });
+  });
+
+  describe("navigation links", () => {
+    it("has link to review detail page on review text", () => {
+      render(<ReviewCard review={baseReview} />);
+
+      const link = screen.getByRole("link", { name: baseReview.reviewText });
+      expect(link).toHaveAttribute("href", "/dashboard/reviews/rev_1");
+    });
+  });
+});

--- a/tests/unit/components/reviews/review-form.test.tsx
+++ b/tests/unit/components/reviews/review-form.test.tsx
@@ -1,0 +1,229 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockPush = vi.fn();
+const mockBack = vi.fn();
+const mockRefresh = vi.fn();
+
+vi.mock("next/link", () => ({
+  default: ({ children, href, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush, replace: vi.fn(), back: mockBack, refresh: mockRefresh }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => "/dashboard",
+}));
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import { ReviewForm } from "@/components/reviews/ReviewForm";
+
+describe("ReviewForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn();
+  });
+
+  describe("create mode", () => {
+    it("renders with 'Add New Review' title in create mode", () => {
+      render(<ReviewForm />);
+
+      expect(screen.getByText("Add New Review")).toBeInTheDocument();
+    });
+
+    it("renders platform selector", () => {
+      render(<ReviewForm />);
+
+      expect(screen.getByText("Platform *")).toBeInTheDocument();
+    });
+
+    it("renders review text textarea", () => {
+      render(<ReviewForm />);
+
+      expect(screen.getByText("Review Text *")).toBeInTheDocument();
+      expect(
+        screen.getByPlaceholderText(
+          "Paste or type the customer review here..."
+        )
+      ).toBeInTheDocument();
+    });
+
+    it("renders rating stars (1-5)", () => {
+      render(<ReviewForm />);
+
+      expect(screen.getByText("Rating (optional)")).toBeInTheDocument();
+      // 5 star buttons rendered
+      const starButtons = screen.getAllByRole("button").filter((btn) => {
+        // Star buttons are type="button" within the rating section
+        return btn.closest(".flex.items-center.gap-1");
+      });
+      expect(starButtons.length).toBe(5);
+    });
+
+    it("renders reviewer name input", () => {
+      render(<ReviewForm />);
+
+      expect(screen.getByText("Reviewer Name (optional)")).toBeInTheDocument();
+      expect(screen.getByPlaceholderText("e.g., John D.")).toBeInTheDocument();
+    });
+
+    it("renders review date input", () => {
+      render(<ReviewForm />);
+
+      expect(screen.getByText("Review Date (optional)")).toBeInTheDocument();
+    });
+
+    it("renders Add Review submit button", () => {
+      render(<ReviewForm />);
+
+      expect(
+        screen.getByRole("button", { name: "Add Review" })
+      ).toBeInTheDocument();
+    });
+
+    it("renders Cancel button", () => {
+      render(<ReviewForm />);
+
+      expect(
+        screen.getByRole("button", { name: "Cancel" })
+      ).toBeInTheDocument();
+    });
+
+    it("calls router.back() on Cancel click", () => {
+      render(<ReviewForm />);
+      fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+      expect(mockBack).toHaveBeenCalled();
+    });
+
+    it("shows character count starting at 0", () => {
+      render(<ReviewForm />);
+
+      expect(screen.getByText("0/2000")).toBeInTheDocument();
+    });
+  });
+
+  describe("edit mode", () => {
+    const initialData = {
+      id: "rev_1",
+      platform: "Google",
+      reviewText: "Great product!",
+      rating: 4,
+      reviewerName: "Jane D.",
+      reviewDate: "2026-01-15",
+      detectedLanguage: "English",
+    };
+
+    it("renders with 'Edit Review' title in edit mode", () => {
+      render(<ReviewForm initialData={initialData} mode="edit" />);
+
+      expect(screen.getByText("Edit Review")).toBeInTheDocument();
+    });
+
+    it("renders Save Changes button in edit mode", () => {
+      render(<ReviewForm initialData={initialData} mode="edit" />);
+
+      expect(
+        screen.getByRole("button", { name: "Save Changes" })
+      ).toBeInTheDocument();
+    });
+
+    it("pre-fills review text from initialData", () => {
+      render(<ReviewForm initialData={initialData} mode="edit" />);
+
+      const textarea = screen.getByPlaceholderText(
+        "Paste or type the customer review here..."
+      );
+      expect(textarea).toHaveValue("Great product!");
+    });
+  });
+
+  describe("language detection", () => {
+    it('shows "Detected: English" indicator', async () => {
+      render(<ReviewForm />);
+
+      // Type text to trigger detection
+      const textarea = screen.getByPlaceholderText(
+        "Paste or type the customer review here..."
+      );
+      fireEvent.change(textarea, {
+        target: { value: "This is a fairly long English review text to trigger language detection with high confidence" },
+      });
+
+      await waitFor(
+        () => {
+          expect(screen.getByText(/detected:/i)).toBeInTheDocument();
+        },
+        { timeout: 1500 }
+      );
+    });
+  });
+
+  describe("form submission", () => {
+    it("calls POST /api/reviews on create submit", async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        json: () =>
+          Promise.resolve({
+            success: true,
+            data: { review: { id: "rev_new" } },
+          }),
+      });
+
+      render(<ReviewForm />);
+
+      // Fill required fields
+      const textarea = screen.getByPlaceholderText(
+        "Paste or type the customer review here..."
+      );
+      fireEvent.change(textarea, {
+        target: { value: "This is a great product that I absolutely love!" },
+      });
+
+      // Submit
+      fireEvent.click(screen.getByRole("button", { name: "Add Review" }));
+
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalledWith(
+          "/api/reviews",
+          expect.objectContaining({ method: "POST" })
+        );
+      });
+    });
+
+    it("calls PUT /api/reviews/:id on edit submit", async () => {
+      const initialData = {
+        id: "rev_1",
+        platform: "Google",
+        reviewText: "Updated review text that is long enough to be valid",
+        rating: 4,
+        reviewerName: "Jane",
+        reviewDate: "2026-01-15",
+        detectedLanguage: "English",
+      };
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        json: () =>
+          Promise.resolve({
+            success: true,
+            data: { review: { id: "rev_1" } },
+          }),
+      });
+
+      render(<ReviewForm initialData={initialData} mode="edit" />);
+
+      fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalledWith(
+          "/api/reviews/rev_1",
+          expect.objectContaining({ method: "PUT" })
+        );
+      });
+    });
+  });
+});

--- a/tests/unit/components/reviews/review-list.test.tsx
+++ b/tests/unit/components/reviews/review-list.test.tsx
@@ -1,0 +1,231 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockPush = vi.fn();
+
+vi.mock("next/link", () => ({
+  default: ({ children, href, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush, replace: vi.fn(), back: vi.fn(), refresh: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => "/dashboard/reviews",
+}));
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import { ReviewList } from "@/components/reviews/ReviewList";
+
+const mockReviews = [
+  {
+    id: "rev_1",
+    platform: "Google",
+    reviewText: "Great product!",
+    rating: 5,
+    reviewerName: "John",
+    reviewDate: new Date().toISOString(),
+    detectedLanguage: "English",
+    sentiment: "positive",
+    createdAt: new Date().toISOString(),
+    response: null,
+  },
+  {
+    id: "rev_2",
+    platform: "Amazon",
+    reviewText: "Terrible experience.",
+    rating: 1,
+    reviewerName: "Jane",
+    reviewDate: new Date().toISOString(),
+    detectedLanguage: "English",
+    sentiment: "negative",
+    createdAt: new Date().toISOString(),
+    response: null,
+  },
+];
+
+describe("ReviewList", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn();
+  });
+
+  it("shows loading skeletons while fetching", () => {
+    // Never resolve the fetch — keeps component in loading state
+    (global.fetch as ReturnType<typeof vi.fn>).mockReturnValue(new Promise(() => {}));
+
+    render(<ReviewList />);
+
+    // Skeleton elements should be visible
+    const skeletons = document.querySelectorAll("[class*='animate-pulse'], [data-slot='skeleton']");
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it("renders reviews after successful fetch", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      json: () =>
+        Promise.resolve({
+          success: true,
+          data: {
+            reviews: mockReviews,
+            pagination: {
+              page: 1,
+              limit: 10,
+              totalCount: 2,
+              totalPages: 1,
+              hasMore: false,
+            },
+          },
+        }),
+    });
+
+    render(<ReviewList />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Great product!")).toBeInTheDocument();
+      expect(screen.getByText("Terrible experience.")).toBeInTheDocument();
+    });
+  });
+
+  it("shows empty message when no reviews exist", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      json: () =>
+        Promise.resolve({
+          success: true,
+          data: {
+            reviews: [],
+            pagination: {
+              page: 1,
+              limit: 10,
+              totalCount: 0,
+              totalPages: 0,
+              hasMore: false,
+            },
+          },
+        }),
+    });
+
+    render(<ReviewList />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/no reviews yet/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("renders platform and sentiment filter dropdowns", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      json: () =>
+        Promise.resolve({
+          success: true,
+          data: {
+            reviews: mockReviews,
+            pagination: { page: 1, limit: 10, totalCount: 2, totalPages: 1, hasMore: false },
+          },
+        }),
+    });
+
+    render(<ReviewList />);
+
+    expect(screen.getByText("Filters:")).toBeInTheDocument();
+  });
+
+  it("renders pagination when totalPages > 1", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      json: () =>
+        Promise.resolve({
+          success: true,
+          data: {
+            reviews: mockReviews,
+            pagination: {
+              page: 1,
+              limit: 10,
+              totalCount: 25,
+              totalPages: 3,
+              hasMore: true,
+            },
+          },
+        }),
+    });
+
+    render(<ReviewList />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Page 1 of 3")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /previous/i })).toBeDisabled();
+      expect(screen.getByRole("button", { name: /next/i })).not.toBeDisabled();
+    });
+  });
+
+  it("does not render pagination when only 1 page", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      json: () =>
+        Promise.resolve({
+          success: true,
+          data: {
+            reviews: mockReviews,
+            pagination: {
+              page: 1,
+              limit: 10,
+              totalCount: 2,
+              totalPages: 1,
+              hasMore: false,
+            },
+          },
+        }),
+    });
+
+    render(<ReviewList />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Great product!")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText(/page \d+ of \d+/i)).not.toBeInTheDocument();
+  });
+
+  it("fetches reviews with correct query params", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      json: () =>
+        Promise.resolve({
+          success: true,
+          data: {
+            reviews: [],
+            pagination: { page: 1, limit: 10, totalCount: 0, totalPages: 0, hasMore: false },
+          },
+        }),
+    });
+
+    render(<ReviewList />);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("/api/reviews?")
+      );
+    });
+
+    // Verify the fetch URL contains expected params
+    const fetchUrl = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(fetchUrl).toContain("page=1");
+    expect(fetchUrl).toContain("limit=10");
+  });
+
+  it("shows error message on fetch failure", async () => {
+    const { toast } = await import("sonner");
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error("Network error")
+    );
+
+    render(<ReviewList />);
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Failed to load reviews");
+    });
+  });
+});

--- a/tests/unit/components/reviews/tone-modifier.test.tsx
+++ b/tests/unit/components/reviews/tone-modifier.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { ToneModifier } from "@/components/reviews/ToneModifier";
+
+describe("ToneModifier", () => {
+  const defaultProps = {
+    onRegenerate: vi.fn().mockResolvedValue(undefined),
+    isLoading: false,
+    currentTone: "professional",
+    creditsNeeded: 1,
+  };
+
+  it("renders Regenerate trigger button", () => {
+    render(<ToneModifier {...defaultProps} />);
+
+    expect(
+      screen.getByRole("button", { name: /regenerate/i })
+    ).toBeInTheDocument();
+  });
+
+  it("disables trigger when isLoading", () => {
+    render(<ToneModifier {...defaultProps} isLoading={true} />);
+
+    expect(
+      screen.getByRole("button", { name: /regenerating/i })
+    ).toBeDisabled();
+  });
+
+  it("disables trigger when disabled prop is true", () => {
+    render(<ToneModifier {...defaultProps} disabled={true} />);
+
+    expect(
+      screen.getByRole("button", { name: /regenerate/i })
+    ).toBeDisabled();
+  });
+
+  it("opens dialog on trigger click and shows tone options", async () => {
+    render(<ToneModifier {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /regenerate/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Regenerate Response")).toBeInTheDocument();
+      expect(screen.getByText("More Professional")).toBeInTheDocument();
+      expect(screen.getByText("More Friendly")).toBeInTheDocument();
+      expect(screen.getByText("More Empathetic")).toBeInTheDocument();
+    });
+  });
+
+  it("shows credit cost in dialog footer", async () => {
+    render(<ToneModifier {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /regenerate/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/this will use 1 credit/i)).toBeInTheDocument();
+    });
+  });
+
+  it("shows current tone in dialog description", async () => {
+    render(<ToneModifier {...defaultProps} currentTone="friendly" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /regenerate/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/current tone:/i)).toBeInTheDocument();
+      expect(screen.getByText("friendly")).toBeInTheDocument();
+    });
+  });
+
+  it("calls onRegenerate with selected tone", async () => {
+    render(<ToneModifier {...defaultProps} />);
+
+    // Open dialog
+    fireEvent.click(screen.getByRole("button", { name: /regenerate/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Regenerate Response")).toBeInTheDocument();
+    });
+
+    // Select "friendly" tone
+    fireEvent.click(screen.getByText("More Friendly"));
+
+    // Click Regenerate in dialog
+    const dialogButtons = screen.getAllByRole("button", { name: /^regenerate$/i });
+    const confirmBtn = dialogButtons[dialogButtons.length - 1]; // Last one is the dialog confirm
+    fireEvent.click(confirmBtn);
+
+    await waitFor(() => {
+      expect(defaultProps.onRegenerate).toHaveBeenCalledWith("friendly");
+    });
+  });
+});

--- a/tests/unit/components/settings/brand-voice-form.test.tsx
+++ b/tests/unit/components/settings/brand-voice-form.test.tsx
@@ -1,0 +1,168 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("next/link", () => ({
+  default: ({ children, href, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn(), refresh: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => "/dashboard/settings/brand-voice",
+}));
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+import { BrandVoiceForm } from "@/components/settings/BrandVoiceForm";
+
+const mockBrandVoice = {
+  id: "bv_1",
+  tone: "professional",
+  formality: 3,
+  keyPhrases: ["Thank you", "We appreciate your feedback"],
+  styleNotes: '["Be genuine and empathetic"]',
+  sampleResponses: [],
+};
+
+describe("BrandVoiceForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn();
+  });
+
+  it("shows loading spinner while fetching brand voice", () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockReturnValue(new Promise(() => {}));
+
+    render(<BrandVoiceForm />);
+
+    // Loading spinner should be visible (the animate-spin class is on the spinner)
+    const spinner = document.querySelector(".animate-spin");
+    expect(spinner).toBeTruthy();
+  });
+
+  it("renders form sections after loading", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          data: { brandVoice: mockBrandVoice },
+        }),
+    });
+
+    render(<BrandVoiceForm />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Brand Voice Configuration")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Response Tone")).toBeInTheDocument();
+    expect(screen.getByText("Formality Level")).toBeInTheDocument();
+    expect(screen.getByText("Key Phrases")).toBeInTheDocument();
+    expect(screen.getByText("Style Guidelines")).toBeInTheDocument();
+    expect(screen.getByText("Sample Responses")).toBeInTheDocument();
+  });
+
+  it("shows auto-save status indicator", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          data: { brandVoice: mockBrandVoice },
+        }),
+    });
+
+    render(<BrandVoiceForm />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Saved")).toBeInTheDocument();
+    });
+  });
+
+  it("renders Reset to Defaults button", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          data: { brandVoice: mockBrandVoice },
+        }),
+    });
+
+    render(<BrandVoiceForm />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /reset to defaults/i })
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows auto-save enabled indicator", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          data: { brandVoice: mockBrandVoice },
+        }),
+    });
+
+    render(<BrandVoiceForm />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Auto-save enabled")).toBeInTheDocument();
+    });
+  });
+
+  it("shows error toast on fetch failure", async () => {
+    const { toast } = await import("sonner");
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error("Network error")
+    );
+
+    render(<BrandVoiceForm />);
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "Failed to load brand voice settings"
+      );
+    });
+  });
+
+  it("fetches brand voice from /api/brand-voice on mount", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          data: { brandVoice: mockBrandVoice },
+        }),
+    });
+
+    render(<BrandVoiceForm />);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith("/api/brand-voice");
+    });
+  });
+
+  it("renders description text about auto-saving", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          data: { brandVoice: mockBrandVoice },
+        }),
+    });
+
+    render(<BrandVoiceForm />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/changes are saved automatically/i)
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,13 +8,9 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: ['./tests/setup.ts'],
     globals: true,
-    // Run test files sequentially in a single thread to prevent
-    // @vitejs/plugin-react config collisions across parallel jsdom workers
-    poolOptions: {
-      threads: {
-        singleThread: true,
-      },
-    },
+    // Disable file parallelism to prevent @vitejs/plugin-react config
+    // collisions across parallel jsdom workers (vitest 4.x)
+    fileParallelism: false,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov'],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,13 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: ['./tests/setup.ts'],
     globals: true,
+    // Run test files sequentially in a single thread to prevent
+    // @vitejs/plugin-react config collisions across parallel jsdom workers
+    poolOptions: {
+      threads: {
+        singleThread: true,
+      },
+    },
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov'],
@@ -20,6 +27,12 @@ export default defineConfig({
         'scripts/**',
         'docs/**',
       ],
+      thresholds: {
+        statements: 70,
+        branches: 60,
+        functions: 60,
+        lines: 70,
+      },
     },
     include: ['tests/**/*.test.ts', 'tests/**/*.test.tsx'],
   },


### PR DESCRIPTION
## Summary
- **134 new tests** across 13 new test files, expanding total from 447 to 581 unit tests
- Component tests for all core UI: ResponsePanel, ReviewCard, ReviewForm, ReviewList, ResponseEditor, ToneModifier, ResponseVersionHistory, LoginForm, SignupForm, OutOfCreditsDialog, BrandVoiceForm, CreditsProvider
- API route tests for `GET /api/sentiment/usage` (previously untested production endpoint)
- Infrastructure: ResizeObserver polyfill for Radix UI in jsdom, vitest singleThread pool fix, coverage thresholds

## What changed
| Category | Before | After |
|----------|--------|-------|
| Unit test files | 30 | 43 |
| Unit test cases | 447 | 581 |
| Component coverage | 3/33 (9%) | 14/33 (42%) |
| API route coverage | 17/21 (81%) | 18/21 (86%) |
| Coverage thresholds | None | 70/60/60/70 enforced |

## Test plan
- [x] All 581 unit tests pass locally
- [x] Coverage meets configured thresholds (70% statements/lines, 60% branches/functions)
- [ ] PR checks pass in CI (lint, typecheck, unit tests, integration tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)