### PR TITLE
chore: enable manual trigger for E2E staging workflow

### DIFF
--- a/.github/workflows/e2e-staging.yml
+++ b/.github/workflows/e2e-staging.yml
@@ -3,6 +3,7 @@ name: E2E Tests — Staging
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 # Wait for staging deploy to complete before running E2E
 # Vercel typically deploys within 1-3 minutes after push


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` to `e2e-staging.yml` so E2E tests can be manually re-run from the Actions tab

This also triggers a Vercel staging rebuild on merge, which deploys the health check endpoint and mock AI changes from PR #39.

## Test plan
- [ ] PR checks pass
- [ ] After merge: verify "E2E Tests — Staging" workflow shows "Run workflow" button
- [ ] After merge: health check and E2E staging workflows pass
- [ ] After merge: production deploy unblocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)