### PR TITLE
docs: document /api/health response shape (triggers fresh deploys)

### DIFF
--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -9,6 +9,10 @@ import { prisma } from "@/lib/prisma";
  *
  * No authentication required.
  * Called daily by Vercel cron (production) and GitHub Actions (staging).
+ *
+ * Response shape:
+ *   200 OK    - { success: true, data: { status, database, responseTimeMs, timestamp } }
+ *   503       - { success: false, error: { code: "DATABASE_UNAVAILABLE", message } }
  */
 export async function GET() {
   try {


### PR DESCRIPTION
## Summary
Minor JSDoc improvement for the `/api/health` route — documenting the 200 and 503 response shapes.

## Why now
This is intentionally a minimal change to **trigger fresh staging and production deploys** so Vercel picks up recently rotated env vars:
- Supabase DB password (DATABASE_URL + DIRECT_URL)
- Security secrets rotated per Vercel advisory (AUTH_SECRET, NEXTAUTH_SECRET, CRON_SECRET, etc.)

Redeploying an existing deployment in Vercel reuses that deployment's env var snapshot. A fresh push to `main` forces Vercel to rebuild with current env var values.

## Test plan
- [ ] PR checks pass
- [ ] After merge: `brandsiq-git-main-...vercel.app/api/health` returns 200
- [ ] After merge: login works on staging with existing credentials
- [ ] Production deploy (manual) picks up rotated production secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)