### PR TITLE
debug: log E2E login failure details for diagnosis

### DIFF
--- a/tests/e2e/core-flow.spec.ts
+++ b/tests/e2e/core-flow.spec.ts
@@ -16,10 +16,32 @@ const TEST_PASSWORD = process.env.E2E_TEST_PASSWORD || "";
 
 async function login(page: Page) {
   await page.goto("/auth/signin");
+
+  // Diagnostic logging (safe — doesn't reveal the password)
+  console.log(`[E2E Login] Email: "${TEST_EMAIL}"`);
+  console.log(`[E2E Login] Password length: ${TEST_PASSWORD.length}`);
+
   await page.locator('input[type="email"]').fill(TEST_EMAIL);
   await page.locator('input[type="password"]').fill(TEST_PASSWORD);
   await page.locator('button[type="submit"]').click();
-  await page.waitForURL(/\/dashboard/, { timeout: 15000 });
+
+  try {
+    await page.waitForURL(/\/dashboard/, { timeout: 15000 });
+    console.log("[E2E Login] Redirected to /dashboard successfully");
+  } catch (err) {
+    const currentUrl = page.url();
+    console.log(`[E2E Login] FAILED. Current URL: ${currentUrl}`);
+
+    // Capture the error message that the LoginForm renders (red bg error div)
+    const errorText = await page
+      .locator(".text-red-600.bg-red-50")
+      .first()
+      .textContent({ timeout: 2000 })
+      .catch(() => null);
+    console.log(`[E2E Login] Visible error: ${errorText ? `"${errorText.trim()}"` : "(none)"}`);
+
+    throw err;
+  }
 }
 
 test.describe("Core User Flow", () => {


### PR DESCRIPTION
## Summary
Add diagnostic logging to the E2E core-flow test's `login()` helper to capture:
- Email being used (to verify env var is set correctly)
- Password length (doesn't reveal the password itself)
- Current URL after submit
- Visible error message on the signin page

## Why
The E2E test has been failing at login with a URL timeout despite:
- Test user exists in DB
- Email is verified
- Manual login with same credentials works on staging
- `E2E_TEST_PASSWORD` GitHub secret was re-set

We need to see what the signin page actually shows when CI submits credentials.

## Next steps
After merge, check the E2E staging workflow logs for `[E2E Login]` output. Based on findings:
- "Invalid email or password" → credential mismatch between secret and DB
- "Please verify your email" → emailVerified got cleared
- No error but no redirect → timing issue, fix with longer timeout or `networkidle` wait
- Wrong URL (e.g., still on /auth/signin with no error) → form submission issue

Will revert with a follow-up PR once diagnosed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)