### PR TITLE
fix: complete rebrand URLs and enable NextAuth trustHost

### DIFF
--- a/.github/workflows/e2e-staging.yml
+++ b/.github/workflows/e2e-staging.yml
@@ -54,13 +54,13 @@ jobs:
             fi
           fi
         env:
-          STAGING_URL: https://review-flow-git-main-prajeens-projects-eb24da7b.vercel.app
+          STAGING_URL: https://brandsiq-git-main-prajeens-projects-eb24da7b.vercel.app
           VERCEL_BYPASS: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
       - name: Run E2E tests against staging
         run: npm run test:e2e
         env:
-          STAGING_URL: https://review-flow-git-main-prajeens-projects-eb24da7b.vercel.app
+          STAGING_URL: https://brandsiq-git-main-prajeens-projects-eb24da7b.vercel.app
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
           E2E_TEST_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD }}
 
@@ -91,11 +91,11 @@ jobs:
                 `**Commit:** [\`${commitSha}\`](${commitUrl})`,
                 `**Branch:** \`main\``,
                 `**Workflow Run:** [View logs](${runUrl})`,
-                `**Staging URL:** https://review-flow-git-main-prajeens-projects-eb24da7b.vercel.app`,
+                `**Staging URL:** https://brandsiq-git-main-prajeens-projects-eb24da7b.vercel.app`,
                 ``,
                 `### What to do`,
                 `1. Check the [workflow run logs](${runUrl}) and download the Playwright report artifact`,
-                `2. Reproduce locally: \`STAGING_URL=https://review-flow-git-main-prajeens-projects-eb24da7b.vercel.app npm run test:e2e\``,
+                `2. Reproduce locally: \`STAGING_URL=https://brandsiq-git-main-prajeens-projects-eb24da7b.vercel.app npm run test:e2e\``,
                 `3. Fix the issue and push to \`main\``,
                 `4. **Do NOT deploy to production** until E2E passes`,
                 ``,

--- a/.github/workflows/health-check-staging.yml
+++ b/.github/workflows/health-check-staging.yml
@@ -16,7 +16,7 @@ jobs:
         run: |
           STATUS=$(curl -s -o response.json -w "%{http_code}" \
             -H "x-vercel-protection-bypass: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}" \
-            "https://review-flow-git-main-prajeens-projects-eb24da7b.vercel.app/api/health")
+            "https://brandsiq-git-main-prajeens-projects-eb24da7b.vercel.app/api/health")
           echo "Health check returned HTTP $STATUS"
           cat response.json
           if [ "$STATUS" -ne 200 ]; then

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
   reporter: process.env.CI ? 'github' : 'html',
 
   use: {
-    baseURL: process.env.STAGING_URL || 'https://review-flow-git-main-prajeens-projects-eb24da7b.vercel.app',
+    baseURL: process.env.STAGING_URL || 'https://brandsiq-git-main-prajeens-projects-eb24da7b.vercel.app',
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     // Bypass Vercel Deployment Protection for automated testing

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -9,6 +9,11 @@ import { SESSION_CONFIG } from "./constants";
 export const { handlers, signIn, signOut, auth } = NextAuth({
   adapter: PrismaAdapter(prisma),
 
+  // Trust the X-Forwarded-Host header set by Vercel's edge proxy.
+  // Required for auth to work across Vercel domain aliases (preview URLs,
+  // custom domains, etc.) without explicitly configuring AUTH_URL per host.
+  trustHost: true,
+
   session: {
     strategy: "jwt",
     maxAge: SESSION_CONFIG.MAX_AGE_DAYS * 24 * 60 * 60, // 30 days


### PR DESCRIPTION
## Summary
Two related fixes that together resolve the E2E staging login failure we've been chasing.

## Why
Manual login to staging works on `brandsiq-git-main-*.vercel.app` but fails with **"Invalid email or password"** on `review-flow-git-main-*.vercel.app` — even though both aliases point to the **same Vercel project** with the **same deployment** and the credentials are correct. The E2E workflow happens to hit the failing alias.

### Root cause #1: Incomplete rebranding
The ReviewFlow → BrandsIQ rebranding commit missed 6 hardcoded URLs in CI/deployment configs. A later workflow (health-check) inherited the stale URL. These point the automation at a legacy domain alias.

### Root cause #2: NextAuth host validation
NextAuth v5 validates the request host on every auth callback. Without `trustHost: true`, it silently rejects callbacks from domain aliases it doesn't explicitly recognize — surfacing as a generic "Invalid email or password" to the UI. This is the **deeper** reason login fails on the `review-flow-*` alias.

## Changes

| File | Change |
|------|--------|
| [playwright.config.ts](playwright.config.ts) | Replace stale `review-flow-*` fallback URL with `brandsiq-*` |
| [.github/workflows/e2e-staging.yml](.github/workflows/e2e-staging.yml) | 4 URL updates |
| [.github/workflows/health-check-staging.yml](.github/workflows/health-check-staging.yml) | 1 URL update |
| [src/lib/auth.ts](src/lib/auth.ts) | Add `trustHost: true` to NextAuth config |

## Why both changes, not just one
- URL rename alone masks the deeper bug — next time Vercel adds an alias (custom domain, preview URL change), auth will break again
- `trustHost` alone would make the old URL work — but leaving stale CI references is confusing
- Doing both makes CI point at the canonical URL AND makes the app resilient to future domain changes

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run lint:strict` passes
- [x] All 581 unit tests pass locally
- [ ] PR Quality Gate passes
- [ ] After merge: health check cron workflow succeeds (uses new URL)
- [ ] After merge: E2E staging workflow runs the core-flow test successfully — `[E2E Login] Redirected to /dashboard successfully`
- [ ] After merge: production deploy is unblocked (E2E gate turns green)

## Follow-up (separate PR after this lands)
Revert the diagnostic logging in `tests/e2e/core-flow.spec.ts` from PR #48.

## Manual cleanup (Vercel dashboard, not in this PR)
Once verified working, consider removing the `review-flow-*` domain alias from Vercel → Project → Settings → Domains. Leaving it there doesn't break anything now, but prevents future confusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)