### PR TITLE
feat: add support contact across app (footer, error pages, help menu)

### DIFF
--- a/src/app/(auth)/auth/error/page.tsx
+++ b/src/app/(auth)/auth/error/page.tsx
@@ -7,6 +7,7 @@ import { AlertCircle, Loader2 } from "lucide-react";
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { SupportLink } from "@/components/shared/SupportLink";
 
 const errorMessages: Record<string, string> = {
   Configuration: "There is a problem with the server configuration.",
@@ -50,6 +51,7 @@ function AuthErrorContent() {
         <Link href="/" className="text-sm text-muted-foreground hover:underline">
           Return to home
         </Link>
+        <SupportLink className="pt-2 text-center" />
       </CardContent>
     </Card>
   );

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from "react";
 import * as Sentry from "@sentry/nextjs";
 import { Button } from "@/components/ui/button";
+import { SupportLink } from "@/components/shared/SupportLink";
 
 export default function Error({
   error,
@@ -17,12 +18,13 @@ export default function Error({
   }, [error]);
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center gap-4">
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 px-4 text-center">
       <h2 className="text-2xl font-bold">Something went wrong!</h2>
       <p className="text-muted-foreground">
         {error.message || "An unexpected error occurred"}
       </p>
       <Button onClick={() => reset()}>Try again</Button>
+      <SupportLink className="mt-2" />
     </div>
   );
 }

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from "react";
 import * as Sentry from "@sentry/nextjs";
 import { Button } from "@/components/ui/button";
+import { SUPPORT_EMAIL } from "@/lib/constants";
 
 export default function GlobalError({
   error,
@@ -34,6 +35,15 @@ export default function GlobalError({
             {error.message || "An unexpected error occurred"}
           </p>
           <Button onClick={() => reset()}>Try again</Button>
+          <p style={{ color: "#666", fontSize: "0.875rem", marginTop: "0.5rem" }}>
+            Having trouble?{" "}
+            <a
+              href={`mailto:${SUPPORT_EMAIL}`}
+              style={{ color: "#111", textDecoration: "underline" }}
+            >
+              Contact {SUPPORT_EMAIL}
+            </a>
+          </p>
         </div>
       </body>
     </html>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,18 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { SupportLink } from "@/components/shared/SupportLink";
+
+export default function NotFound() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 px-4 text-center">
+      <h2 className="text-2xl font-bold">Page not found</h2>
+      <p className="text-muted-foreground">
+        The page you are looking for does not exist or has been moved.
+      </p>
+      <Button asChild>
+        <Link href="/">Return home</Link>
+      </Button>
+      <SupportLink className="mt-2" />
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { TIER_LIMITS } from "@/lib/constants";
+import { SUPPORT_MAILTO, TIER_LIMITS } from "@/lib/constants";
 
 export default function HomePage() {
   return (
@@ -327,9 +327,17 @@ export default function HomePage() {
             </div>
             <span className="text-sm font-medium">BrandsIQ</span>
           </div>
-          <p className="text-sm text-muted-foreground">
-            &copy; {new Date().getFullYear()} BrandsIQ. All rights reserved.
-          </p>
+          <div className="flex flex-col items-center gap-2 md:flex-row md:gap-6">
+            <a
+              href={SUPPORT_MAILTO}
+              className="text-sm text-muted-foreground hover:text-foreground hover:underline"
+            >
+              Contact support
+            </a>
+            <p className="text-sm text-muted-foreground">
+              &copy; {new Date().getFullYear()} BrandsIQ. All rights reserved.
+            </p>
+          </div>
         </div>
       </footer>
     </div>

--- a/src/components/dashboard/DashboardHeader.tsx
+++ b/src/components/dashboard/DashboardHeader.tsx
@@ -2,7 +2,8 @@
 
 import { useSession, signOut } from "next-auth/react";
 import Link from "next/link";
-import { Menu, LogOut, Settings, User, Sparkles } from "lucide-react";
+import { Menu, LogOut, Settings, User, Sparkles, LifeBuoy } from "lucide-react";
+import { SUPPORT_MAILTO } from "@/lib/constants";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
@@ -99,6 +100,13 @@ export function DashboardHeader({ onMenuClick, tier = "FREE" }: DashboardHeaderP
                 <Settings className="mr-2 h-4 w-4" />
                 Settings
               </Link>
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem asChild>
+              <a href={SUPPORT_MAILTO} className="cursor-pointer">
+                <LifeBuoy className="mr-2 h-4 w-4" />
+                Contact support
+              </a>
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem asChild>

--- a/src/components/shared/ErrorBoundary.tsx
+++ b/src/components/shared/ErrorBoundary.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { AlertCircle, RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { SupportLink } from "@/components/shared/SupportLink";
 
 interface ErrorBoundaryProps {
   children: React.ReactNode;
@@ -63,6 +64,7 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoun
               <RefreshCw className="mr-2 h-4 w-4" />
               Try again
             </Button>
+            <SupportLink className="mt-4 text-center" />
           </CardContent>
         </Card>
       );

--- a/src/components/shared/SupportLink.tsx
+++ b/src/components/shared/SupportLink.tsx
@@ -1,0 +1,28 @@
+import { SUPPORT_EMAIL, SUPPORT_MAILTO } from "@/lib/constants";
+import { cn } from "@/lib/utils";
+
+interface SupportLinkProps {
+  prefix?: string;
+  className?: string;
+}
+
+/**
+ * Renders a standard "Having trouble? Contact support@brandsiq.app" line
+ * with a mailto link. Used on error pages and the 404 page.
+ */
+export function SupportLink({
+  prefix = "Having trouble?",
+  className,
+}: SupportLinkProps) {
+  return (
+    <p className={cn("text-sm text-muted-foreground", className)}>
+      {prefix}{" "}
+      <a
+        href={SUPPORT_MAILTO}
+        className="font-medium text-foreground underline-offset-4 hover:underline"
+      >
+        Contact {SUPPORT_EMAIL}
+      </a>
+    </p>
+  );
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -211,3 +211,7 @@ export const EMAIL_CONFIG = {
   VERIFICATION_EXPIRY_HOURS: 24,
   PASSWORD_RESET_EXPIRY_HOURS: 1,
 } as const;
+
+// Support contact
+export const SUPPORT_EMAIL = "support@brandsiq.app";
+export const SUPPORT_MAILTO = `mailto:${SUPPORT_EMAIL}`;


### PR DESCRIPTION
## Summary
Makes `support@brandsiq.app` discoverable from three places:
1. **App footer** (landing page) — new "Contact support" link
2. **Error pages** — all 4 surfaces (`error.tsx`, `global-error.tsx`, auth error, ErrorBoundary) now show "Having trouble? Contact support@brandsiq.app" below the retry button
3. **Help menu** — new "Contact support" item in the DashboardHeader user dropdown with LifeBuoy icon

Bonus: a branded 404 page (`src/app/not-found.tsx`) that previously didn't exist.

## Why
The suggestion was to add support email to footer, error pages, and a help menu. Exploration revealed:
- No help menu existed anywhere in the UI
- No 404 page existed
- Error pages showed generic messages with no support contact
- No `SUPPORT_EMAIL` constant in the codebase

This PR establishes a single source of truth (`SUPPORT_EMAIL` in `src/lib/constants.ts`) and wires it through consistent surfaces.

## Implementation

| File | Change |
|------|--------|
| `src/lib/constants.ts` | Add `SUPPORT_EMAIL` and `SUPPORT_MAILTO` constants |
| `src/components/shared/SupportLink.tsx` | **New** shared component for the standard "Having trouble?" line |
| `src/components/shared/ErrorBoundary.tsx` | Add `<SupportLink />` to Card fallback (not `ErrorMessage` — would be noise) |
| `src/app/error.tsx` | Add `<SupportLink />` under Try Again button |
| `src/app/(auth)/auth/error/page.tsx` | Add `<SupportLink />` below "Return to home" |
| `src/app/global-error.tsx` | Add support line using inline styles (Tailwind/shared component may not be available) |
| `src/app/page.tsx` | Add "Contact support" link in landing footer |
| `src/components/dashboard/DashboardHeader.tsx` | Add "Contact support" item with LifeBuoy icon between Settings and Plan |
| `src/app/not-found.tsx` | **New** branded 404 page |

## Copy consistency

| Surface | Copy |
|---------|------|
| Error pages + 404 | `Having trouble? Contact support@brandsiq.app` (long — email visible for screenshots) |
| Footer, dropdown | `Contact support` (short — not an error context) |

## Grep audit
`support@brandsiq.app` appears in **only 2 files**:
- `src/lib/constants.ts` (definition)
- `src/components/shared/SupportLink.tsx` (via import + template)

`global-error.tsx` uses `${SUPPORT_EMAIL}` interpolation so the literal string isn't in the source.

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run lint:strict` passes
- [x] All 581 unit tests pass
- [ ] PR Quality Gate passes
- [ ] After merge: landing footer shows "Contact support", clicking opens mailto
- [ ] After merge: dashboard dropdown shows "Contact support" with LifeBuoy icon
- [ ] After merge: visiting a bogus URL shows the new branded 404

## Out of scope (explicitly)
- No `/contact` page or contact form
- No footers added to dashboard/auth layouts
- No support line in `ErrorMessage` (small inline errors)
- No phone/tel number
- No mailto subject/body prefill

🤖 Generated with [Claude Code](https://claude.com/claude-code)