### PR TITLE
docs: expand SupportLink JSDoc (triggers fresh staging deploy)

### DIFF
--- a/src/components/shared/SupportLink.tsx
+++ b/src/components/shared/SupportLink.tsx
@@ -9,6 +9,11 @@ interface SupportLinkProps {
 /**
  * Renders a standard "Having trouble? Contact support@brandsiq.app" line
  * with a mailto link. Used on error pages and the 404 page.
+ *
+ * @param prefix - Leading text shown before the mailto link. Defaults to
+ *   "Having trouble?". Override for non-error contexts, e.g. "Questions?".
+ * @param className - Additional Tailwind classes for the wrapper paragraph,
+ *   e.g. "mt-4 text-center" for centered placement under a button.
  */
 export function SupportLink({
   prefix = "Having trouble?",


### PR DESCRIPTION
## Summary
Expand JSDoc on the `SupportLink` component to document the `prefix` and `className` props inline. Also triggers a fresh staging deploy so Vercel picks up the updated `NEXTAUTH_URL` env var (changed from `review-flow-*` to `brandsiq-*` for the Preview environment).

## Why now
As we discovered earlier, Vercel redeploys reuse the old deployment's env var snapshot. A fresh push to `main` forces Vercel to rebuild staging with current env var values.

After merge, sign-out on staging should correctly redirect to `brandsiq-git-main-*.vercel.app` instead of the old `review-flow-*` URL.

## Test plan
- [x] Type check passes (JSDoc-only change)
- [ ] PR checks pass
- [ ] After merge: sign in on staging, then sign out — should land on `brandsiq-git-main-*.vercel.app/` (not review-flow)
- [ ] After merge: E2E staging workflow still passes (login flow unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)