### PR TITLE
feat: add staging-deploy gate to production workflow

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -62,9 +62,49 @@ jobs:
               core.info('✅ E2E staging tests passed. Safe to deploy.');
             }
 
+  check-staging-deploy:
+    name: Verify Staging Deploy Passed
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check latest staging deploy workflow status
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Find the most recent staging deploy run on main (applies Prisma migrations to staging DB)
+            const workflows = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'deploy-staging.yml',
+              branch: 'main',
+              per_page: 1,
+              status: 'completed',
+            });
+
+            if (workflows.data.total_count === 0) {
+              core.warning('No staging deploy workflow runs found. Proceeding without staging-deploy gate.');
+              return;
+            }
+
+            const latestRun = workflows.data.workflow_runs[0];
+            const conclusion = latestRun.conclusion;
+            const runUrl = latestRun.html_url;
+
+            core.info(`Latest staging deploy: ${latestRun.head_sha.substring(0, 7)} — ${conclusion}`);
+            core.info(`Run URL: ${runUrl}`);
+
+            if (conclusion !== 'success') {
+              core.setFailed(
+                `Latest staging deploy ${conclusion}. Staging migrations may have failed — fix before deploying to production.\n` +
+                `See: ${runUrl}`
+              );
+            } else {
+              core.info('✅ Staging deploy passed. Safe to proceed.');
+            }
+
   test:
     name: Run All Tests
-    needs: [validate, check-e2e]
+    needs: [validate, check-e2e, check-staging-deploy]
     runs-on: ubuntu-latest
 
     services:


### PR DESCRIPTION
## Summary
Add a `check-staging-deploy` job to [deploy-production.yml](.github/workflows/deploy-production.yml) that verifies the latest `deploy-staging.yml` run succeeded before allowing production deploys. Mirrors the existing `check-e2e` gate, closing the gap where a failed staging migration could slip through.

## Why
The current production workflow has these gates:
1. `validate` — user typed "deploy"
2. `check-e2e` — latest E2E staging run succeeded
3. `test` — re-run all tests
4. `deploy-production` — apply prod migrations + deploy
5. `smoke-check` — ping `/api/health`

**Missing gate**: nothing verifies that `deploy-staging.yml` itself passed. `deploy-staging.yml` and `e2e-staging.yml` run independently — neither depends on the other.

### Failure scenario this catches
1. PR merged to main → `deploy-staging.yml` migration fails (DB pool auth desync, locked table, bad SQL, etc.)
2. Vercel still builds staging (it doesn't know about the migration failure)
3. E2E tests pass because they don't exercise the new schema changes yet
4. `check-e2e` is green → production deploy cleared
5. Same migration runs against prod DB → fails or partially applies → prod schema damaged

The smoke check at the end would catch the deployed app crashing, but by then the prod DB is already in an inconsistent state.

## Changes
One file modified. ~41 new lines.

**`.github/workflows/deploy-production.yml`:**
- **Added** `check-staging-deploy` job — clones `check-e2e` with `workflow_id: 'deploy-staging.yml'`
- **Updated** `test.needs` from `[validate, check-e2e]` → `[validate, check-e2e, check-staging-deploy]`

### Final pipeline order
```
validate
    ├── check-e2e              ┐
    └── check-staging-deploy   ┴─→  test → deploy-production → smoke-check
```

Both gate jobs run in parallel after `validate`. Either failing blocks production.

## Edge case behavior
Identical to `check-e2e`:
- **If no prior staging deploy run found:** warn and proceed (consistent with existing pattern; avoids chicken-and-egg on first deploy)
- **If a run exists and failed:** hard-fail with a link to the failed run

## Test plan
- [x] YAML syntax validated locally via `js-yaml`
- [x] Job list verified: `validate, check-e2e, check-staging-deploy, test, deploy-production, smoke-check`
- [x] `test.needs` verified to include `check-staging-deploy`
- [ ] PR Quality Gate passes
- [ ] After merge: next "Deploy to Production" trigger shows `Verify Staging Deploy Passed` job running in parallel with `Verify E2E Tests Passed`, both green

🤖 Generated with [Claude Code](https://claude.com/claude-code)