### PR TITLE
docs: sync Phase 0 specs with sentiment balance model

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -259,7 +259,7 @@ Platform filter uses exact match	Filters use the exact platform string from cons
 Spec Said	Implemented	Why Deviated	Impact/Risk
 API base URL /api/v1	Used /api (no version prefix)	Next.js App Router convention; versioning can be added later if needed	Low - easy to add /v1 prefix later
 DeepSeek required for sentiment	Made DeepSeek optional with fallback	Allows testing without API key; ensures feature works even if API is down	Low - fallback has lower accuracy but is functional
-Sentiment cost 0.3 credits	Sentiment counts against separate sentimentQuota, not credits	This matches the schema design where sentiment has its own quota (35/150/500 per tier)	None - follows schema design
+Sentiment cost 0.3 credits	Sentiment counts against separate sentimentCredits balance (1 analysis = 1 sentimentCredit), not response credits. **Superseded Jan 20, 2026:** originally `sentimentUsed`/`sentimentQuota`; standardized to balance model — see "Schema Change: Sentiment Credits Standardization".	Separate balance matches response-credit pattern; quota sized per tier (35/150/500)	None - follows schema design
 externalId and externalUrl in create	Available in schema but not in create form UI	These are for future platform integrations (CSV import), not manual entry	Low - can add to form when needed
 
 ![alt text](image-1.png)

--- a/docs/phase-0/CLAUDE_CODE_PROMPTS.md
+++ b/docs/phase-0/CLAUDE_CODE_PROMPTS.md
@@ -284,7 +284,7 @@ Implement the complete database schema using Prisma and connect to Supabase Post
    Copy the COMPLETE Prisma schema from `docs/phase-0/CORE_SPECS.md` into `prisma/schema.prisma`.
    
    The schema includes:
-   - User (with tier, credits, sentimentQuota)
+   - User (with tier, credits, sentimentCredits)
    - Account (OAuth)
    - Session (JWT sessions)
    - VerificationToken (email verification)
@@ -925,22 +925,22 @@ Implement sentiment analysis using DeepSeek API.
 
 2. **Integrate with Review Creation**
    Update `POST /api/reviews` endpoint:
-   - After language detection, check sentiment quota
-   - If quota available:
+   - After language detection, check user.sentimentCredits
+   - If sentimentCredits > 0:
      * Call analyzeSentiment()
      * Save sentiment to Review.sentiment
      * Log usage in SentimentUsage table
-     * Increment user.sentimentUsed
-   - If quota exceeded:
-     * Skip sentiment analysis
+     * Decrement user.sentimentCredits by 1 (atomic with the log insert)
+   - If sentimentCredits === 0:
+     * Skip sentiment analysis (non-blocking — review still created)
      * Set sentiment to null
-     * Show warning to user
+     * Return sentimentWarning in the API response; redirect to detail page with ?sentimentSkipped=true
 
-3. **Sentiment Quota Tracking**
-   - Track usage in user.sentimentUsed
-   - Reset monthly on user.sentimentResetDate
-   - Display quota in dashboard (e.g., "8/35 used")
-   - Show warning when approaching limit (>90%)
+3. **Sentiment Credit Tracking (Balance Model)**
+   - Track remaining balance in user.sentimentCredits (decrement 1 per analysis)
+   - Reset every 30 days on user.sentimentResetDate (anniversary from signup)
+   - Display balance in dashboard (e.g., "27/35 remaining")
+   - Show warning when approaching limit (≤20% remaining)
 
 4. **Sentiment Display**
    Add sentiment badges to ReviewCard:
@@ -1074,9 +1074,9 @@ Implement comprehensive credit tracking and management system.
    Logic:
    - Find users where creditsResetDate < now
    - Reset credits to tier default
-   - Reset sentimentUsed to 0
-   - Update reset dates to next month
-   - Log in system (for audit)
+   - Reset sentimentCredits to tier default (balance model)
+   - Update reset dates +30 days (anniversary-based, not calendar-aligned)
+   - Log MONTHLY_RESET action in CreditUsage (for audit)
 
 7. **Fraud Prevention**
    Implement race condition prevention:

--- a/docs/phase-0/CORE_SPECS.md
+++ b/docs/phase-0/CORE_SPECS.md
@@ -30,7 +30,7 @@ Reviews added → AI generates response in same language → User edits (optiona
 **Credit Costs:**
 - Response generation: 1.0 credits
 - Response regeneration: 1.0 credits
-- Sentiment analysis: 0.3 credits (counted against sentiment quota, not credits)
+- Sentiment analysis: 1 sentiment credit per analysis (separate balance from response credits; does not consume response credits)
 
 ---
 
@@ -62,8 +62,7 @@ model User {
   tier                Tier      @default(FREE)
   credits             Int       @default(15)
   creditsResetDate    DateTime  @default(now())
-  sentimentQuota      Int       @default(35)
-  sentimentUsed       Int       @default(0)
+  sentimentCredits    Int       @default(35)   // Balance model: remaining sentiment credits (decremented 1 per analysis)
   sentimentResetDate  DateTime  @default(now())
   
   // Timestamps
@@ -509,10 +508,11 @@ const TIER_LIMITS = {
 
 // Credit costs
 const CREDIT_COSTS = {
-  RESPONSE_GENERATION: 1.0,
-  RESPONSE_REGENERATION: 1.0,
-  SENTIMENT_ANALYSIS: 0.3  // Counted against sentiment quota
+  GENERATE_RESPONSE: 1.0,
+  REGENERATE_RESPONSE: 1.0,
 };
+// Sentiment analysis is NOT in CREDIT_COSTS — it consumes 1 sentimentCredit
+// from a separate balance (see TIER_LIMITS.*.sentiment).
 
 // Supported platforms
 const PLATFORMS = [

--- a/docs/phase-0/IMPLEMENTATION_GUIDE.md
+++ b/docs/phase-0/IMPLEMENTATION_GUIDE.md
@@ -369,23 +369,23 @@ export async function POST(req: Request) {
   
   // Detect language
   const languageResult = detectLanguage(reviewText);
-  
-  // Check sentiment quota
+
+  // Load user (for sentiment credit check — non-blocking)
   const user = await prisma.user.findUnique({
     where: { id: session.user.id }
   });
-  
-  if (!user || user.sentimentUsed >= user.sentimentQuota) {
-    return NextResponse.json(
-      { error: { code: "SENTIMENT_QUOTA_EXCEEDED", message: "Monthly sentiment analysis limit reached" } },
-      { status: 402 }
-    );
+
+  // Analyze sentiment only if credits remain.
+  // If not, review creation still proceeds with sentiment = null (non-blocking).
+  let sentiment: string | null = null;
+  let sentimentAnalyzed = false;
+  if (user && user.sentimentCredits > 0) {
+    const result = await analyzeSentiment(reviewText);
+    sentiment = result.sentiment;
+    sentimentAnalyzed = true;
   }
-  
-  // Analyze sentiment
-  const { sentiment } = await analyzeSentiment(reviewText);
-  
-  // Create review
+
+  // Create review (always — sentiment may be null)
   const review = await prisma.review.create({
     data: {
       userId: session.user.id,
@@ -398,29 +398,38 @@ export async function POST(req: Request) {
       sentiment
     }
   });
-  
-  // Log sentiment usage (audit trail)
-  await prisma.sentimentUsage.create({
-    data: {
-      userId: session.user.id,
-      reviewId: review.id,
-      sentiment,
-      details: JSON.stringify({
-        platform,
-        rating,
-        preview: reviewText.substring(0, 100),
-        analyzedAt: new Date(),
+
+  // Log sentiment usage + decrement balance atomically (only if analyzed)
+  if (sentimentAnalyzed && sentiment) {
+    await prisma.$transaction([
+      prisma.sentimentUsage.create({
+        data: {
+          userId: session.user.id,
+          reviewId: review.id,
+          sentiment,
+          details: JSON.stringify({
+            reviewId: review.id,
+            platform,
+            rating,
+            analyzedAt: new Date(),
+          })
+        }
+      }),
+      prisma.user.update({
+        where: { id: session.user.id },
+        data: { sentimentCredits: { decrement: 1 } }
       })
-    }
-  });
-  
-  // Increment sentiment usage counter
-  await prisma.user.update({
-    where: { id: session.user.id },
-    data: { sentimentUsed: { increment: 1 } }
-  });
-  
-  return NextResponse.json({ success: true, data: { review } }, { status: 201 });
+    ]);
+  }
+
+  return NextResponse.json(
+    {
+      success: true,
+      data: { review },
+      ...(sentimentAnalyzed ? {} : { sentimentWarning: "Sentiment analysis skipped: no credits remaining" })
+    },
+    { status: 201 }
+  );
 }
 ```
 
@@ -454,30 +463,18 @@ if (user.credits < 1) {
 
 **UI:** Show upgrade modal with pricing options
 
-### 2. Sentiment Quota Exceeded
-**Scenario:** User tries to add review when sentiment quota used up
+### 2. Sentiment Credits Exhausted
+**Scenario:** User adds a review when `sentimentCredits === 0`
 
-**Handling:**
+**Handling (non-blocking):** Review creation proceeds as normal; sentiment is stored as `null` and the API response includes a `sentimentWarning`. No 402 error — the review still gets saved because sentiment is enrichment, not a hard prerequisite.
+
 ```typescript
-if (user.sentimentUsed >= user.sentimentQuota) {
-  return NextResponse.json(
-    {
-      error: {
-        code: "SENTIMENT_QUOTA_EXCEEDED",
-        message: "Monthly sentiment analysis limit reached",
-        details: {
-          quotaUsed: user.sentimentUsed,
-          quotaTotal: user.sentimentQuota,
-          resetDate: user.sentimentResetDate
-        }
-      }
-    },
-    { status: 402 }
-  );
-}
+// See sentiment analysis block above — skipped when user.sentimentCredits === 0.
+// The review is created with sentiment: null and the response carries:
+//   { success: true, data: { review }, sentimentWarning: "Sentiment analysis skipped: no credits remaining" }
 ```
 
-**UI:** Allow review creation but show warning: "Sentiment analysis unavailable (quota reached)"
+**UI:** Redirect to the review detail page with `?sentimentSkipped=true`. The page shows a dismissible yellow alert ("Sentiment Analysis Skipped") with an upgrade CTA, and the review itself displays a `Sentiment ⚠` indicator with tooltip instead of a sentiment badge.
 
 ### 3. Language Detection Low Confidence
 **Scenario:** Review text too short (<50 chars) or mixed languages

--- a/docs/phase-0/SECURITY_AUTH.md
+++ b/docs/phase-0/SECURITY_AUTH.md
@@ -151,14 +151,13 @@ export const authOptions = {
   events: {
     async signIn({ user, isNewUser }) {
       if (isNewUser) {
-        // Initialize new user
+        // Initialize new user (balance model: sentimentCredits holds remaining balance)
         await prisma.user.update({
           where: { id: user.id },
           data: {
             credits: 15,
             tier: "FREE",
-            sentimentQuota: 35,
-            sentimentUsed: 0
+            sentimentCredits: 35
           }
         });
         


### PR DESCRIPTION
## Summary
- Fix stale Phase 0 specs that still described sentiment as `0.3 response credits` and used the old `sentimentUsed + sentimentQuota` usage model. Actual code uses a 1:1 `sentimentCredits` balance model (corrected Jan 20, 2026) and the condensed docs were never updated.
- Correct the non-blocking behavior when sentiment credits are exhausted: review is still created with `sentiment: null` and a `sentimentWarning` in the response — not a 402 `SENTIMENT_QUOTA_EXCEEDED` error as the spec claimed.
- Replace misleading "monthly reset" wording with anniversary-based language (every 30 days from signup) in CLAUDE_CODE_PROMPTS where it could mislead a future implementation.

## Why this matters
`CLAUDE.md` imports `@docs/phase-0/CORE_SPECS.md`, `@docs/phase-0/SECURITY_AUTH.md`, and `@docs/phase-0/IMPLEMENTATION_GUIDE.md` into every session. Until now those files were steering Claude toward the pre-refactor design.

## Files touched
- `docs/phase-0/CORE_SPECS.md` — credit costs prose, `CREDIT_COSTS` constants block, Prisma `User` schema
- `docs/phase-0/IMPLEMENTATION_GUIDE.md` — review-creation sentiment flow + Edge Case #2 (renamed to "Sentiment Credits Exhausted")
- `docs/phase-0/SECURITY_AUTH.md` — new-user init snippet
- `docs/phase-0/CLAUDE_CODE_PROMPTS.md` — balance-model tracking instructions + anniversary reset wording

## Explicitly not changed
- `/month` shorthand in the pricing table (industry standard, clarified by later prose)
- `MONTHLY_RESET` audit action name and `resetMonthlyCredits()` function references (these match real code)
- `docs/archive/phase-0-verbose/*` (marked read-only historical reference in CLAUDE.md)

## Test plan
- [ ] Skim each diff and confirm no prose was altered beyond the corrections
- [ ] Grep `docs/phase-0/` for `0.3 credits`, `SENTIMENT_ANALYSIS:`, `sentimentUsed`, `sentimentQuota`, `SENTIMENT_QUOTA_EXCEEDED` — should return zero matches
- [ ] Spot-check that the Prisma schema in CORE_SPECS now matches `prisma/schema.prisma`
- [ ] Confirm the new IMPLEMENTATION_GUIDE sentiment flow matches `src/app/api/reviews/route.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)