### PR TITLE
chore: centralize staging URL and add issue-on-failure for health check

### DIFF
--- a/.github/workflows/e2e-staging.yml
+++ b/.github/workflows/e2e-staging.yml
@@ -54,13 +54,13 @@ jobs:
             fi
           fi
         env:
-          STAGING_URL: https://brandsiq-git-main-prajeens-projects-eb24da7b.vercel.app
+          STAGING_URL: ${{ vars.STAGING_URL }}
           VERCEL_BYPASS: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
       - name: Run E2E tests against staging
         run: npm run test:e2e
         env:
-          STAGING_URL: https://brandsiq-git-main-prajeens-projects-eb24da7b.vercel.app
+          STAGING_URL: ${{ vars.STAGING_URL }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
           E2E_TEST_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD }}
 
@@ -75,11 +75,14 @@ jobs:
       - name: Create GitHub Issue on failure
         if: failure()
         uses: actions/github-script@v7
+        env:
+          STAGING_URL: ${{ vars.STAGING_URL }}
         with:
           script: |
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const commitSha = context.sha.substring(0, 7);
             const commitUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/commit/${context.sha}`;
+            const stagingUrl = process.env.STAGING_URL;
 
             await github.rest.issues.create({
               owner: context.repo.owner,
@@ -91,11 +94,11 @@ jobs:
                 `**Commit:** [\`${commitSha}\`](${commitUrl})`,
                 `**Branch:** \`main\``,
                 `**Workflow Run:** [View logs](${runUrl})`,
-                `**Staging URL:** https://brandsiq-git-main-prajeens-projects-eb24da7b.vercel.app`,
+                `**Staging URL:** ${stagingUrl}`,
                 ``,
                 `### What to do`,
                 `1. Check the [workflow run logs](${runUrl}) and download the Playwright report artifact`,
-                `2. Reproduce locally: \`STAGING_URL=https://brandsiq-git-main-prajeens-projects-eb24da7b.vercel.app npm run test:e2e\``,
+                `2. Reproduce locally: \`STAGING_URL=${stagingUrl} npm run test:e2e\``,
                 `3. Fix the issue and push to \`main\``,
                 `4. **Do NOT deploy to production** until E2E passes`,
                 ``,

--- a/.github/workflows/health-check-staging.yml
+++ b/.github/workflows/health-check-staging.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 6 * * *'    # Daily at 6 AM UTC
   workflow_dispatch:         # Manual trigger
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   ping-staging-db:
     name: Ping Staging Database
@@ -16,7 +20,7 @@ jobs:
         run: |
           STATUS=$(curl -s -o response.json -w "%{http_code}" \
             -H "x-vercel-protection-bypass: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}" \
-            "https://brandsiq-git-main-prajeens-projects-eb24da7b.vercel.app/api/health")
+            "${STAGING_URL}/api/health")
           echo "Health check returned HTTP $STATUS"
           cat response.json
           if [ "$STATUS" -ne 200 ]; then
@@ -24,6 +28,45 @@ jobs:
             exit 1
           fi
           echo "Staging database is healthy."
+        env:
+          STAGING_URL: ${{ vars.STAGING_URL }}
+
+      - name: Create GitHub Issue on failure
+        if: failure()
+        uses: actions/github-script@v7
+        env:
+          STAGING_URL: ${{ vars.STAGING_URL }}
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const stagingUrl = process.env.STAGING_URL;
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `🔴 Staging DB Health Check Failed`,
+              body: [
+                `## Staging Database Health Check Failed`,
+                ``,
+                `The daily ping to the staging \`/api/health\` endpoint did not return HTTP 200.`,
+                ``,
+                `**Workflow Run:** [View logs](${runUrl})`,
+                `**Staging URL:** ${stagingUrl}`,
+                ``,
+                `### Likely causes`,
+                `1. **Supabase staging project is paused** — free-tier projects auto-pause after inactivity. Unpause from the [Supabase dashboard](https://supabase.com/dashboard).`,
+                `2. **Pooler out of sync after unpause** — if unpausing alone doesn't fix it, reset the staging DB password (see DECISIONS.md → "DB Health Check Strategy").`,
+                `3. **Staging deployment is broken** — \`/api/health\` may not exist on the current deployment. Check Vercel.`,
+                `4. **Staging URL is stale** — verify the \`STAGING_URL\` repo variable still points to a live alias.`,
+                ``,
+                `### Why this matters`,
+                `If left unaddressed, the staging DB stays paused and subsequent deploys / E2E runs will fail.`,
+                ``,
+                `---`,
+                `*This issue was automatically created by the staging health check workflow.*`,
+              ].join('\n'),
+              labels: ['bug', 'health-check-failure', 'automated'],
+            });
 
       - name: Summary
         if: always()

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -15,6 +15,9 @@ export default defineConfig({
   reporter: process.env.CI ? 'github' : 'html',
 
   use: {
+    // CI always sets STAGING_URL from the repo variable; the literal below is a
+    // local-DX fallback only. If the staging alias changes, update both this
+    // string and the STAGING_URL repo variable.
     baseURL: process.env.STAGING_URL || 'https://brandsiq-git-main-prajeens-projects-eb24da7b.vercel.app',
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',


### PR DESCRIPTION
## Summary

- Move the hardcoded staging URL out of `e2e-staging.yml`, `health-check-staging.yml`, and `playwright.config.ts` (CI path) into the `STAGING_URL` repo variable. The next Vercel project rename now only needs one update instead of hand-editing six occurrences across three files.
- Add an issue-on-failure step to `health-check-staging.yml`, mirroring what `e2e-staging.yml` already does. Scheduled-workflow failures don't notify by default — three consecutive 404s went unnoticed last month, and the staging DB got auto-paused as a result.

## Context

Last month the staging Supabase project paused after ~60 hours of zero DB traffic. The health check that was supposed to prevent exactly that had been failing silently for three days because `/api/health` returned 404 on the alias being pinged. The cron ran, the cron failed, nobody saw it.

Two related improvements here:
1. **Centralization** — the URL lived hardcoded in six places; a rename fragmented the fix across multiple PRs and left CI broken in the meantime.
2. **Notification** — the health-check workflow was deliberately less noisy than `e2e-staging.yml` (no issue creation). That asymmetry is what hid the failure.

`playwright.config.ts` keeps a literal fallback because local `npm run test:e2e` runs without `STAGING_URL` set. A comment now flags the dual-update requirement on rename.

## Prerequisite (already done)

Repo variable `STAGING_URL` set to `https://brandsiq-git-main-prajeens-projects-eb24da7b.vercel.app` (Settings → Secrets and variables → Actions → Variables).

## Test plan

- [ ] Merge to main
- [ ] Trigger `Health Check — Staging DB Ping` manually via `workflow_dispatch`, confirm it passes (proves the variable resolves correctly in CI)
- [ ] (Optional) Temporarily set `STAGING_URL` to a bad value, run manually, confirm a GitHub Issue is opened with the expected body, then restore the variable
- [ ] Confirm next push to `main` triggers `e2e-staging.yml` and tests still pass against the variable-sourced URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)