### PR TITLE
ci: upload Playwright traces so E2E failures can be debugged

### DIFF
--- a/.github/workflows/e2e-staging.yml
+++ b/.github/workflows/e2e-staging.yml
@@ -71,6 +71,19 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 7
+          if-no-files-found: ignore
+
+      # test-results/ contains screenshots, trace.zip, and error-context.md
+      # for any failed test — needed for post-mortem since `reporter: github`
+      # alone only writes annotations, not files.
+      - name: Upload Playwright traces and screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-test-results
+          path: test-results/
+          retention-days: 7
+          if-no-files-found: ignore
 
       - name: Create GitHub Issue on failure
         if: failure()


### PR DESCRIPTION
## Summary

- Add a second `upload-artifact` step that captures `test-results/` (screenshots, trace.zip, error-context.md) — the existing one only captures `playwright-report/`, which is empty when `reporter: 'github'` is in use.
- Add `if-no-files-found: ignore` to suppress spurious warnings on green runs.

## Why

The cleanup test in `core-flow.spec.ts` (`cleanup: delete test review`) has been failing on every E2E run since at least Apr 23. Confirmed by inspecting the staging test account (`e2e-test@brandsiq.app`): test reviews are being created and not deleted, accumulating over time.

To fix the test correctly we need to see what the page actually looks like at the moment the assertion fails, instead of guessing. With this change merged, the next E2E run will preserve the trace.

This is a stepping-stone PR — the test fix itself comes after we inspect the trace.

## Plan after merge

1. Trigger E2E manually via `workflow_dispatch` on main.
2. Download `playwright-test-results` artifact.
3. Open trace.zip with `npx playwright show-trace` and identify why the delete button isn't visible within 10s on the cleanup test's fresh-login page load.
4. Fix the test in a follow-up PR.
5. (Optional) Manual cleanup of the accumulated test reviews under `e2e-test@brandsiq.app` once the test is fixed.

## Test plan

- [ ] Merge to main; observe that the next E2E run produces both `playwright-report` and `playwright-test-results` artifacts (the latter will contain the cleanup-test failure trace)
- [ ] Confirm the existing E2E pass/fail behavior is unchanged (this PR adds artifacts only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)