### PR TITLE
fix: merge E2E cleanup step into main test and tighten review URL regex

### DIFF
--- a/tests/e2e/core-flow.spec.ts
+++ b/tests/e2e/core-flow.spec.ts
@@ -26,9 +26,7 @@ test.describe("Core User Flow", () => {
   // Skip if no test password configured (prevents failures in environments without setup)
   test.skip(!TEST_PASSWORD, "E2E_TEST_PASSWORD not set — skipping core flow tests");
 
-  let createdReviewUrl: string | null = null;
-
-  test("login → add review → generate response → edit → approve", async ({
+  test("login → add review → generate response → edit → approve → delete", async ({
     page,
   }) => {
     // Step 1: Login
@@ -54,11 +52,13 @@ test.describe("Core User Flow", () => {
     // Submit the form
     await page.locator('button[type="submit"]').click();
 
-    // Wait for redirect to review detail page
-    await page.waitForURL(/\/dashboard\/reviews\/[a-z0-9]+/, {
+    // Wait for redirect to the *detail* page. The previous regex
+    // /\/dashboard\/reviews\/[a-z0-9]+/ also matched /dashboard/reviews/new
+    // (the form's own URL), so it could resolve before the API redirect
+    // landed. CUIDs are 25 chars starting with 'c'.
+    await page.waitForURL(/\/dashboard\/reviews\/c[a-z0-9]{20,}$/, {
       timeout: 15000,
     });
-    createdReviewUrl = page.url();
 
     // Step 4: Generate AI Response
     const generateButton = page
@@ -100,25 +100,22 @@ test.describe("Core User Flow", () => {
     await expect(page.getByText("Approved", { exact: true }).first()).toBeVisible({
       timeout: 10000,
     });
-  });
 
-  // Cleanup: delete the test review to avoid accumulating test data
-  test("cleanup: delete test review", async ({ page }) => {
-    test.skip(!createdReviewUrl, "No review was created to clean up");
-
-    await login(page);
-    await page.goto(createdReviewUrl!);
-
-    // Click the delete button (trash icon in the header area)
-    const deleteButton = page.getByRole("button", { name: /delete/i }).first();
-    await expect(deleteButton).toBeVisible({ timeout: 10000 });
+    // Step 7: Delete the review (cleanup, in-flow). Bundling cleanup into the
+    // main test eliminates the need to share state between tests and keeps the
+    // browser session warm — a separate cleanup test was prone to retry-skip
+    // when worker state was reset between attempts.
+    const deleteButton = page.getByRole("button", { name: /^delete$/i }).first();
+    await expect(deleteButton).toBeVisible({ timeout: 5000 });
     await deleteButton.click();
 
-    // Confirm deletion in the dialog — the last Delete button is the dialog confirm
+    // Confirm deletion in the dialog. With the dialog open there are two
+    // buttons matching /^delete$/i — the page-level one and the dialog
+    // confirm — so .last() targets the confirm.
     const confirmButton = page.getByRole("button", { name: /^delete$/i }).last();
     await confirmButton.click();
 
-    // Should redirect to reviews list
-    await page.waitForURL(/\/dashboard\/reviews/, { timeout: 10000 });
+    // Verify we landed on the reviews list (signals successful deletion)
+    await page.waitForURL(/\/dashboard\/reviews$/, { timeout: 10000 });
   });
 });


### PR DESCRIPTION
## Summary

- Bundle the delete step into the main core-flow test so there's no inter-test state. Removes the separate `cleanup: delete test review` test entirely.
- Tighten `waitForURL` regex from `/\/dashboard\/reviews\/[a-z0-9]+/` to `/\/dashboard\/reviews\/c[a-z0-9]{20,}\$/` so it only matches CUID-shaped paths, not `/dashboard/reviews/new`.

## Root cause

Two compounding issues were causing the cleanup test to fail on every E2E run since at least Apr 23, leaving orphaned test reviews accumulating on staging under `e2e-test@brandsiq.app`:

**1. Loose `waitForURL` regex matched `/new`.**
After form submit, the URL transiently sits at `/dashboard/reviews/new` (the form's own URL) before the API call resolves and redirects to the real `/dashboard/reviews/<cuid>`. The old regex matched `new` as `[a-z0-9]+`, so `page.url()` captured the wrong URL. The main test still passed because Playwright auto-waits for visibility on the next `expect(...).toBeVisible()`, by which point the URL had settled. But `createdReviewUrl` was already stored as `…/dashboard/reviews/new`. Confirmed by the page snapshot from the captured trace (PR #66) — the cleanup test landed on the Add New Review form.

**2. Module-level state didn't survive retries.**
The retry trace from run 25598882120 shows the retry attempt skipped immediately — no `goto`, no `login`, no test code at all. `test.skip(!createdReviewUrl, ...)` was firing on retry, meaning module state was effectively lost between attempts. Even fixing the URL regex alone wouldn't have made retries reliable.

## Fix

Combine both tests into one. The delete step now runs in the same browser session, with no shared state, immediately after Approve. This:

- Eliminates the inter-test state dependency entirely.
- Avoids a second login (which created a fresh navigation that race-conditioned with `goto(createdReviewUrl)`).
- Makes a delete failure show up as a real test failure rather than silently skipping on retry.
- Mirrors the actual user flow more closely.

URL regex tightened as belt-and-suspenders — a CUID is `c` followed by 20+ lowercase alphanumerics, and `\$` anchors to end-of-path so any future query-string variant won't accidentally match.

## Test plan

- [ ] Merge to main, watch the next E2E run. Expectation: green, no annotation about cleanup.
- [ ] Verify (in the test account `e2e-test@brandsiq.app`) that no new test review accumulates after the merged run lands.
- [ ] Manual cleanup of the existing accumulated test reviews under that account is still needed (one-time, not in scope of this PR).

## Confidence

~95%. The two issues identified are independent (URL bug + state-sharing bug) and this PR fixes both. The remaining 5% covers things like Vercel cold-start timing affecting the new step's 5s timeout — easy to bump if it bites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)