### PR TITLE
fix(sidebar): expose isFounder via session so client components can read it

### DIFF
--- a/src/components/dashboard/Sidebar.tsx
+++ b/src/components/dashboard/Sidebar.tsx
@@ -14,7 +14,6 @@ import {
   Ticket,
   X,
 } from "lucide-react";
-import { isFounder } from "@/lib/auth-helpers";
 
 interface SidebarProps {
   isOpen?: boolean;
@@ -53,7 +52,10 @@ const adminNavigation = [
 export function Sidebar({ isOpen = true, onClose, isMobile = false }: SidebarProps) {
   const pathname = usePathname();
   const { data: session } = useSession();
-  const showAdmin = isFounder(session);
+  // isFounder is computed server-side in the JWT callback (see src/lib/auth.ts)
+  // and exposed on the session, because FOUNDER_EMAILS is a server-only env
+  // var that wouldn't resolve in the browser bundle.
+  const showAdmin = session?.user?.isFounder === true;
 
   const sidebarContent = (
     <>

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -7,6 +7,7 @@ import { cookies } from "next/headers";
 import { prisma } from "./prisma";
 import { SESSION_CONFIG, BETA_PLAN, TIER_LIMITS } from "./constants";
 import { getCurrentPhase } from "./system-phase";
+import { isFounderEmail } from "./auth-helpers";
 
 const INVITE_COOKIE_NAME = "bx_invite_code";
 
@@ -165,6 +166,12 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         }
       }
 
+      // Compute isFounder server-side from FOUNDER_EMAILS so client components
+      // (Sidebar etc.) don't need to read the env var. Recomputed on every JWT
+      // pass — cheap (in-memory string compare); picks up env-var changes after
+      // the user signs out/in (acceptable for a one-founder MVP).
+      token.isFounder = isFounderEmail(token.email);
+
       return token;
     },
 
@@ -173,6 +180,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       if (session.user) {
         session.user.id = token.id as string;
         session.user.tier = (token.tier as string) || "FREE";
+        session.user.isFounder = token.isFounder ?? false;
       }
       return session;
     },

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -7,6 +7,10 @@ declare module "next-auth" {
     user: {
       id: string;
       tier: string;
+      // Computed in the JWT callback from FOUNDER_EMAILS (server-only env var).
+      // Exposed on the session so client components like Sidebar can render
+      // founder-only UI without needing to read FOUNDER_EMAILS in the browser.
+      isFounder: boolean;
     } & DefaultSession["user"];
   }
 
@@ -19,5 +23,6 @@ declare module "next-auth/jwt" {
   interface JWT extends DefaultJWT {
     id?: string;
     tier?: string;
+    isFounder?: boolean;
   }
 }


### PR DESCRIPTION
## Summary

The Admin section of the dashboard sidebar wasn't appearing for founder accounts on staging, even though server-side admin gating worked correctly. Three small files, ~10 lines.

## What was broken

`src/components/dashboard/Sidebar.tsx` is a **client** component that called `isFounder(session)` to decide whether to render the "Admin" navigation section. The helper reads `process.env.FOUNDER_EMAILS` — but Next.js only ships env vars prefixed with `NEXT_PUBLIC_` to the browser bundle, so this was always `undefined` client-side and `isFounder()` always returned `false`.

**Server-side gating was unaffected**: middleware and `/api/admin/*` route handlers run on the server where `process.env.FOUNDER_EMAILS` is available. Verified during smoke test on staging by visiting `https://...vercel.app/api/admin/beta-invites` directly while signed in — returned 200 with `{"success":true,"data":{"invites":[]}}`. So security held; only the UX link to the page was hidden.

## How it's fixed

Compute `isFounder` once in the NextAuth JWT callback (server-side, where `process.env` works) and copy it onto the session. The Sidebar now reads `session.user.isFounder` via the existing `useSession()` hook — no extra fetch, no flicker, no env-var read in the browser.

## Files changed

- **`src/types/next-auth.d.ts`** — add `isFounder: boolean` to `Session.user` and `isFounder?: boolean` to `JWT`
- **`src/lib/auth.ts`** — `jwt` callback now computes `token.isFounder = isFounderEmail(token.email)` on every pass; `session` callback copies `token.isFounder` to `session.user.isFounder`
- **`src/components/dashboard/Sidebar.tsx`** — replace `const showAdmin = isFounder(session)` with `const showAdmin = session?.user?.isFounder === true`; drop the `isFounder` import

## Trade-offs

- **Recomputed on every JWT pass** instead of cached. The compute is a synchronous in-memory string compare against a 1-element array — effectively free. Avoids subtle staleness issues where a cached flag survives an env-var change.
- **Existing sessions don't pick up `FOUNDER_EMAILS` env-var changes until the user signs out/in.** Acceptable for a one-founder MVP. Proper RBAC is post-MVP work (Scale-tier).

## Test plan

### Pre-merge automated gates (verified locally)

- `npm run lint:strict` clean
- `npm run type-check` clean
- `npm run test:unit` 604 passed, 17 skipped (integration), 0 failed

### Manual smoke test on staging (after merge)

After this merges and the staging deploy completes:

- [ ] Sign **out** of the staging dashboard, then sign back in as `prajeen.builder@gmail.com` — existing JWTs predate this change and won't have `isFounder` until refreshed
- [ ] Confirm the **"Admin"** section now appears in the left sidebar with a "Beta invites" link
- [ ] Click the link → land on `/dashboard/admin/beta-invites` (already works, just confirming the click path works end-to-end)
- [ ] Sign in as a non-founder email → confirm Admin section does **not** appear (and the URL still 404s if visited directly)

### Defense-in-depth check (server-side gating still works)

- [ ] As a non-founder, visit `/api/admin/beta-invites` directly → still returns 404. (This was already verified in the original smoke test; re-confirming nothing regressed.)

## Why this wasn't caught earlier

The unit tests for `auth-helpers.ts` and `Sidebar.tsx` (if any) test the functions in isolation, where `process.env.FOUNDER_EMAILS` is available because Vitest runs in Node. The bug only surfaces in a real browser environment where the bundler strips server-only env vars. Future-proofing: any client component reading `process.env.X` (without `NEXT_PUBLIC_` prefix) is a similar bug waiting to happen — could add an ESLint rule for this in iteration 3 if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)