### PR TITLE
fix(api): honor isBetaUser when computing credit/quota totals on read paths

### DIFF
--- a/src/app/api/credits/route.ts
+++ b/src/app/api/credits/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
-import { TIER_LIMITS } from "@/lib/constants";
+import { getEffectiveAllocation } from "@/lib/constants";
 import type { SubscriptionTier } from "@/lib/constants";
 
 /**
@@ -27,6 +27,7 @@ export async function GET() {
       select: {
         id: true,
         tier: true,
+        isBetaUser: true,
         credits: true,
         creditsResetDate: true,
         sentimentCredits: true,
@@ -44,25 +45,30 @@ export async function GET() {
       );
     }
 
-    // Get tier limits
-    const tierLimits = TIER_LIMITS[user.tier as SubscriptionTier] || TIER_LIMITS.FREE;
+    // Allocation honors isBetaUser (beta plan is 150/750 regardless of tier).
+    // See src/lib/constants.ts:getEffectiveAllocation.
+    const allocation = getEffectiveAllocation({
+      tier: user.tier as SubscriptionTier,
+      isBetaUser: user.isBetaUser,
+    });
 
-    // Calculate credits used (total - remaining)
-    const creditsUsed = tierLimits.credits - user.credits;
+    // Calculate credits used (total - remaining), clamped to 0
+    const creditsUsed = Math.max(0, allocation.credits - user.credits);
+    const sentimentUsed = Math.max(0, allocation.sentimentQuota - user.sentimentCredits);
 
     return NextResponse.json({
       success: true,
       data: {
         credits: {
           remaining: user.credits,
-          total: tierLimits.credits,
-          used: creditsUsed > 0 ? creditsUsed : 0,
+          total: allocation.credits,
+          used: creditsUsed,
           resetDate: user.creditsResetDate.toISOString(),
         },
         sentiment: {
           remaining: user.sentimentCredits,
-          total: tierLimits.sentimentQuota,
-          used: tierLimits.sentimentQuota - user.sentimentCredits,
+          total: allocation.sentimentQuota,
+          used: sentimentUsed,
           resetDate: user.sentimentResetDate.toISOString(),
         },
         tier: user.tier,

--- a/src/app/api/dashboard/stats/route.ts
+++ b/src/app/api/dashboard/stats/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
-import { TIER_LIMITS } from "@/lib/constants";
+import { getEffectiveAllocation } from "@/lib/constants";
 import type { SubscriptionTier } from "@/lib/constants";
 
 export async function GET() {
@@ -24,6 +24,7 @@ export async function GET() {
       select: {
         id: true,
         tier: true,
+        isBetaUser: true,
         credits: true,
         creditsResetDate: true,
         sentimentCredits: true,
@@ -122,11 +123,15 @@ export async function GET() {
       }
     }
 
-    // Get tier limits
-    const tierLimits = TIER_LIMITS[user.tier as SubscriptionTier] || TIER_LIMITS.FREE;
+    // Allocation honors isBetaUser (beta plan is 150/750 regardless of tier).
+    // See src/lib/constants.ts:getEffectiveAllocation.
+    const allocation = getEffectiveAllocation({
+      tier: user.tier as SubscriptionTier,
+      isBetaUser: user.isBetaUser,
+    });
 
     // Calculate credits used (total - remaining)
-    const creditsUsed = tierLimits.credits - user.credits;
+    const creditsUsed = allocation.credits - user.credits;
 
     // Format recent reviews
     const recentReviews = user.reviews.map((review) => ({
@@ -145,14 +150,14 @@ export async function GET() {
       data: {
         credits: {
           remaining: user.credits,
-          total: tierLimits.credits,
+          total: allocation.credits,
           used: creditsUsed > 0 ? creditsUsed : 0,
           resetDate: user.creditsResetDate.toISOString(),
         },
         sentiment: {
           remaining: user.sentimentCredits,
-          total: tierLimits.sentimentQuota,
-          used: tierLimits.sentimentQuota - user.sentimentCredits,
+          total: allocation.sentimentQuota,
+          used: Math.max(0, allocation.sentimentQuota - user.sentimentCredits),
           resetDate: user.sentimentResetDate.toISOString(),
         },
         tier: user.tier,

--- a/src/app/api/sentiment/usage/route.ts
+++ b/src/app/api/sentiment/usage/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
-import { TIER_LIMITS } from "@/lib/constants";
+import { getEffectiveAllocation } from "@/lib/constants";
 import type { SubscriptionTier } from "@/lib/constants";
 
 /**
@@ -127,6 +127,7 @@ export async function GET(request: NextRequest) {
       where: { id: session.user.id },
       select: {
         tier: true,
+        isBetaUser: true,
         sentimentCredits: true,
         sentimentResetDate: true,
       },
@@ -194,10 +195,14 @@ export async function GET(request: NextRequest) {
         },
         quota: user
           ? (() => {
-              const tierLimits = TIER_LIMITS[user.tier as SubscriptionTier] || TIER_LIMITS.FREE;
+              // Honors isBetaUser (beta plan is 750 sentiment regardless of tier).
+              const allocation = getEffectiveAllocation({
+                tier: user.tier as SubscriptionTier,
+                isBetaUser: user.isBetaUser,
+              });
               return {
-                used: tierLimits.sentimentQuota - user.sentimentCredits,
-                total: tierLimits.sentimentQuota,
+                used: Math.max(0, allocation.sentimentQuota - user.sentimentCredits),
+                total: allocation.sentimentQuota,
                 remaining: user.sentimentCredits,
                 resetDate: user.sentimentResetDate.toISOString(),
               };

--- a/tests/unit/api/credits/credits.test.ts
+++ b/tests/unit/api/credits/credits.test.ts
@@ -87,6 +87,7 @@ describe('GET /api/credits', () => {
     mockPrisma.user.findUnique.mockResolvedValue({
       id: mockSession.user.id,
       tier: 'FREE',
+      isBetaUser: false,
       credits: 12,
       creditsResetDate: resetDate,
       sentimentCredits: 30,
@@ -107,6 +108,7 @@ describe('GET /api/credits', () => {
     mockPrisma.user.findUnique.mockResolvedValue({
       id: mockSession.user.id,
       tier: 'FREE',
+      isBetaUser: false,
       credits: 12,
       creditsResetDate: new Date(),
       sentimentCredits: 30,
@@ -125,6 +127,7 @@ describe('GET /api/credits', () => {
     mockPrisma.user.findUnique.mockResolvedValue({
       id: mockSession.user.id,
       tier: 'FREE',
+      isBetaUser: false,
       credits: 12,
       creditsResetDate: new Date(),
       sentimentCredits: 30,
@@ -139,5 +142,29 @@ describe('GET /api/credits', () => {
     expect(json.data.sentiment.remaining).toBe(30);
     expect(json.data.sentiment.total).toBe(35);
     expect(json.data.sentiment.used).toBe(5);
+  });
+
+  it('returns BETA_PLAN totals (150/750) for beta users, regardless of tier', async () => {
+    // Locks in MVP Phase 1 contract: isBetaUser=true overrides tier-based
+    // allocation (see MVP.md Section 12.3 + getEffectiveAllocation helper).
+    mockPrisma.user.findUnique.mockResolvedValue({
+      id: mockSession.user.id,
+      tier: 'FREE',
+      isBetaUser: true,
+      credits: 150,
+      creditsResetDate: new Date('2026-06-09T00:00:00Z'),
+      sentimentCredits: 750,
+      sentimentResetDate: new Date('2026-06-09T00:00:00Z'),
+    });
+
+    const res = await GET();
+    const json = await res.json();
+
+    expect(json.data.credits.remaining).toBe(150);
+    expect(json.data.credits.total).toBe(150);
+    expect(json.data.credits.used).toBe(0);
+    expect(json.data.sentiment.remaining).toBe(750);
+    expect(json.data.sentiment.total).toBe(750);
+    expect(json.data.sentiment.used).toBe(0);
   });
 });

--- a/tests/unit/api/dashboard/stats.test.ts
+++ b/tests/unit/api/dashboard/stats.test.ts
@@ -87,6 +87,7 @@ describe('GET /api/dashboard/stats', () => {
       id: mockSession.user.id,
       name: 'Test User',
       tier: 'FREE',
+      isBetaUser: false,
       credits: 12,
       creditsResetDate: resetDate,
       sentimentCredits: 30,
@@ -108,11 +109,64 @@ describe('GET /api/dashboard/stats', () => {
     expect(json.data.tier).toBe('FREE');
   });
 
+  it('returns BETA_PLAN totals (150/750) for beta users, regardless of tier', async () => {
+    // Beta users are on the BETA_PLAN allocation regardless of tier (their
+    // tier stays "FREE" but isBetaUser=true overrides — see MVP.md Section 12.3).
+    mockPrisma.user.findUnique.mockResolvedValue({
+      id: mockSession.user.id,
+      name: 'Beta User',
+      tier: 'FREE',
+      isBetaUser: true,
+      credits: 150,
+      creditsResetDate: new Date('2026-06-09T00:00:00Z'),
+      sentimentCredits: 750,
+      sentimentResetDate: new Date('2026-06-09T00:00:00Z'),
+      reviews: [],
+      _count: { reviews: 0 },
+    });
+    mockPrisma.reviewResponse.count.mockResolvedValue(0);
+    mockPrisma.review.groupBy.mockResolvedValue([]);
+
+    const res = await GET();
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data.credits.remaining).toBe(150);
+    expect(json.data.credits.total).toBe(150);    // BETA_PLAN, not TIER_LIMITS.FREE
+    expect(json.data.credits.used).toBe(0);
+    expect(json.data.sentiment.remaining).toBe(750);
+    expect(json.data.sentiment.total).toBe(750);  // BETA_PLAN, not TIER_LIMITS.FREE
+    expect(json.data.sentiment.used).toBe(0);
+  });
+
+  it('clamps credits.used and sentiment.used to 0 (never negative for beta users with full allocation)', async () => {
+    mockPrisma.user.findUnique.mockResolvedValue({
+      id: mockSession.user.id,
+      name: 'Fresh Beta User',
+      tier: 'FREE',
+      isBetaUser: true,
+      credits: 150,
+      creditsResetDate: new Date(),
+      sentimentCredits: 750,
+      sentimentResetDate: new Date(),
+      reviews: [],
+      _count: { reviews: 0 },
+    });
+    mockPrisma.reviewResponse.count.mockResolvedValue(0);
+    mockPrisma.review.groupBy.mockResolvedValue([]);
+
+    const res = await GET();
+    const json = await res.json();
+    expect(json.data.credits.used).toBeGreaterThanOrEqual(0);
+    expect(json.data.sentiment.used).toBeGreaterThanOrEqual(0);
+  });
+
   it('returns sentiment distribution percentages', async () => {
     mockPrisma.user.findUnique.mockResolvedValue({
       id: mockSession.user.id,
       name: 'Test User',
       tier: 'FREE',
+      isBetaUser: false,
       credits: 15,
       creditsResetDate: new Date(),
       sentimentCredits: 35,
@@ -166,6 +220,7 @@ describe('GET /api/dashboard/stats', () => {
       id: mockSession.user.id,
       name: 'Test User',
       tier: 'FREE',
+      isBetaUser: false,
       credits: 15,
       creditsResetDate: new Date(),
       sentimentCredits: 35,

--- a/tests/unit/api/sentiment/sentiment-usage.test.ts
+++ b/tests/unit/api/sentiment/sentiment-usage.test.ts
@@ -92,6 +92,7 @@ describe("GET /api/sentiment/usage", () => {
     ]);
     mockPrisma.user.findUnique.mockResolvedValue({
       tier: "FREE",
+      isBetaUser: false,
       sentimentCredits: 30,
       sentimentResetDate: new Date("2026-03-01"),
     });
@@ -119,6 +120,7 @@ describe("GET /api/sentiment/usage", () => {
     ]);
     mockPrisma.user.findUnique.mockResolvedValue({
       tier: "FREE",
+      isBetaUser: false,
       sentimentCredits: 25,
       sentimentResetDate: new Date("2026-03-01"),
     });
@@ -139,6 +141,7 @@ describe("GET /api/sentiment/usage", () => {
     mockPrisma.review.groupBy.mockResolvedValue([]);
     mockPrisma.user.findUnique.mockResolvedValue({
       tier: "FREE",
+      isBetaUser: false,
       sentimentCredits: 35,
       sentimentResetDate: new Date("2026-03-01"),
     });
@@ -164,6 +167,7 @@ describe("GET /api/sentiment/usage", () => {
     mockPrisma.review.groupBy.mockResolvedValue([]);
     mockPrisma.user.findUnique.mockResolvedValue({
       tier: "FREE",
+      isBetaUser: false,
       sentimentCredits: 35,
       sentimentResetDate: new Date("2026-03-01"),
     });
@@ -194,6 +198,7 @@ describe("GET /api/sentiment/usage", () => {
     mockPrisma.review.groupBy.mockResolvedValue([]);
     mockPrisma.user.findUnique.mockResolvedValue({
       tier: "FREE",
+      isBetaUser: false,
       sentimentCredits: 30,
       sentimentResetDate: new Date("2026-03-01"),
     });
@@ -229,6 +234,7 @@ describe("GET /api/sentiment/usage", () => {
     mockPrisma.review.groupBy.mockResolvedValue([]);
     mockPrisma.user.findUnique.mockResolvedValue({
       tier: "FREE",
+      isBetaUser: false,
       sentimentCredits: 35,
       sentimentResetDate: new Date("2026-03-01"),
     });
@@ -250,6 +256,7 @@ describe("GET /api/sentiment/usage", () => {
     mockPrisma.review.groupBy.mockResolvedValue([]);
     mockPrisma.user.findUnique.mockResolvedValue({
       tier: "FREE",
+      isBetaUser: false,
       sentimentCredits: 35,
       sentimentResetDate: new Date("2026-03-01"),
     });


### PR DESCRIPTION
## Summary

A beta user with `credits=150, sentimentCredits=750` in the database was seeing the dashboard render `Response Credits 15 / 15` and `Sentiment Analysis 750 / 35`. The DB was correct; the read-path APIs hardcoded the FREE-tier ceiling instead of going through the `getEffectiveAllocation(user)` helper that already exists from iteration 1.

## Root cause

Three GET endpoints computed `total` from `TIER_LIMITS[user.tier]` instead of `getEffectiveAllocation({ tier, isBetaUser })`. Beta users have `tier='FREE'` with `isBetaUser=true` — so the FREE-tier ceiling (15/35) was being returned as their cap.

| File | Line | Bug |
|---|---|---|
| `src/app/api/dashboard/stats/route.ts` | 126 | `tierLimits = TIER_LIMITS[user.tier]` |
| `src/app/api/credits/route.ts` | 48 | same |
| `src/app/api/sentiment/usage/route.ts` | 197 | same |

The signup transaction and anniversary cron both used `getEffectiveAllocation` correctly, so write paths were fine. The bug was purely in the display layer.

## Why the two cards rendered different numerators

Both endpoints compute `used = total - remaining`. The credits endpoint clamps `used` to 0 (`-135 → 0`), the sentiment endpoint didn't (`-715` passed through). `QuotaCard` then **ignores** the API's `remaining` field and recomputes `remaining = total - used`:

- Credits: `15 - 0 = 15` → renders `15 / 15`
- Sentiment: `35 - (-715) = 750` → renders `750 / 35`

Fixing at the source (`getEffectiveAllocation`) makes both cards correct without touching `QuotaCard`. I also added `Math.max(0, ...)` to the sentiment endpoint for defensive parity.

## How DB was verified correct

```sql
SELECT email, "isBetaUser", tier, credits, "sentimentCredits"
FROM users WHERE name = 'SmokingTest';
-- Returns: prajeen_v@yahoo.com, true, FREE, 150, 750
```

## Files

- 3 route files: switch to `getEffectiveAllocation`, add `isBetaUser: true` to Prisma `select`, clamp `used` to 0
- 3 test files: add `isBetaUser: false` to 13 existing fixtures (so they accurately reflect the schema), add 3 new test cases asserting beta users get 150/750 totals

## Audit

```
$ rg 'TIER_LIMITS\[' src/
src/lib/constants.ts:141:  const limits = TIER_LIMITS[user.tier];
```

Only the one inside `getEffectiveAllocation` itself remains. Confirmed clean.

## Why this wasn't caught in CI

The existing dashboard/stats and credits tests didn't include `isBetaUser` in their fixtures (the field didn't exist when those tests were written, and iteration 1 didn't update them — only the routes that already used `getEffectiveAllocation`, like `db-utils.resetMonthlyCredits`, were tested for the beta path). The bug only surfaced in manual smoke testing on staging with a real beta user.

## Test plan

### Pre-merge (verified locally)

- `npm run lint:strict` clean
- `npm run type-check` clean
- `npm run test:unit` 607 passed (up from 604), 17 skipped (integration), 0 failed

### Post-merge smoke test on staging

After this merges and the staging deploy completes:

- [ ] Sign in to staging as a beta user (the existing `SmokingTest` account works — `prajeen_v@yahoo.com`)
- [ ] Refresh `/dashboard` — should now display:
  - **Response Credits: `150 / 150`**
  - **Sentiment Analysis: `750 / 750`**
- [ ] Sign in as a regular Free user (no `isBetaUser`) — should still display:
  - **Response Credits: `15 / 15`**
  - **Sentiment Analysis: `35 / 35`**
- [ ] Generate one AI response as the beta user, refresh dashboard:
  - **Response Credits: `149 / 150`** (used: 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)