### PR TITLE
fix(ui): use prajeen@brandsiq.app for public-facing founder contact

### DIFF
--- a/src/app/(auth)/auth/beta-link-expired/page.tsx
+++ b/src/app/(auth)/auth/beta-link-expired/page.tsx
@@ -10,6 +10,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { FOUNDER_PUBLIC_EMAIL } from "@/lib/constants";
 
 export const metadata: Metadata = {
   title: "Beta invite expired - BrandsIQ",
@@ -47,10 +48,10 @@ export default function BetaLinkExpiredPage() {
         <div className="rounded-md bg-muted/30 p-4 text-sm text-muted-foreground">
           If you received this link recently and expected beta access, email{" "}
           <a
-            href="mailto:prajeen.builder@gmail.com?subject=BrandsIQ%20beta%20invite%20-%20expired%20link"
+            href={`mailto:${FOUNDER_PUBLIC_EMAIL}?subject=BrandsIQ%20beta%20invite%20-%20expired%20link`}
             className="text-primary underline hover:no-underline"
           >
-            prajeen.builder@gmail.com
+            {FOUNDER_PUBLIC_EMAIL}
           </a>{" "}
           and we&apos;ll send a fresh invite within 24 hours.
           <p className="mt-3 text-xs">

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -241,3 +241,16 @@ export const EMAIL_CONFIG = {
 // Support contact
 export const SUPPORT_EMAIL = "support@brandsiq.app";
 export const SUPPORT_MAILTO = `mailto:${SUPPORT_EMAIL}`;
+
+// MVP Phase 1: Founder's public-facing email address.
+//
+// This is the address SHOWN to beta prospects (e.g. on the expired-invite-link
+// recovery page) and used as the destination for founder-inquiry notifications
+// in iteration 2.
+//
+// Distinct from FOUNDER_EMAILS (env var): that is the founder's *identity* —
+// the email they log in with to access /dashboard/admin/*. FOUNDER_PUBLIC_EMAIL
+// is the address other people write TO when they want to reach the founder.
+// In practice these can be different addresses (e.g. login via Gmail, public
+// inbox on the brandsiq.app domain).
+export const FOUNDER_PUBLIC_EMAIL = "prajeen@brandsiq.app";


### PR DESCRIPTION
## Summary

The beta-link-expired recovery page exposed `prajeen.builder@gmail.com` — that's the founder's **login identity** (tied to `FOUNDER_EMAILS` for admin gating), not a public-facing address. Replace with `prajeen@brandsiq.app` via a new constant.

## Why two different addresses

These are distinct concerns that look related but serve different purposes:

| Constant / var | Purpose | Where seen |
|---|---|---|
| `FOUNDER_EMAILS` (env var) | Founder's **identity** for admin gating — the email used to log in to BrandsIQ as founder | Server-side only; never rendered to other users |
| `FOUNDER_PUBLIC_EMAIL` (new constant) | Address **other people write TO** to reach the founder | Public surfaces (expired-link page, future founder-inquiry destinations) |

For BrandsIQ these are intentionally different addresses: Gmail for login (Google OAuth account already exists), brandsiq.app for public contact (Resend-verified domain, branded, routes to the founder's real inbox).

## Why a constant rather than inline

Iteration 2 will wire the same address into:
- Founder-inquiry notification destinations (`POST /api/founder-inquiries`)
- Embedded `FounderInquiryForm` success messaging
- Any other "contact us" surfaces

Centralizing now avoids a find-and-replace later.

## Files

- `src/lib/constants.ts` — new `FOUNDER_PUBLIC_EMAIL = "prajeen@brandsiq.app"` constant with explanatory comment about the FOUNDER_EMAILS distinction
- `src/app/(auth)/auth/beta-link-expired/page.tsx` — import the constant; replace both the `mailto` href and the rendered link text

## Test plan

### Pre-merge (verified locally)

- `npm run lint:strict` clean
- `npm run type-check` clean
- `npm run test:unit` 607 passed, 17 skipped (integration), 0 failed (no test changes needed — constants don't have direct test coverage; the rendered output of the expired-link page wasn't asserted by the existing E2E test either, which only verifies the page renders and contains a mailto link — and it still does)

### Post-merge smoke test on staging

After this merges and the staging deploy completes:

- [ ] Sign out + sign back in on staging (or open `/auth/beta-link-expired` directly while signed out)
- [ ] Visit `/auth/beta-link-expired` (or trigger via the reused-invite flow)
- [ ] Confirm the displayed email reads `prajeen@brandsiq.app` (not `prajeen.builder@gmail.com`)
- [ ] Click the email link — `mailto:prajeen@brandsiq.app?subject=BrandsIQ%20beta%20invite%20-%20expired%20link` opens in the default mail client
- [ ] Send a test email; confirm it lands in the founder's actual inbox (per the user's confirmation that the address receives email)

🤖 Generated with [Claude Code](https://claude.com/claude-code)