### PR TITLE
fix(email): welcome email renders beta plan content for isBetaUser=true

### DIFF
--- a/src/app/api/auth/verify-email/route.ts
+++ b/src/app/api/auth/verify-email/route.ts
@@ -74,8 +74,9 @@ export async function GET(request: Request) {
       data: { emailVerified: new Date() },
     });
 
-    // Send welcome email (non-blocking)
-    sendWelcomeEmail(result.email, user.name || undefined).catch((err) => {
+    // Send welcome email (non-blocking). Pass isBetaUser so the template
+    // renders beta-plan content (150/750) instead of Free-plan (15/35).
+    sendWelcomeEmail(result.email, user.name || undefined, user.isBetaUser).catch((err) => {
       console.error("Failed to send welcome email:", err);
     });
 

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,5 +1,5 @@
 import { Resend } from "resend";
-import { EMAIL_CONFIG } from "./constants";
+import { EMAIL_CONFIG, BETA_PLAN, TIER_LIMITS } from "./constants";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
@@ -107,14 +107,54 @@ export async function sendPasswordResetEmail(email: string, token: string) {
   }
 }
 
-export async function sendWelcomeEmail(email: string, name?: string) {
+/**
+ * Plan-specific copy block rendered inside the welcome email.
+ * Numbers and framing come from BETA_PLAN / TIER_LIMITS.FREE so a future
+ * change to the allocation propagates here automatically.
+ */
+function buildWelcomePlanSection(isBetaUser: boolean): { headerLine: string; planTitle: string; planItems: string[]; closing: string } {
+  if (isBetaUser) {
+    return {
+      headerLine: "You're on the BrandsIQ closed beta — your account is verified and ready.",
+      planTitle: "Your beta plan includes:",
+      planItems: [
+        `${BETA_PLAN.credits} AI-generated responses per month`,
+        `${BETA_PLAN.sentimentQuota} sentiment analyses per month`,
+        "Support for 40+ languages",
+        "Brand voice customization",
+      ],
+      closing:
+        "As a beta user, your feedback shapes the product. We may reach out personally to hear how it's going.",
+    };
+  }
+  return {
+    headerLine: "Your account has been verified and you're all set to start managing your review responses with AI.",
+    planTitle: "Your Free Plan includes:",
+    planItems: [
+      `${TIER_LIMITS.FREE.credits} AI-generated responses per month`,
+      `${TIER_LIMITS.FREE.sentimentQuota} sentiment analyses per month`,
+      "Support for 40+ languages",
+      "Brand voice customization",
+    ],
+    closing: "Need help? Reply to this email or visit our documentation.",
+  };
+}
+
+export async function sendWelcomeEmail(email: string, name?: string, isBetaUser: boolean = false) {
   const dashboardUrl = `${process.env.NEXTAUTH_URL}/dashboard`;
+  const section = buildWelcomePlanSection(isBetaUser);
+  const subject = isBetaUser
+    ? "Welcome to the BrandsIQ closed beta!"
+    : "Welcome to BrandsIQ! Let's get started";
+  const heading = isBetaUser
+    ? `Welcome to the BrandsIQ closed beta${name ? `, ${name}` : ""}!`
+    : `Welcome to BrandsIQ${name ? `, ${name}` : ""}!`;
 
   try {
     const { data, error } = await resend.emails.send({
       from: FROM_EMAIL,
       to: email,
-      subject: "Welcome to BrandsIQ! Let's get started",
+      subject,
       html: `
         <!DOCTYPE html>
         <html>
@@ -125,17 +165,14 @@ export async function sendWelcomeEmail(email: string, name?: string) {
           </head>
           <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
             <div style="background: linear-gradient(135deg, #6366f1 0%, #4f46e5 100%); padding: 30px; border-radius: 12px 12px 0 0;">
-              <h1 style="color: white; margin: 0; font-size: 24px;">Welcome to BrandsIQ${name ? `, ${name}` : ""}!</h1>
+              <h1 style="color: white; margin: 0; font-size: 24px;">${heading}</h1>
             </div>
             <div style="background: #ffffff; padding: 30px; border: 1px solid #e5e7eb; border-top: none; border-radius: 0 0 12px 12px;">
-              <p style="margin-top: 0;">Your account has been verified and you're all set to start managing your review responses with AI.</p>
+              <p style="margin-top: 0;">${section.headerLine}</p>
 
-              <h3 style="color: #4f46e5; margin-top: 25px;">Your Free Plan includes:</h3>
+              <h3 style="color: #4f46e5; margin-top: 25px;">${section.planTitle}</h3>
               <ul style="padding-left: 20px;">
-                <li>15 AI-generated responses per month</li>
-                <li>35 sentiment analyses per month</li>
-                <li>Support for 40+ languages</li>
-                <li>Brand voice customization</li>
+                ${section.planItems.map((item) => `<li>${item}</li>`).join("\n                ")}
               </ul>
 
               <div style="text-align: center; margin: 30px 0;">
@@ -146,7 +183,7 @@ export async function sendWelcomeEmail(email: string, name?: string) {
 
               <hr style="border: none; border-top: 1px solid #e5e7eb; margin: 30px 0;">
               <p style="color: #999; font-size: 12px; margin-bottom: 0;">
-                Need help? Reply to this email or visit our documentation.
+                ${section.closing}
               </p>
             </div>
           </body>

--- a/tests/unit/api/auth/verify-email.test.ts
+++ b/tests/unit/api/auth/verify-email.test.ts
@@ -90,9 +90,18 @@ const mockUser = {
   emailVerified: null,
   name: 'Test User',
   tier: 'FREE',
+  isBetaUser: false,
   credits: 15,
   createdAt: new Date(),
   updatedAt: new Date(),
+};
+
+const mockBetaUser = {
+  ...mockUser,
+  id: 'user-beta-456',
+  email: 'beta@example.com',
+  isBetaUser: true,
+  credits: 150,
 };
 
 describe('GET /api/auth/verify-email', () => {
@@ -184,7 +193,7 @@ describe('GET /api/auth/verify-email', () => {
     );
   });
 
-  it('sends welcome email (non-blocking)', async () => {
+  it('sends welcome email (non-blocking) with isBetaUser flag for Free users', async () => {
     const req = createRequest('/api/auth/verify-email', {
       searchParams: { token: 'valid-token' },
     });
@@ -192,7 +201,30 @@ describe('GET /api/auth/verify-email', () => {
 
     expect(mockEmail.sendWelcomeEmail).toHaveBeenCalledWith(
       'test@example.com',
-      'Test User'
+      'Test User',
+      false
+    );
+  });
+
+  it('sends welcome email with isBetaUser=true for beta users', async () => {
+    // Verify-email looks up the user by the token's email and uses that
+    // record's isBetaUser. Mock the token's verified email + user fetch
+    // to a beta account.
+    mockTokens.verifyEmailToken.mockResolvedValue({
+      success: true,
+      email: 'beta@example.com',
+    });
+    mockPrisma.user.findUnique.mockResolvedValue(mockBetaUser);
+
+    const req = createRequest('/api/auth/verify-email', {
+      searchParams: { token: 'valid-token' },
+    });
+    await GET(req);
+
+    expect(mockEmail.sendWelcomeEmail).toHaveBeenCalledWith(
+      'beta@example.com',
+      'Test User',
+      true
     );
   });
 

--- a/tests/unit/lib/email.test.ts
+++ b/tests/unit/lib/email.test.ts
@@ -141,5 +141,42 @@ describe('email.ts', () => {
         expect.objectContaining({ success: false }),
       );
     });
+
+    it('should render Free Plan content by default (isBetaUser omitted)', async () => {
+      await sendWelcomeEmail('user@example.com', 'Alice');
+
+      const callArgs = mockSend.mock.calls[0][0];
+      expect(callArgs.html).toContain('Free Plan');
+      expect(callArgs.html).toContain('15 AI-generated responses');
+      expect(callArgs.html).toContain('35 sentiment analyses');
+      // Make sure beta-specific copy is NOT present in the Free email
+      expect(callArgs.html).not.toContain('closed beta');
+      expect(callArgs.html).not.toContain('150 AI-generated');
+    });
+
+    it('should render beta plan content when isBetaUser=true', async () => {
+      // Locks in MVP Phase 1 contract (MVP.md Section 12.3): beta users get
+      // 150/750 framing and copy, not Free-plan 15/35 framing.
+      await sendWelcomeEmail('user@example.com', 'Alice', true);
+
+      const callArgs = mockSend.mock.calls[0][0];
+      expect(callArgs.subject).toContain('closed beta');
+      expect(callArgs.html).toContain('closed beta');
+      expect(callArgs.html).toContain('beta plan');
+      expect(callArgs.html).toContain('150 AI-generated responses');
+      expect(callArgs.html).toContain('750 sentiment analyses');
+      // Make sure Free-tier numbers leak through
+      expect(callArgs.html).not.toContain('Free Plan');
+      expect(callArgs.html).not.toContain('15 AI-generated');
+      expect(callArgs.html).not.toContain('35 sentiment');
+    });
+
+    it('isBetaUser=false explicitly should behave the same as default', async () => {
+      await sendWelcomeEmail('user@example.com', 'Alice', false);
+
+      const callArgs = mockSend.mock.calls[0][0];
+      expect(callArgs.html).toContain('Free Plan');
+      expect(callArgs.html).not.toContain('closed beta');
+    });
   });
 });


### PR DESCRIPTION
## Summary

A beta user who verified their email received a "Welcome to Free Plan" message listing 15 responses + 35 sentiment analyses — the FREE-tier numbers — even though their account was provisioned with the beta plan (150/750).

Same class of read-path bug as the dashboard display bug fixed in PR #74. The welcome email template was missed in iteration 1's audit.

## Cause

- `src/lib/email.ts:sendWelcomeEmail` hardcoded "Your Free Plan includes: 15 responses / 35 analyses" in its HTML body
- `verify-email/route.ts` didn't pass plan info to the email function

## Fix

**API:**

```ts
sendWelcomeEmail(email, name, isBetaUser)
                              └────────────── new parameter, default false
```

**Behavior:**

| `isBetaUser` | Subject | Plan heading | Numbers |
|---|---|---|---|
| `false` (default) | "Welcome to BrandsIQ! Let's get started" | "Your Free Plan includes:" | `15` / `35` |
| `true` | "Welcome to the BrandsIQ closed beta!" | "Your beta plan includes:" | `150` / `750` |

Numbers come from `BETA_PLAN` / `TIER_LIMITS.FREE` constants — so a future allocation change propagates automatically.

The beta variant changes more than just the numbers: subject, heading, intro paragraph, and closing line are all reframed to match the "you're on a special program" tone rather than "welcome to free tier." Beta closing teases the engagement playbook: "As a beta user, your feedback shapes the product. We may reach out personally to hear how it's going."

## Files

- `src/lib/email.ts` — new `buildWelcomePlanSection(isBetaUser)` helper; `sendWelcomeEmail` accepts third arg
- `src/app/api/auth/verify-email/route.ts` — reads `user.isBetaUser` (already loaded) and passes to the email call
- `tests/unit/lib/email.test.ts` — 3 new test cases (Free default, Beta variant, explicit false)
- `tests/unit/api/auth/verify-email.test.ts` — extends "sends welcome email" assertion to expect the third arg; adds a beta-user variant; fixtures gain `isBetaUser: false`

## Context note (for future audit)

This is the **second** bug in the same shape — PR #74 was the dashboard read-path equivalent. Pattern across iteration 1:

- **Write paths** (signup transaction, anniversary cron) correctly used `getEffectiveAllocation`
- **Read paths** hardcoded `TIER_LIMITS[user.tier]`

Each read path was caught one at a time during smoke testing rather than in a single pass. Worth a more systematic audit at the end of iteration 2 — probably an ESLint rule banning bare `TIER_LIMITS[` outside the `getEffectiveAllocation` helper.

## Test plan

### Pre-merge (verified locally)

- `npm run lint:strict` clean
- `npm run type-check` clean
- `npm run test:unit` 611 passed (was 607, +4), 17 skipped (integration), 0 failed

### Post-merge smoke test on staging

After this merges and the staging deploy completes:

- [ ] Generate a new beta invite via `/dashboard/admin/beta-invites`
- [ ] Sign up via the invite in incognito with a fresh email
- [ ] Click the verification link in the email
- [ ] **Check the welcome email** that arrives shortly after:
  - Subject reads "Welcome to the BrandsIQ closed beta!" (not "Welcome to BrandsIQ! Let's get started")
  - Body mentions "closed beta" and "beta plan"
  - Plan list shows **150 AI-generated responses** and **750 sentiment analyses** (not 15/35)
  - Closing line is "As a beta user, your feedback shapes the product..."
- [ ] Sign up at `/auth/signup` directly (no `?b=`) with another fresh email → verify → check welcome email:
  - Subject reads "Welcome to BrandsIQ! Let's get started"
  - Body lists "Free Plan" with 15 / 35
  - Closing line is "Need help? Reply to this email or visit our documentation."

🤖 Generated with [Claude Code](https://claude.com/claude-code)