### PR TITLE
revert: PR #79 (waitUntil for welcome email) — broke staging E2E

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,6 @@
         "@sentry/nextjs": "^10.48.0",
         "@upstash/ratelimit": "^2.0.7",
         "@upstash/redis": "^1.36.1",
-        "@vercel/functions": "^3.5.1",
         "axios": "^1.13.2",
         "bcryptjs": "^3.0.3",
         "class-variance-authority": "^0.7.1",
@@ -6950,35 +6949,6 @@
       "peer": true,
       "dependencies": {
         "uncrypto": "^0.1.3"
-      }
-    },
-    "node_modules/@vercel/functions": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@vercel/functions/-/functions-3.5.1.tgz",
-      "integrity": "sha512-ndh5v+uhWqGA8033oD0i0KHvqUHcLlLCOaLOw5L+xx5zVsWUSQcZPKEYk2nm51aisnKhcnTylxnOmhx+w4UCRA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@vercel/oidc": "3.4.1"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "@aws-sdk/credential-provider-web-identity": "*"
-      },
-      "peerDependenciesMeta": {
-        "@aws-sdk/credential-provider-web-identity": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vercel/oidc": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.4.1.tgz",
-      "integrity": "sha512-H6B+/ig/GoahccL3WZjiHayHw1H5KhvTJNceqYulwfK9kkz5iul2hTmYzcJ7tTCQzyd0dutuL9xYFZCyLUqsog==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 20"
       }
     },
     "node_modules/@vitejs/plugin-react": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "@sentry/nextjs": "^10.48.0",
     "@upstash/ratelimit": "^2.0.7",
     "@upstash/redis": "^1.36.1",
-    "@vercel/functions": "^3.5.1",
     "axios": "^1.13.2",
     "bcryptjs": "^3.0.3",
     "class-variance-authority": "^0.7.1",

--- a/src/app/api/auth/verify-email/route.ts
+++ b/src/app/api/auth/verify-email/route.ts
@@ -1,5 +1,4 @@
 import { NextResponse } from "next/server";
-import { waitUntil } from "@vercel/functions";
 import { prisma } from "@/lib/prisma";
 import { verifyEmailToken } from "@/lib/tokens";
 import { sendWelcomeEmail } from "@/lib/email";
@@ -75,23 +74,11 @@ export async function GET(request: Request) {
       data: { emailVerified: new Date() },
     });
 
-    // Send welcome email (non-blocking from the user's perspective).
-    //
-    // waitUntil tells Vercel to keep the serverless function alive until the
-    // returned promise settles, even after we've sent the HTTP response back
-    // to the client. Without this, Vercel can freeze the Lambda the moment
-    // NextResponse is returned, aborting the Resend SDK's in-flight fetch()
-    // mid-request — which manifests as `application_error / statusCode: null
-    // / "Unable to fetch data"` and no Resend dashboard log row, because
-    // the request died at the socket layer before reaching Resend's server.
-    //
-    // Pass isBetaUser so the template renders beta-plan content (150/750)
-    // instead of Free-plan (15/35).
-    waitUntil(
-      sendWelcomeEmail(result.email, user.name || undefined, user.isBetaUser).catch((err) => {
-        console.error("Failed to send welcome email:", err);
-      }),
-    );
+    // Send welcome email (non-blocking). Pass isBetaUser so the template
+    // renders beta-plan content (150/750) instead of Free-plan (15/35).
+    sendWelcomeEmail(result.email, user.name || undefined, user.isBetaUser).catch((err) => {
+      console.error("Failed to send welcome email:", err);
+    });
 
     return NextResponse.json(
       {

--- a/tests/unit/api/auth/verify-email.test.ts
+++ b/tests/unit/api/auth/verify-email.test.ts
@@ -54,12 +54,6 @@ vi.mock('@/lib/prisma', () => ({ prisma: mockPrisma }));
 vi.mock('@/lib/email', () => mockEmail);
 vi.mock('@/lib/tokens', () => mockTokens);
 vi.mock('@/lib/rate-limit', () => mockRateLimit);
-// waitUntil keeps the Lambda alive in production. For tests we just want the
-// wrapped promise to execute synchronously so existing assertions on
-// sendWelcomeEmail (called with the right args) still hold.
-vi.mock('@vercel/functions', () => ({
-  waitUntil: (promise: Promise<unknown>) => promise,
-}));
 vi.mock('bcryptjs', () => ({
   default: {
     hash: vi.fn().mockResolvedValue('$2a$12$hashed'),


### PR DESCRIPTION
## Summary

Reverts PR #79 (`fix(api): keep Lambda alive for welcome email via waitUntil`) — the fix was correct in principle but caused two consecutive failures of `tests/e2e/core-flow.spec.ts` in the post-merge staging E2E suite. We're reverting to unblock the production deploy of iteration 1; the underlying race condition (welcome emails losing the freeze-vs-fetch race on Vercel Lambda) will be addressed properly later.

## What PR #79 was trying to fix

A pre-existing race condition in `src/app/api/auth/verify-email/route.ts`. The route fires `sendWelcomeEmail(...)` without awaiting and immediately returns a response. Vercel's serverless runtime can freeze the Lambda the moment the response is sent, aborting Resend's in-flight `fetch()` — which surfaces as `application_error / statusCode: null / "Unable to fetch data"` with no row in the Resend dashboard.

PR #78 (welcome email beta variant) added a few microseconds of pre-fetch work to the path, which was enough to lose the race deterministically. The race itself has been there since iteration 1.

## Why PR #79's fix didn't stick

The fix wrapped the call in `waitUntil()` from `@vercel/functions`. It passed:
- ✅ `npm run lint:strict`
- ✅ `npm run type-check`
- ✅ `npm run test:unit` (611/611)
- ✅ All PR Quality Gate jobs on PR #79 itself

But after merging, the **post-merge staging E2E** (`e2e-staging.yml`) failed twice consecutively at:

```
tests/e2e/core-flow.spec.ts:71
  expect(getByText('Generated', { exact: true })).toBeVisible({ timeout: 30000 })
```

That test exercises an unrelated code path (login → add review → generate AI response). It does not touch verify-email, `waitUntil`, or `@vercel/functions`. The 9 prior staging E2E runs on `main` were all green.

We didn't fully diagnose why an unrelated test started failing. Possible causes (none confirmed):
- `E2E_MOCK_AI` env var dropped from Vercel Preview scope
- Test user credit exhaustion on staging
- Some side-effect of `@vercel/functions` runtime behavior on Vercel Preview

Pragmatic decision: revert now, finish iteration 1 prod rollout, investigate properly in iteration 2 or as a standalone follow-up.

## Net effects of this revert

- `@vercel/functions` removed from `package.json` and `package-lock.json`
- `src/app/api/auth/verify-email/route.ts` returns to the pre-PR-79 fire-and-forget call: `sendWelcomeEmail(...).catch(err => console.error(...))`
- `tests/unit/api/auth/verify-email.test.ts` removes the `@vercel/functions` mock
- 4 files changed, -55 / +5 (exact inverse of PR #79's +55/-5)

## Impact on users

| Surface | Effect |
|---|---|
| Welcome email on **production** | ✅ Unaffected — prod doesn't have PR #77, #78, or #79 deployed yet anyway |
| Welcome email on **staging** | ⚠️ Likely won't arrive due to the pre-existing race condition (made deterministic by PR #78). No wrong content is sent; the email just silently fails. |
| All other features | ✅ Unaffected — verification email, signup, login, dashboard, admin all intact |

## Test plan

### Pre-merge (verified locally)

- `npm run lint:strict` clean
- `npm run type-check` clean
- `npm run test:unit` 611/611 passing (same baseline as `main` before PR #79)

### Post-merge

After this revert merges and staging redeploys:
- [ ] **Critical**: the staging E2E (`e2e-staging.yml`) should run and **pass** — this confirms PR #79 was the cause of the E2E failure and unblocks future production deploys
- [ ] If E2E still fails on the same test, the cause is unrelated to PR #79 (likely env-var or test-user credit issue on staging) — needs separate investigation but doesn't block production deploy
- [ ] Welcome email send on staging will likely silently fail (expected — back to pre-PR-79 latent state)

## Followups

- The proper `waitUntil` fix should return — either in iteration 2 or as a standalone PR — with a separate investigation into why it broke the core-flow E2E. Candidate hypotheses to validate first: `E2E_MOCK_AI` env-var presence on Preview, staging test-user credit balance, whether `waitUntil` interacts with Vercel's deployment protection bypass in some way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)