### PR TITLE
fix(api): re-apply waitUntil for welcome email (post PR #82 revert)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@sentry/nextjs": "^10.48.0",
         "@upstash/ratelimit": "^2.0.7",
         "@upstash/redis": "^1.36.1",
+        "@vercel/functions": "^3.5.1",
         "axios": "^1.13.2",
         "bcryptjs": "^3.0.3",
         "class-variance-authority": "^0.7.1",
@@ -6949,6 +6950,35 @@
       "peer": true,
       "dependencies": {
         "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/@vercel/functions": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@vercel/functions/-/functions-3.5.1.tgz",
+      "integrity": "sha512-ndh5v+uhWqGA8033oD0i0KHvqUHcLlLCOaLOw5L+xx5zVsWUSQcZPKEYk2nm51aisnKhcnTylxnOmhx+w4UCRA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/oidc": "3.4.1"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-web-identity": "*"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-web-identity": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.4.1.tgz",
+      "integrity": "sha512-H6B+/ig/GoahccL3WZjiHayHw1H5KhvTJNceqYulwfK9kkz5iul2hTmYzcJ7tTCQzyd0dutuL9xYFZCyLUqsog==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/@vitejs/plugin-react": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@sentry/nextjs": "^10.48.0",
     "@upstash/ratelimit": "^2.0.7",
     "@upstash/redis": "^1.36.1",
+    "@vercel/functions": "^3.5.1",
     "axios": "^1.13.2",
     "bcryptjs": "^3.0.3",
     "class-variance-authority": "^0.7.1",

--- a/src/app/api/auth/verify-email/route.ts
+++ b/src/app/api/auth/verify-email/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { waitUntil } from "@vercel/functions";
 import { prisma } from "@/lib/prisma";
 import { verifyEmailToken } from "@/lib/tokens";
 import { sendWelcomeEmail } from "@/lib/email";
@@ -74,11 +75,23 @@ export async function GET(request: Request) {
       data: { emailVerified: new Date() },
     });
 
-    // Send welcome email (non-blocking). Pass isBetaUser so the template
-    // renders beta-plan content (150/750) instead of Free-plan (15/35).
-    sendWelcomeEmail(result.email, user.name || undefined, user.isBetaUser).catch((err) => {
-      console.error("Failed to send welcome email:", err);
-    });
+    // Send welcome email (non-blocking from the user's perspective).
+    //
+    // waitUntil tells Vercel to keep the serverless function alive until the
+    // returned promise settles, even after we've sent the HTTP response back
+    // to the client. Without this, Vercel can freeze the Lambda the moment
+    // NextResponse is returned, aborting the Resend SDK's in-flight fetch()
+    // mid-request — which manifests as `application_error / statusCode: null
+    // / "Unable to fetch data"` and no Resend dashboard log row, because
+    // the request died at the socket layer before reaching Resend's server.
+    //
+    // Pass isBetaUser so the template renders beta-plan content (150/750)
+    // instead of Free-plan (15/35).
+    waitUntil(
+      sendWelcomeEmail(result.email, user.name || undefined, user.isBetaUser).catch((err) => {
+        console.error("Failed to send welcome email:", err);
+      }),
+    );
 
     return NextResponse.json(
       {

--- a/tests/unit/api/auth/verify-email.test.ts
+++ b/tests/unit/api/auth/verify-email.test.ts
@@ -54,6 +54,12 @@ vi.mock('@/lib/prisma', () => ({ prisma: mockPrisma }));
 vi.mock('@/lib/email', () => mockEmail);
 vi.mock('@/lib/tokens', () => mockTokens);
 vi.mock('@/lib/rate-limit', () => mockRateLimit);
+// waitUntil keeps the Lambda alive in production. For tests we just want the
+// wrapped promise to execute synchronously so existing assertions on
+// sendWelcomeEmail (called with the right args) still hold.
+vi.mock('@vercel/functions', () => ({
+  waitUntil: (promise: Promise<unknown>) => promise,
+}));
 vi.mock('bcryptjs', () => ({
   default: {
     hash: vi.fn().mockResolvedValue('$2a$12$hashed'),


### PR DESCRIPTION
## Summary

Re-applies PR #79's `waitUntil` welcome-email fix, cleanly cherry-picked from commit `1a15cd8`. PR #79 was reverted in PR #82 because the post-merge staging E2E failed twice — but follow-up investigation showed **the E2E failure was caused by the E2E test user's credits being exhausted on staging**, completely unrelated to this code change.

Diagnostic trail:
1. PR #79 fix was correct and passed all PR Quality Gate checks (lint, type-check, unit, integration)
2. Post-merge staging E2E failed at `core-flow.spec.ts:71` — `expect(getByText('Generated', { exact: true })).toBeVisible()` timed out at 30s
3. That test exercises an unrelated code path (login → add review → generate AI response)
4. Two consecutive E2E failures with identical signatures ruled out transient flakes
5. PR #82 reverted PR #79 — and the staging E2E **still failed identically**, definitively ruling out PR #79 as the cause
6. Diagnosed: E2E test user (`e2e-test@brandsiq.app`) on staging had `credits=0` from cumulative test runs. When the test clicks "Generate Response," the API returns 402 INSUFFICIENT_CREDITS, the frontend shows the Out-of-Credits dialog, the "Generated" badge never renders, Playwright times out.
7. Restored credits via `UPDATE users SET credits = 15, "sentimentCredits" = 35 WHERE email = '...'`. Manually re-triggered staging E2E → **passed** (run #42)

So PR #79's logic was never the problem. This PR brings it back.

## What this fixes (original PR #79 description)

A latent race condition in the fire-and-forget pattern at `verify-email/route.ts`. The route fires `sendWelcomeEmail(...)` without awaiting and immediately returns the HTTP response. On Vercel's serverless runtime, the Lambda can be frozen the moment the response is sent — aborting any in-flight `fetch()` inside the Resend SDK. PR #78 made this race deterministic by adding microseconds of pre-fetch work to the welcome email path.

The fix wraps the call in `waitUntil()` from `@vercel/functions`. Vercel keeps the Lambda alive until the promise settles, even after the HTTP response has gone out. User sees no added latency; welcome email completes in the background.

## Files (identical to PR #79)

- `package.json` + `package-lock.json` — `@vercel/functions ^3.5.1`
- `src/app/api/auth/verify-email/route.ts` — `waitUntil()` wrapper with inline comment documenting the failure mode
- `tests/unit/api/auth/verify-email.test.ts` — mock `@vercel/functions` so `waitUntil(promise)` executes synchronously in test context

## Test plan

### Pre-merge (verified locally)

- `npm run lint:strict` clean
- `npm run type-check` clean
- `npm run test:unit` 611 passed, 17 skipped (integration), 0 failed

### Post-merge

Staging E2E should pass this time (the actual root cause — exhausted test user credits — has been fixed). After that:

- [ ] Smoke test on staging: sign up a fresh Free account, click verification link, **welcome email arrives within seconds** (this time it actually should)
- [ ] Beta variant: sign up via a fresh beta invite, verify, welcome email arrives with beta-plan copy
- [ ] Resend dashboard → Emails → both should show status `Delivered`

## Followup (separate)

Bump the E2E test user's tier to STARTER, GROWTH, or `isBetaUser=true` so its credit allocation survives ~weeks of test runs instead of ~15 merges. Currently the test user is Free tier (15 credits/month) which exhausts quickly. Not urgent — manual credit restoration works as a stopgap. Best fixed in iteration 2 alongside the other E2E hardening tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)