### PR TITLE
fix(pricing): tone down /pricing under phase_1 and fix anon Current Plan badge

### DIFF
--- a/src/app/pricing/pricing-client.tsx
+++ b/src/app/pricing/pricing-client.tsx
@@ -95,7 +95,9 @@ const plans: Plan[] = [
 
 export function PricingClient({ currentPhase }: { currentPhase: SystemPhase }) {
   const { data: session } = useSession();
-  const userTier = (session?.user as { tier?: string })?.tier || "FREE";
+  // null when signed out — prevents the "Current Plan" badge from defaulting
+  // onto the Free card for anonymous visitors.
+  const userTier = (session?.user as { tier?: string })?.tier ?? null;
   const [betaInquiryOpen, setBetaInquiryOpen] = useState(false);
 
   const isPhase1 = currentPhase === "phase_1";
@@ -150,18 +152,25 @@ export function PricingClient({ currentPhase }: { currentPhase: SystemPhase }) {
         {/* Plans grid */}
         <div className="grid gap-6 md:grid-cols-3 mb-12">
           {plans.map((plan) => {
-            const isCurrentPlan = userTier === plan.tier;
+            const isCurrentPlan = !!userTier && userTier === plan.tier;
             const isUpgrade =
-              SUBSCRIPTION_TIERS.indexOf(plan.tier) > SUBSCRIPTION_TIERS.indexOf(userTier as SubscriptionTier);
+              !!userTier &&
+              SUBSCRIPTION_TIERS.indexOf(plan.tier) >
+                SUBSCRIPTION_TIERS.indexOf(userTier as SubscriptionTier);
+            // Under phase_1 we present every tier with equal visual weight —
+            // the closed-beta banner is the sole CTA, and singling out
+            // "Starter" as Most Popular would be misleading when no plan is
+            // actually purchasable.
+            const showPopular = plan.popular && !isPhase1;
 
             return (
               <Card
                 key={plan.tier}
                 className={`relative flex flex-col ${
-                  plan.popular ? "border-primary shadow-lg scale-105" : ""
+                  showPopular ? "border-primary shadow-lg scale-105" : ""
                 }`}
               >
-                {plan.popular && (
+                {showPopular && (
                   <div className="absolute -top-3 left-1/2 -translate-x-1/2">
                     <Badge className="bg-primary text-primary-foreground">
                       <Sparkles className="mr-1 h-3 w-3" />
@@ -229,33 +238,28 @@ export function PricingClient({ currentPhase }: { currentPhase: SystemPhase }) {
                   </div>
                 </CardContent>
 
-                <CardFooter>
-                  {isCurrentPlan ? (
-                    <Button className="w-full" variant="secondary" disabled>
-                      Current Plan
-                    </Button>
-                  ) : isPhase1 ? (
-                    // Phase 1: every non-current tier card invites a beta
-                    // request rather than a "Coming Soon" upgrade button. The
-                    // closed-beta banner above is the canonical CTA; this just
-                    // keeps the cards consistent.
-                    <Button
-                      className="w-full"
-                      variant={plan.popular ? "default" : "outline"}
-                      onClick={() => setBetaInquiryOpen(true)}
-                    >
-                      Request beta access
-                    </Button>
-                  ) : isUpgrade ? (
-                    <Button className="w-full" disabled>
-                      Upgrade - Coming Soon
-                    </Button>
-                  ) : (
-                    <Button className="w-full" variant="outline" disabled>
-                      Downgrade - Coming Soon
-                    </Button>
-                  )}
-                </CardFooter>
+                {/* Phase 1: tier cards are informational only — no per-tier
+                    CTAs. The banner above the grid is the single Request beta
+                    access entry point. The "Current Plan" badge in the header
+                    still flags the signed-in user's current tier. Phase 2 will
+                    restore the upgrade/downgrade buttons. */}
+                {!isPhase1 && (
+                  <CardFooter>
+                    {isCurrentPlan ? (
+                      <Button className="w-full" variant="secondary" disabled>
+                        Current Plan
+                      </Button>
+                    ) : isUpgrade ? (
+                      <Button className="w-full" disabled>
+                        Upgrade - Coming Soon
+                      </Button>
+                    ) : (
+                      <Button className="w-full" variant="outline" disabled>
+                        Downgrade - Coming Soon
+                      </Button>
+                    )}
+                  </CardFooter>
+                )}
               </Card>
             );
           })}

--- a/tests/e2e/iteration-2-surfaces.spec.ts
+++ b/tests/e2e/iteration-2-surfaces.spec.ts
@@ -24,18 +24,29 @@ test.describe('MVP Phase 1 iteration 2 surfaces', () => {
     ).toBeVisible();
   });
 
-  test('pricing tier cards show "Request beta access" instead of "Coming Soon" buttons', async ({
+  test('pricing tier cards are informational under phase_1 — banner is the sole CTA', async ({
     page,
   }) => {
     await page.goto('/pricing');
-    // Under phase_1, the iteration-1 "Upgrade - Coming Soon" / "Downgrade -
-    // Coming Soon" disabled buttons are replaced with active "Request beta
-    // access" buttons. At least three are visible (one banner + at least two
-    // tier-card variants — Free is current/disabled for unauthed users).
+    // Under phase_1 the per-tier CTAs (both the iteration-1 "Coming Soon"
+    // disabled buttons and the early-iteration-2 per-card "Request beta
+    // access" buttons) are gone. The closed-beta banner above the grid is
+    // the single entry point. So exactly one "Request beta access" button
+    // exists on the page — the one inside the banner.
     const ctas = page.getByRole('button', { name: /request beta access/i });
-    await expect(ctas.first()).toBeVisible();
-    const count = await ctas.count();
-    expect(count).toBeGreaterThanOrEqual(2);
+    await expect(ctas).toHaveCount(1);
+    // And no "Coming Soon" buttons leak through.
+    await expect(page.getByRole('button', { name: /coming soon/i })).toHaveCount(0);
+  });
+
+  test('pricing page does not mark Free as "Current Plan" for signed-out visitors', async ({
+    page,
+  }) => {
+    await page.goto('/pricing');
+    // Bug fix: anonymous visitors used to see the Free card flagged as
+    // "Current Plan" because the userTier defaulted to "FREE". Signed-out
+    // users should see no Current Plan badge anywhere on the page.
+    await expect(page.getByText('Current Plan')).toHaveCount(0);
   });
 
   test('clicking "Request beta access" on /pricing opens the inquiry-form dialog', async ({


### PR DESCRIPTION
## Summary

Three issues caught during the iteration-2 smoke test of [/pricing](src/app/pricing/pricing-client.tsx):

1. **Tier cards looked interactive but weren't.** Starter was scaled-up with a "Most Popular" badge, every non-current tier had a "Request beta access" button — but the closed-beta banner is the only real CTA. Now the cards are informational only (equal visual weight, no per-tier buttons under phase_1).
2. **Free card showed "Current Plan" for signed-out visitors.** `userTier` defaulted to `"FREE"` when there was no session. Now it's `null` when signed out, so no card is badged on the public/anon view.
3. **Phase 2 paths preserved.** "Upgrade/Downgrade — Coming Soon" buttons, the "Most Popular" badge, and the `scale-105` styling all still render — they're gated on `!isPhase1`.

## Files

- `src/app/pricing/pricing-client.tsx` — three small edits (userTier nullable, `showPopular` gate, footer rendering gated on `!isPhase1`).
- `tests/e2e/iteration-2-surfaces.spec.ts` — old test asserted ≥2 per-tier "Request beta access" buttons; now asserts exactly one on the page (the banner) plus zero "Coming Soon" buttons. Added a new test that signed-out visitors never see a "Current Plan" badge anywhere.

## Test plan

- [x] `npm run lint:strict` clean
- [x] `npm run type-check` clean
- [x] `npx vitest run` — 652 passing, 22 skipped (pre-existing)
- [ ] CI: PR checks (lint + typecheck + unit + integration)
- [ ] CI: E2E against staging after merge
- [ ] Manual smoke on staging: signed-out visitor to `/pricing` sees no "Current Plan" badge; tier cards are flat (no scale-up, no "Most Popular"); only one "Request beta access" button on the page (banner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)