### PR TITLE
fix(test): scope E2E 'Coming Soon' assertion to the tier grid

### DIFF
--- a/src/app/pricing/pricing-client.tsx
+++ b/src/app/pricing/pricing-client.tsx
@@ -150,7 +150,7 @@ export function PricingClient({ currentPhase }: { currentPhase: SystemPhase }) {
         )}
 
         {/* Plans grid */}
-        <div className="grid gap-6 md:grid-cols-3 mb-12">
+        <div data-testid="pricing-tier-grid" className="grid gap-6 md:grid-cols-3 mb-12">
           {plans.map((plan) => {
             const isCurrentPlan = !!userTier && userTier === plan.tier;
             const isUpgrade =

--- a/tests/e2e/iteration-2-surfaces.spec.ts
+++ b/tests/e2e/iteration-2-surfaces.spec.ts
@@ -35,8 +35,12 @@ test.describe('MVP Phase 1 iteration 2 surfaces', () => {
     // exists on the page — the one inside the banner.
     const ctas = page.getByRole('button', { name: /request beta access/i });
     await expect(ctas).toHaveCount(1);
-    // And no "Coming Soon" buttons leak through.
-    await expect(page.getByRole('button', { name: /coming soon/i })).toHaveCount(0);
+    // And no "Coming Soon" buttons leak through the tier grid. We scope this
+    // assertion to the grid because the page also has an unrelated
+    // "Contact Sales — Coming Soon" disabled button in the footer that is
+    // not part of iteration 2's phase-aware tier rendering.
+    const tierGrid = page.getByTestId('pricing-tier-grid');
+    await expect(tierGrid.getByRole('button', { name: /coming soon/i })).toHaveCount(0);
   });
 
   test('pricing page does not mark Free as "Current Plan" for signed-out visitors', async ({


### PR DESCRIPTION
## Summary

PR #87 added an E2E assertion that no "Coming Soon" buttons exist on `/pricing` under `phase_1`. Too broad — the page also has an unrelated "Contact Sales — Coming Soon" disabled button in the footer that predates phase_1. Staging E2E caught it (1 found, 0 expected).

Fix: scope the assertion to the tier grid via a new `data-testid="pricing-tier-grid"` on the grid wrapper. The tier-card content is what iteration 2 changes; the Contact Sales button is a separate, pre-existing concern.

## Files

- [src/app/pricing/pricing-client.tsx](src/app/pricing/pricing-client.tsx) — added `data-testid="pricing-tier-grid"` to the grid wrapper.
- [tests/e2e/iteration-2-surfaces.spec.ts](tests/e2e/iteration-2-surfaces.spec.ts) — `expect(page.getByRole('button', { name: /coming soon/i }))` → `expect(tierGrid.getByRole('button', { name: /coming soon/i }))`.

## Test plan

- [x] `npm run lint:strict` clean
- [x] `npm run type-check` clean
- [ ] CI: PR checks
- [ ] CI: E2E against staging after merge — the failing test should now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)