### PR TITLE
fix(phase-1): hybrid inquiry-form label, sharper placeholder, beta-aware /pricing banner

### DIFF
--- a/src/app/pricing/pricing-client.tsx
+++ b/src/app/pricing/pricing-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useSession } from "next-auth/react";
 import { Check, ArrowLeft, Sparkles, AlertCircle } from "lucide-react";
@@ -94,13 +94,45 @@ const plans: Plan[] = [
 ];
 
 export function PricingClient({ currentPhase }: { currentPhase: SystemPhase }) {
-  const { data: session } = useSession();
+  const { data: session, status: sessionStatus } = useSession();
   // null when signed out — prevents the "Current Plan" badge from defaulting
   // onto the Free card for anonymous visitors.
   const userTier = (session?.user as { tier?: string })?.tier ?? null;
   const [betaInquiryOpen, setBetaInquiryOpen] = useState(false);
 
   const isPhase1 = currentPhase === "phase_1";
+
+  // Beta-aware banner state. `/pricing` is reachable when signed out and lives
+  // outside the dashboard layout, so we can't read `isBetaUser` from
+  // CreditsProvider. We fetch it from /api/credits once per signed-in mount —
+  // single round-trip, low-traffic page, naturally up-to-date if the founder
+  // toggles beta access without forcing a session refresh.
+  // Undefined = unknown yet (signed-out, or signed-in but request hasn't
+  // resolved). Falsy banner-swap logic treats unknown the same as non-beta —
+  // we'd rather flash the prospect-facing copy than the beta-thank-you copy
+  // for someone who isn't actually a beta user.
+  const [isBetaUser, setIsBetaUser] = useState<boolean | undefined>(undefined);
+  useEffect(() => {
+    if (sessionStatus !== "authenticated") return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch("/api/credits");
+        if (!res.ok) return;
+        const json = await res.json();
+        if (!cancelled) {
+          setIsBetaUser(Boolean(json?.data?.isBetaUser));
+        }
+      } catch {
+        // Silent fail — banner falls back to the prospect-facing copy, which
+        // is harmless for a beta user who'll then realise they're on the
+        // wrong surface anyway.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionStatus]);
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-background to-muted/30">
@@ -120,12 +152,35 @@ export function PricingClient({ currentPhase }: { currentPhase: SystemPhase }) {
           </div>
         </div>
 
-        {/* MVP Phase 1: closed-beta banner. Replaces the disabled "Coming Soon"
-            upgrade buttons with a single Request beta access CTA. Per MVP.md
-            Section 12.5. No specific launch date promised — vague-but-honest
-            framing beats committing to a date that may slip. */}
-        {isPhase1 && (
-          <div className="mb-10 rounded-lg border bg-primary/5 border-primary/20 p-5 sm:p-6 flex flex-col sm:flex-row items-start sm:items-center gap-4 sm:justify-between">
+        {/* MVP Phase 1: closed-beta banner. Per MVP.md Section 12.5.
+            Two states:
+            - Beta users: thank-you message, no CTA (they're already in;
+              "request more credits" lives in the dashboard zero-balance flow)
+            - Everyone else: prospect-facing copy with Request beta access CTA
+            No specific launch date is promised — vague-but-honest framing
+            beats committing to a date that may slip. */}
+        {isPhase1 && isBetaUser && (
+          <div
+            data-testid="pricing-banner-beta-user"
+            className="mb-10 rounded-lg border bg-primary/5 border-primary/20 p-5 sm:p-6 flex items-start gap-3"
+          >
+            <AlertCircle className="h-5 w-5 text-primary shrink-0 mt-0.5" />
+            <div>
+              <p className="font-semibold text-foreground">
+                You&apos;re in the closed beta — thank you!
+              </p>
+              <p className="text-sm text-muted-foreground mt-1">
+                Below is a preview of the commercial plans we&apos;ll launch
+                later — we&apos;ll be in touch before then.
+              </p>
+            </div>
+          </div>
+        )}
+        {isPhase1 && !isBetaUser && (
+          <div
+            data-testid="pricing-banner-prospect"
+            className="mb-10 rounded-lg border bg-primary/5 border-primary/20 p-5 sm:p-6 flex flex-col sm:flex-row items-start sm:items-center gap-4 sm:justify-between"
+          >
             <div className="flex items-start gap-3">
               <AlertCircle className="h-5 w-5 text-primary shrink-0 mt-0.5" />
               <div>

--- a/src/components/shared/FounderInquiryForm.tsx
+++ b/src/components/shared/FounderInquiryForm.tsx
@@ -48,29 +48,45 @@ interface FounderInquiryFormProps {
   onSuccess?: () => void;
 }
 
+// Per-type copy. The `messageLabel` is the bold field label; `messageHint` is
+// the italic sub-label rendered next to it (one line). The hint primes the
+// reader on what we'd like to hear without forcing a survey shape — the
+// placeholder example does the heavier lifting.
 const DEFAULT_COPY: Record<
   FounderInquiryType,
-  { heading: string; description: string; messagePlaceholder: string; submitLabel: string }
+  {
+    heading: string;
+    description: string;
+    messageLabel: string;
+    messageHint?: string;
+    messagePlaceholder: string;
+    submitLabel: string;
+  }
 > = {
   beta_request: {
     heading: "Request beta access",
     description:
       "BrandsIQ is in closed beta. Tell us a little about your business and we'll be in touch within 24 hours.",
+    messageLabel: "Tell us about your business",
+    messageHint: "what you do, what's painful about reviews today",
     messagePlaceholder:
-      "What kind of business do you run? How many reviews are you handling each month?",
+      'e.g. "I run a small bakery in Shoreditch. Responding to Google reviews takes me ~30 min a day and I usually copy-paste the same few replies."',
     submitLabel: "Request beta access",
   },
   more_credits: {
     heading: "Need more credits?",
     description:
       "Let us know what you're working on and we'll top up your beta account so you can keep going.",
+    messageLabel: "Message",
+    messageHint: "what are you working on?",
     messagePlaceholder:
-      "Anything we should know? (E.g. \"I'm running a campaign next week and want to respond to 50 reviews\".)",
+      'e.g. "I\'m running a campaign next week and want to respond to 50 reviews."',
     submitLabel: "Send request",
   },
   general: {
     heading: "Get in touch",
     description: "We'd love to hear from you — leave a note below and we'll reply.",
+    messageLabel: "Message",
     messagePlaceholder: "How can we help?",
     submitLabel: "Send",
   },
@@ -78,8 +94,10 @@ const DEFAULT_COPY: Record<
     heading: "Request a fresh invite",
     description:
       "Your beta invite link has expired or has already been used. Fill in the form below and we'll send a fresh invite within 24 hours.",
+    messageLabel: "Tell us about your business",
+    messageHint: "what you do, what's painful about reviews today",
     messagePlaceholder:
-      "Anything else we should know? (Optional)",
+      'e.g. "I run a small bakery in Shoreditch. Responding to Google reviews takes me ~30 min a day and I usually copy-paste the same few replies."',
     submitLabel: "Request fresh invite",
   },
 };
@@ -240,7 +258,16 @@ export function FounderInquiryForm({
         )}
 
         <div className="space-y-1.5">
-          <Label htmlFor="founder-inquiry-message">Message *</Label>
+          <Label htmlFor="founder-inquiry-message" className="flex flex-wrap items-baseline gap-x-1.5">
+            <span>
+              {copy.messageLabel} <span className="text-red-600">*</span>
+            </span>
+            {copy.messageHint && (
+              <span className="text-xs italic text-muted-foreground font-normal">
+                ({copy.messageHint})
+              </span>
+            )}
+          </Label>
           <div className="relative">
             <MessageSquare className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
             <Textarea

--- a/tests/unit/components/pricing/pricing-client.test.tsx
+++ b/tests/unit/components/pricing/pricing-client.test.tsx
@@ -1,0 +1,162 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// next/link stub — passthrough to <a>
+vi.mock("next/link", () => ({
+  default: ({ children, href, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+// next-auth/react — we control `data` and `status` per test via useSession.
+const useSessionMock = vi.fn();
+vi.mock("next-auth/react", () => ({
+  useSession: () => useSessionMock(),
+}));
+
+import { PricingClient } from "@/app/pricing/pricing-client";
+
+describe("PricingClient — phase_1 banner state", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("shows the prospect-facing banner with Request beta access CTA for anonymous visitors", () => {
+    useSessionMock.mockReturnValue({ data: null, status: "unauthenticated" });
+
+    render(<PricingClient currentPhase="phase_1" />);
+
+    // Prospect banner is visible
+    expect(
+      screen.getByTestId("pricing-banner-prospect"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/brandsiq is currently in closed beta\./i),
+    ).toBeInTheDocument();
+    // CTA button present
+    expect(
+      screen.getByRole("button", { name: /request beta access/i }),
+    ).toBeInTheDocument();
+    // Beta-thank-you banner is NOT shown
+    expect(
+      screen.queryByTestId("pricing-banner-beta-user"),
+    ).not.toBeInTheDocument();
+    // /api/credits is not called for an anon visitor
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("swaps to the thank-you banner with no CTA when the signed-in user is a beta user", async () => {
+    useSessionMock.mockReturnValue({
+      data: { user: { id: "u-beta", email: "beta@x.com", tier: "FREE" } },
+      status: "authenticated",
+    });
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true, data: { isBetaUser: true } }),
+    });
+
+    render(<PricingClient currentPhase="phase_1" />);
+
+    // Until the fetch resolves, the prospect banner is shown (better to flash
+    // the public copy than the thank-you copy for someone who isn't beta).
+    expect(
+      screen.getByTestId("pricing-banner-prospect"),
+    ).toBeInTheDocument();
+
+    // After the fetch resolves, the banner swaps
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("pricing-banner-beta-user"),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(/you're in the closed beta — thank you!/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/preview of the commercial plans we'll launch later/i),
+    ).toBeInTheDocument();
+
+    // Critically: no "Request beta access" CTA exists once the swap happens
+    expect(
+      screen.queryByRole("button", { name: /request beta access/i }),
+    ).not.toBeInTheDocument();
+    // And the prospect banner is gone
+    expect(
+      screen.queryByTestId("pricing-banner-prospect"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps the prospect banner for signed-in non-beta users (Free tier)", async () => {
+    useSessionMock.mockReturnValue({
+      data: { user: { id: "u-free", email: "free@x.com", tier: "FREE" } },
+      status: "authenticated",
+    });
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true, data: { isBetaUser: false } }),
+    });
+
+    render(<PricingClient currentPhase="phase_1" />);
+
+    // Wait for the fetch to settle
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith("/api/credits");
+    });
+
+    // After settlement, prospect banner remains visible (non-beta user gets
+    // the same "Request beta access" surface as anon visitors).
+    expect(
+      screen.getByTestId("pricing-banner-prospect"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("pricing-banner-beta-user"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("falls back to the prospect banner if /api/credits errors", async () => {
+    useSessionMock.mockReturnValue({
+      data: { user: { id: "u-x", email: "x@x.com", tier: "FREE" } },
+      status: "authenticated",
+    });
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: "boom" }),
+    });
+
+    render(<PricingClient currentPhase="phase_1" />);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalled();
+    });
+
+    // Banner state never flips to beta-thank-you
+    expect(
+      screen.getByTestId("pricing-banner-prospect"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("pricing-banner-beta-user"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not render a phase_1 banner under phase_2", () => {
+    useSessionMock.mockReturnValue({ data: null, status: "unauthenticated" });
+
+    render(<PricingClient currentPhase="phase_2" />);
+
+    expect(
+      screen.queryByTestId("pricing-banner-prospect"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("pricing-banner-beta-user"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/tests/unit/components/shared/founder-inquiry-form.test.tsx
+++ b/tests/unit/components/shared/founder-inquiry-form.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+
+// Stub fetch — we only assert rendering, not submission flow here.
+vi.stubGlobal("fetch", vi.fn());
+
+import { FounderInquiryForm } from "@/components/shared/FounderInquiryForm";
+
+describe("FounderInquiryForm — hybrid label + example placeholder", () => {
+  it("beta_request renders the prospect-qualifying label, hint, and example placeholder", () => {
+    render(<FounderInquiryForm type="beta_request" source="pricing" />);
+
+    // Bold prompt label
+    expect(screen.getByText(/tell us about your business/i)).toBeInTheDocument();
+    // Italic hint sits next to the label
+    expect(
+      screen.getByText(/\(what you do, what's painful about reviews today\)/i),
+    ).toBeInTheDocument();
+    // Placeholder example — concrete narrative shape
+    const messageField = screen.getByLabelText(
+      /tell us about your business/i,
+    ) as HTMLTextAreaElement;
+    expect(messageField).toBeInTheDocument();
+    expect(messageField.placeholder).toContain("bakery in Shoreditch");
+    expect(messageField.placeholder).toContain("Google reviews");
+    // The old filler should not have crept back in
+    expect(messageField.placeholder).not.toContain("Would love to try BrandsIQ");
+    // The old volume question should not appear anywhere on the form
+    expect(
+      screen.queryByText(/how many reviews are you handling/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("expired_link_recovery uses the same prospect-qualifying copy as beta_request", () => {
+    render(<FounderInquiryForm type="expired_link_recovery" source="expired_link" />);
+
+    expect(screen.getByText(/tell us about your business/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/\(what you do, what's painful about reviews today\)/i),
+    ).toBeInTheDocument();
+  });
+
+  it("more_credits keeps the simpler 'Message' label with a working-context hint", () => {
+    render(<FounderInquiryForm type="more_credits" source="zero_balance" />);
+
+    expect(screen.getByText(/\(what are you working on\?\)/i)).toBeInTheDocument();
+    const messageField = screen.getByLabelText(/^message/i) as HTMLTextAreaElement;
+    expect(messageField.placeholder).toContain("campaign next week");
+  });
+
+  it("general inquiry uses no hint and keeps the simplest placeholder", () => {
+    render(<FounderInquiryForm type="general" source="other" />);
+
+    // No bold beta-qualifying label
+    expect(screen.queryByText(/tell us about your business/i)).not.toBeInTheDocument();
+    // No italic hint
+    expect(
+      screen.queryByText(/\(what are you working on\?\)/i),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/\(what you do, what's painful about reviews today\)/i),
+    ).not.toBeInTheDocument();
+    const messageField = screen.getByLabelText(/^message/i) as HTMLTextAreaElement;
+    expect(messageField.placeholder).toBe("How can we help?");
+  });
+});


### PR DESCRIPTION
## Summary

Three findings from the iteration-2 smoke test, bundled into one small PR since they all sit on phase-1 surfaces.

### 1. `FounderInquiryForm` message field — hybrid label + sharper placeholder

The message field used to ask *"What kind of business do you run? How many reviews are you handling each month?"*. Monthly volume is weak self-reported signal — PostHog gives us accurate numbers within two weeks of beta start, and [MVP.md Section 9](docs/MVP_Phase-1/MVP.md) explicitly dropped the same field from signup for the same reason.

Replaced with a hybrid: **bold per-type label**, *italic hint on the same line*, concrete narrative example as placeholder.

| Type | Label | Hint | Placeholder |
|---|---|---|---|
| `beta_request`, `expired_link_recovery` | Tell us about your business | (what you do, what's painful about reviews today) | e.g. "I run a small bakery in Shoreditch. Responding to Google reviews takes me ~30 min a day and I usually copy-paste the same few replies." |
| `more_credits` | Message | (what are you working on?) | e.g. "I'm running a campaign next week and want to respond to 50 reviews." |
| `general` | Message | — | How can we help? |

The "Would love to try BrandsIQ" filler was dropped — primes flattery imitation, adds zero signal.

### 2. Beta users seeing "Request beta access" on /pricing

A beta user already has beta access — showing them the prospect-facing CTA is confusing. The banner now splits by `isBetaUser`:

- **Beta users:** "You're in the closed beta — thank you!" + "Below is a preview of the commercial plans we'll launch later — we'll be in touch before then." **No button.**
- **Everyone else** (anon, Free, future Starter/Growth pre-Phase-2): existing prospect copy + CTA unchanged.

### 3. How we know

`/pricing` lives outside the dashboard layout so `CreditsProvider` isn't mounted. Single fetch from `/api/credits` on signed-in mount (low-traffic page; naturally up-to-date if the founder ever flips the flag). Fetch failures fall back to the prospect banner — better to flash public copy at a beta user for a moment than greet a non-beta user with a thank-you message.

## Files

- [src/components/shared/FounderInquiryForm.tsx](src/components/shared/FounderInquiryForm.tsx) — per-type `messageLabel` + `messageHint` in `DEFAULT_COPY`; label JSX rebuilt as flex with bold span + italic hint span on one line.
- [src/app/pricing/pricing-client.tsx](src/app/pricing/pricing-client.tsx) — `isBetaUser` state, `useEffect` to fetch from `/api/credits`, banner split with two `data-testid`s (`pricing-banner-prospect`, `pricing-banner-beta-user`).
- [tests/unit/components/shared/founder-inquiry-form.test.tsx](tests/unit/components/shared/founder-inquiry-form.test.tsx) — 4 new cases (per-type label + placeholder shape).
- [tests/unit/components/pricing/pricing-client.test.tsx](tests/unit/components/pricing/pricing-client.test.tsx) — 5 new cases (anon, beta post-fetch, non-beta post-fetch, fetch-failure fallback, phase_2 no-banner).

## Test plan

- [x] `npm run lint:strict` clean
- [x] `npm run type-check` clean
- [x] `npx vitest run` — **661 passing**, 22 skipped (was 652 + 9 new). No regressions.
- [ ] CI: PR checks
- [ ] CI: E2E against staging after merge — existing iteration-2 E2E hits `/pricing` while signed out, so should still pass (anon path unchanged)
- [ ] Manual smoke on staging:
  - [ ] Anon visitor to /pricing — prospect banner + CTA
  - [ ] Beta user signed in to /pricing — thank-you banner, no CTA
  - [ ] Free user signed in to /pricing — prospect banner + CTA
  - [ ] Open Request beta access dialog from any surface — message field shows the new hybrid label + Shoreditch-bakery placeholder
  - [ ] Beta user opens LowCreditWarning → Request more credits — message field shows "Message" + "(what are you working on?)" + campaign placeholder

## Out of scope (deferred per your call)

- **"You've already requested beta access" hint** — to be filed as a follow-up issue.
- **"Grant beta access" admin button on `FounderInquiry` rows** — to be filed as a follow-up issue (currently the founder has to manually `UPDATE` the User row in DB; this PR doesn't change that).

🤖 Generated with [Claude Code](https://claude.com/claude-code)