### PR TITLE
feat(phase-1): pre-fill FounderInquiryForm submitter fields for signed-in users

### DIFF
--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -93,7 +93,7 @@ function formatTimeAgo(dateString: string) {
 
 export default function DashboardPage() {
   const { data: session } = useSession();
-  const { currentPhase } = useCredits();
+  const { currentPhase, organizationName } = useCredits();
   const [stats, setStats] = useState<DashboardStats | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -155,6 +155,9 @@ export default function DashboardPage() {
           sentimentResetDate={stats.sentiment.resetDate}
           currentPhase={currentPhase}
           isBetaUser={stats.isBetaUser}
+          submitterName={session?.user?.name ?? null}
+          submitterEmail={session?.user?.email ?? null}
+          submitterBusinessName={organizationName}
         />
       )}
 

--- a/src/app/(dashboard)/dashboard/reviews/[id]/generate/page.tsx
+++ b/src/app/(dashboard)/dashboard/reviews/[id]/generate/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import Link from "next/link";
 import { useRouter, useParams } from "next/navigation";
+import { useSession } from "next-auth/react";
 import { toast } from "sonner";
 import {
   ArrowLeft,
@@ -84,7 +85,16 @@ export default function GenerateResponsePage() {
   const [generatedResponse, setGeneratedResponse] = useState<GeneratedResponse | null>(null);
   const [creditsRemaining, setCreditsRemaining] = useState<number | null>(null);
   const [showOutOfCreditsDialog, setShowOutOfCreditsDialog] = useState(false);
-  const { credits, creditsTotal, creditsResetDate, refreshCredits, currentPhase, isBetaUser } = useCredits();
+  const {
+    credits,
+    creditsTotal,
+    creditsResetDate,
+    refreshCredits,
+    currentPhase,
+    isBetaUser,
+    organizationName,
+  } = useCredits();
+  const { data: session } = useSession();
   const [error, setError] = useState<string | null>(null);
 
   // Fetch review
@@ -384,6 +394,9 @@ export default function GenerateResponsePage() {
         actionType="generate"
         currentPhase={currentPhase}
         isBetaUser={isBetaUser}
+        submitterName={session?.user?.name ?? null}
+        submitterEmail={session?.user?.email ?? null}
+        submitterBusinessName={organizationName}
       />
     </div>
   );

--- a/src/app/(dashboard)/dashboard/reviews/[id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/reviews/[id]/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import Link from "next/link";
 import { useRouter, useParams, useSearchParams } from "next/navigation";
+import { useSession } from "next-auth/react";
 import { toast } from "sonner";
 import {
   ArrowLeft,
@@ -149,7 +150,17 @@ export default function ReviewDetailPage() {
   const [showSentimentAlert, setShowSentimentAlert] = useState(
     searchParams.get("sentimentSkipped") === "true"
   );
-  const { credits, creditsTotal, creditsResetDate, sentimentResetDate, refreshCredits, currentPhase, isBetaUser } = useCredits();
+  const {
+    credits,
+    creditsTotal,
+    creditsResetDate,
+    sentimentResetDate,
+    refreshCredits,
+    currentPhase,
+    isBetaUser,
+    organizationName,
+  } = useCredits();
+  const { data: session } = useSession();
 
   useEffect(() => {
     async function fetchReview() {
@@ -537,6 +548,9 @@ export default function ReviewDetailPage() {
         actionType="generate"
         currentPhase={currentPhase}
         isBetaUser={isBetaUser}
+        submitterName={session?.user?.name ?? null}
+        submitterEmail={session?.user?.email ?? null}
+        submitterBusinessName={organizationName}
       />
     </div>
   );

--- a/src/app/api/credits/route.ts
+++ b/src/app/api/credits/route.ts
@@ -32,6 +32,9 @@ export async function GET() {
         creditsResetDate: true,
         sentimentCredits: true,
         sentimentResetDate: true,
+        // Surfaced so the FounderInquiryForm can pre-fill businessName for
+        // signed-in users (set during /onboarding; null until then).
+        organizationName: true,
       },
     });
 
@@ -73,6 +76,7 @@ export async function GET() {
         },
         tier: user.tier,
         isBetaUser: user.isBetaUser,
+        organizationName: user.organizationName,
       },
     });
   } catch (error) {

--- a/src/app/api/dashboard/stats/route.ts
+++ b/src/app/api/dashboard/stats/route.ts
@@ -29,6 +29,9 @@ export async function GET() {
         creditsResetDate: true,
         sentimentCredits: true,
         sentimentResetDate: true,
+        // Surfaced so FounderInquiryForm can pre-fill businessName for
+        // signed-in users — see CreditsProvider + iteration 2 follow-up.
+        organizationName: true,
         reviews: {
           select: {
             id: true,
@@ -165,6 +168,10 @@ export async function GET() {
         // OutOfCreditsDialog, etc.) can render phase-aware CTAs without an
         // extra round-trip. See MVP.md Section 12.4.
         isBetaUser: user.isBetaUser,
+        // organizationName pre-fills FounderInquiryForm.businessName for
+        // signed-in users so they don't re-type info already captured at
+        // /onboarding. null until onboarding is completed.
+        organizationName: user.organizationName,
         stats: {
           totalReviews: user._count.reviews,
           totalResponses,

--- a/src/app/pricing/pricing-client.tsx
+++ b/src/app/pricing/pricing-client.tsx
@@ -112,6 +112,10 @@ export function PricingClient({ currentPhase }: { currentPhase: SystemPhase }) {
   // we'd rather flash the prospect-facing copy than the beta-thank-you copy
   // for someone who isn't actually a beta user.
   const [isBetaUser, setIsBetaUser] = useState<boolean | undefined>(undefined);
+  // organizationName is captured from the same /api/credits fetch and used to
+  // pre-fill FounderInquiryForm.businessName for signed-in users. null when
+  // signed out or before the fetch resolves.
+  const [organizationName, setOrganizationName] = useState<string | null>(null);
   useEffect(() => {
     if (sessionStatus !== "authenticated") return;
     let cancelled = false;
@@ -122,6 +126,7 @@ export function PricingClient({ currentPhase }: { currentPhase: SystemPhase }) {
         const json = await res.json();
         if (!cancelled) {
           setIsBetaUser(Boolean(json?.data?.isBetaUser));
+          setOrganizationName(json?.data?.organizationName ?? null);
         }
       } catch {
         // Silent fail — banner falls back to the prospect-facing copy, which
@@ -133,6 +138,15 @@ export function PricingClient({ currentPhase }: { currentPhase: SystemPhase }) {
       cancelled = true;
     };
   }, [sessionStatus]);
+
+  // For the /pricing inquiry dialog: pre-fill from session/credits when
+  // signed in. Anonymous visitors keep the manual-entry fields (they have
+  // to give us their email so we can reply).
+  const isSignedIn = sessionStatus === "authenticated";
+  const prefillName = isSignedIn ? session?.user?.name ?? null : null;
+  const prefillEmail = isSignedIn ? session?.user?.email ?? null : null;
+  const prefillBusinessName = isSignedIn ? organizationName : null;
+  const canHideSubmitterFields = Boolean(prefillName && prefillEmail);
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-background to-muted/30">
@@ -387,6 +401,10 @@ export function PricingClient({ currentPhase }: { currentPhase: SystemPhase }) {
             <FounderInquiryForm
               type="beta_request"
               source="pricing"
+              defaultName={prefillName}
+              defaultEmail={prefillEmail}
+              defaultBusinessName={prefillBusinessName}
+              hideSubmitterFields={canHideSubmitterFields}
               onSuccess={() => {
                 setTimeout(() => setBetaInquiryOpen(false), 1800);
               }}

--- a/src/components/dashboard/LowCreditWarning.tsx
+++ b/src/components/dashboard/LowCreditWarning.tsx
@@ -28,6 +28,12 @@ interface LowCreditWarningProps {
   // Optional with sensible defaults so existing call sites stay compatible.
   currentPhase?: SystemPhase;
   isBetaUser?: boolean;
+  // Pre-fill submitter info for the nested FounderInquiryForm. When all
+  // three are provided we hide the submitter fields entirely. Callers in
+  // the dashboard layout typically source these from session + CreditsProvider.
+  submitterName?: string | null;
+  submitterEmail?: string | null;
+  submitterBusinessName?: string | null;
 }
 
 type WarningType =
@@ -112,9 +118,13 @@ export function LowCreditWarning({
   sentimentResetDate,
   currentPhase = "phase_2",
   isBetaUser = false,
+  submitterName,
+  submitterEmail,
+  submitterBusinessName,
 }: LowCreditWarningProps) {
   const [isDismissed, setIsDismissed] = useState(false);
   const [inquiryOpen, setInquiryOpen] = useState(false);
+  const canHideSubmitterFields = Boolean(submitterName && submitterEmail);
 
   const { type: warningType, isRed } = getWarningState(
     creditsRemaining,
@@ -307,6 +317,10 @@ export function LowCreditWarning({
             <FounderInquiryForm
               type={isBetaUser ? "more_credits" : "beta_request"}
               source="zero_balance"
+              defaultName={submitterName ?? null}
+              defaultEmail={submitterEmail ?? null}
+              defaultBusinessName={submitterBusinessName ?? null}
+              hideSubmitterFields={canHideSubmitterFields}
               onSuccess={() => {
                 setTimeout(() => setInquiryOpen(false), 1800);
               }}

--- a/src/components/dashboard/OutOfCreditsDialog.tsx
+++ b/src/components/dashboard/OutOfCreditsDialog.tsx
@@ -31,6 +31,13 @@ interface OutOfCreditsDialogProps {
   // tier is reserved for Phase 2 ("Starter / Growth") tier-specific copy.
   // Accepted but ignored under phase_1; renamed _tier to satisfy the linter.
   _tier?: string;
+  // Pre-fill submitter info for FounderInquiryForm. When all three are
+  // provided we hide the submitter fields entirely — the user has already
+  // given us this info at signup/onboarding. Callers in the dashboard
+  // layout typically source these from session + CreditsProvider.
+  submitterName?: string | null;
+  submitterEmail?: string | null;
+  submitterBusinessName?: string | null;
 }
 
 export function OutOfCreditsDialog({
@@ -42,7 +49,15 @@ export function OutOfCreditsDialog({
   actionType = "generate",
   currentPhase = "phase_2",
   isBetaUser = false,
+  submitterName,
+  submitterEmail,
+  submitterBusinessName,
 }: OutOfCreditsDialogProps) {
+  // Hide submitter fields when we have what we need from session/onboarding.
+  // We require name + email at minimum; business name is allowed to be null
+  // (a user who somehow lands here without finishing onboarding still gets
+  // their name+email pre-filled and just types business name themselves).
+  const canHideSubmitterFields = Boolean(submitterName && submitterEmail);
   const nextResetDate = getNextResetDate(resetDate);
   const formattedResetDate = nextResetDate
     ? nextResetDate.toLocaleDateString("en-US", {
@@ -138,7 +153,10 @@ export function OutOfCreditsDialog({
             <FounderInquiryForm
               type={inquiryType}
               source="zero_balance"
-              hideSubmitterFields={false}
+              defaultName={submitterName ?? null}
+              defaultEmail={submitterEmail ?? null}
+              defaultBusinessName={submitterBusinessName ?? null}
+              hideSubmitterFields={canHideSubmitterFields}
               onSuccess={() => {
                 // Auto-close shortly after the success card renders so the
                 // user sees confirmation, not a stuck modal.

--- a/src/components/providers/CreditsProvider.tsx
+++ b/src/components/providers/CreditsProvider.tsx
@@ -18,6 +18,10 @@ interface CreditsContextType {
   // CURRENT_PHASE and passes it down via initialCurrentPhase).
   isBetaUser: boolean;
   currentPhase: SystemPhase;
+  // Set during /onboarding. Pre-fills FounderInquiryForm.businessName for
+  // signed-in users so they don't re-type information we already have. null
+  // for users who haven't completed onboarding yet.
+  organizationName: string | null;
   setCredits: (_credits: number) => void;
   refreshCredits: () => Promise<void>;
 }
@@ -34,6 +38,7 @@ interface CreditsProviderProps {
   initialSentimentResetDate?: string | null;
   initialTier?: string;
   initialIsBetaUser?: boolean;
+  initialOrganizationName?: string | null;
   // Defaults to "phase_1" — overridden by the dashboard layout (server
   // component) which reads CURRENT_PHASE on the server and passes it in.
   initialCurrentPhase?: SystemPhase;
@@ -49,6 +54,7 @@ export function CreditsProvider({
   initialSentimentResetDate = null,
   initialTier = "FREE",
   initialIsBetaUser = false,
+  initialOrganizationName = null,
   initialCurrentPhase = "phase_1",
 }: CreditsProviderProps) {
   const [credits, setCreditsState] = useState(initialCredits);
@@ -59,6 +65,9 @@ export function CreditsProvider({
   const [sentimentResetDate, setSentimentResetDate] = useState<string | null>(initialSentimentResetDate);
   const [tier, setTier] = useState(initialTier);
   const [isBetaUser, setIsBetaUser] = useState(initialIsBetaUser);
+  const [organizationName, setOrganizationName] = useState<string | null>(
+    initialOrganizationName,
+  );
   // currentPhase is intentionally not mutable from inside the provider — it's
   // fixed at mount from the server's CURRENT_PHASE env var.
   const [currentPhase] = useState<SystemPhase>(initialCurrentPhase);
@@ -80,6 +89,7 @@ export function CreditsProvider({
         setSentimentResetDate(data.data.sentiment.resetDate);
         setTier(data.data.tier);
         setIsBetaUser(data.data.isBetaUser ?? false);
+        setOrganizationName(data.data.organizationName ?? null);
       }
     } catch (error) {
       console.error("Failed to refresh credits:", error);
@@ -98,6 +108,7 @@ export function CreditsProvider({
         tier,
         isBetaUser,
         currentPhase,
+        organizationName,
         setCredits,
         refreshCredits,
       }}

--- a/src/components/reviews/ResponsePanel.tsx
+++ b/src/components/reviews/ResponsePanel.tsx
@@ -17,6 +17,7 @@ import {
   ChevronUp,
   Coins,
 } from "lucide-react";
+import { useSession } from "next-auth/react";
 import { ResponseEditor } from "./ResponseEditor";
 import { ToneModifier } from "./ToneModifier";
 import { ResponseVersionHistory } from "./ResponseVersionHistory";
@@ -99,7 +100,16 @@ export function ResponsePanel({
   textDirection = "ltr",
   onResponseUpdate,
 }: ResponsePanelProps) {
-  const { credits, creditsTotal, creditsResetDate, refreshCredits, currentPhase, isBetaUser } = useCredits();
+  const {
+    credits,
+    creditsTotal,
+    creditsResetDate,
+    refreshCredits,
+    currentPhase,
+    isBetaUser,
+    organizationName,
+  } = useCredits();
+  const { data: session } = useSession();
   const [isEditing, setIsEditing] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [localResponse, setLocalResponse] = useState<Response | null>(response);
@@ -327,6 +337,9 @@ export function ResponsePanel({
           actionType={outOfCreditsActionType}
           currentPhase={currentPhase}
           isBetaUser={isBetaUser}
+          submitterName={session?.user?.name ?? null}
+          submitterEmail={session?.user?.email ?? null}
+          submitterBusinessName={organizationName}
         />
       </>
     );
@@ -485,6 +498,9 @@ export function ResponsePanel({
         actionType={outOfCreditsActionType}
         currentPhase={currentPhase}
         isBetaUser={isBetaUser}
+        submitterName={session?.user?.name ?? null}
+        submitterEmail={session?.user?.email ?? null}
+        submitterBusinessName={organizationName}
       />
     </Card>
   );

--- a/tests/unit/components/dashboard/out-of-credits-dialog.test.tsx
+++ b/tests/unit/components/dashboard/out-of-credits-dialog.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent } from "@testing-library/react";
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("next/link", () => ({
   default: ({ children, href, ...props }: any) => (
@@ -85,5 +85,81 @@ describe("OutOfCreditsDialog", () => {
     expect(
       screen.queryByText(/you're out of response credits/i)
     ).not.toBeInTheDocument();
+  });
+});
+
+describe("OutOfCreditsDialog — phase_1 inquiry-form pre-fill", () => {
+  // Stub fetch — the embedded FounderInquiryForm will POST to it on submit,
+  // but we don't submit in these tests.
+  const originalFetch = global.fetch;
+  beforeEach(() => {
+    global.fetch = vi.fn();
+  });
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  const baseProps = {
+    open: true,
+    onOpenChange: vi.fn(),
+    creditsRemaining: 0,
+    creditsTotal: 150,
+    resetDate: "2026-06-15T00:00:00Z",
+    actionType: "generate" as const,
+    currentPhase: "phase_1" as const,
+    isBetaUser: true,
+  };
+
+  it("hides submitter inputs in the embedded form when name+email are pre-filled", () => {
+    render(
+      <OutOfCreditsDialog
+        {...baseProps}
+        submitterName="Anita"
+        submitterEmail="anita@example.com"
+        submitterBusinessName="Cafe Arabica"
+      />,
+    );
+
+    // Open the inquiry form by clicking the phase-1 CTA. For beta users
+    // the button reads "Request more credits".
+    fireEvent.click(
+      screen.getByRole("button", { name: /request more credits/i }),
+    );
+
+    // Submitter inputs are gone — we have what we need from session/onboarding
+    expect(screen.queryByLabelText(/^name$/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/^email/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/business name/i)).not.toBeInTheDocument();
+    // Message field is still there
+    expect(screen.getByLabelText(/^message/i)).toBeInTheDocument();
+  });
+
+  it("still shows submitter inputs (pre-filled) when only some fields are provided", () => {
+    // E.g. user finished onboarding but somehow has no email on session —
+    // we should still let them edit, not silently lose the form fields.
+    render(
+      <OutOfCreditsDialog
+        {...baseProps}
+        submitterName="Anita"
+        submitterEmail={null}
+        submitterBusinessName="Cafe Arabica"
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /request more credits/i }),
+    );
+
+    // Submitter inputs are visible because email is missing
+    expect(screen.getByLabelText(/^name$/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^email/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/business name/i)).toBeInTheDocument();
+    // And the values we did pre-fill are populated
+    expect((screen.getByLabelText(/^name$/i) as HTMLInputElement).value).toBe(
+      "Anita",
+    );
+    expect(
+      (screen.getByLabelText(/business name/i) as HTMLInputElement).value,
+    ).toBe("Cafe Arabica");
   });
 });

--- a/tests/unit/components/pricing/pricing-client.test.tsx
+++ b/tests/unit/components/pricing/pricing-client.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // next/link stub — passthrough to <a>
@@ -158,5 +158,76 @@ describe("PricingClient — phase_1 banner state", () => {
     expect(
       screen.queryByTestId("pricing-banner-beta-user"),
     ).not.toBeInTheDocument();
+  });
+});
+
+describe("PricingClient — inquiry form pre-fill", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("hides submitter inputs when a signed-in non-beta user opens the inquiry dialog", async () => {
+    // Free user — they still see the prospect banner so the CTA is present.
+    useSessionMock.mockReturnValue({
+      data: {
+        user: {
+          id: "u-free",
+          email: "free@x.com",
+          name: "Free User",
+          tier: "FREE",
+        },
+      },
+      status: "authenticated",
+    });
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        success: true,
+        data: { isBetaUser: false, organizationName: "Free Co" },
+      }),
+    });
+
+    render(<PricingClient currentPhase="phase_1" />);
+
+    // Wait until the fetch settled (organizationName is now in state)
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith("/api/credits");
+    });
+
+    // Banner CTA is the prospect "Request beta access" button
+    const cta = screen.getByRole("button", { name: /request beta access/i });
+    fireEvent.click(cta);
+
+    // Form is now open. Submitter fields are hidden because we have
+    // name+email from the session.
+    await waitFor(() => {
+      expect(screen.queryByLabelText(/^name$/i)).not.toBeInTheDocument();
+    });
+    expect(screen.queryByLabelText(/^email/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/business name/i)).not.toBeInTheDocument();
+    // Message field is still rendered
+    expect(screen.getByLabelText(/tell us about your business/i)).toBeInTheDocument();
+  });
+
+  it("keeps submitter inputs visible for anonymous visitors", () => {
+    useSessionMock.mockReturnValue({ data: null, status: "unauthenticated" });
+
+    render(<PricingClient currentPhase="phase_1" />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /request beta access/i }),
+    );
+
+    // Anonymous — submitter fields render so they can give us a way to reply
+    expect(screen.getByLabelText(/^name$/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^email/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/business name/i)).toBeInTheDocument();
   });
 });

--- a/tests/unit/components/reviews/response-panel.test.tsx
+++ b/tests/unit/components/reviews/response-panel.test.tsx
@@ -18,6 +18,16 @@ vi.mock("sonner", () => ({
   toast: { success: vi.fn(), error: vi.fn() },
 }));
 
+// MVP Phase 1 iter-2 follow-up: ResponsePanel now reads session for inquiry-
+// form pre-fill. Stub useSession so the standalone render doesn't trip
+// next-auth's "must be wrapped in a SessionProvider" runtime error.
+vi.mock("next-auth/react", () => ({
+  useSession: () => ({
+    data: { user: { id: "u-1", email: "test@example.com", name: "Test User" } },
+    status: "authenticated",
+  }),
+}));
+
 const mockRefreshCredits = vi.fn();
 vi.mock("@/components/providers/CreditsProvider", () => ({
   useCredits: () => ({
@@ -25,6 +35,10 @@ vi.mock("@/components/providers/CreditsProvider", () => ({
     creditsTotal: 15,
     creditsResetDate: "2026-02-15T00:00:00Z",
     refreshCredits: mockRefreshCredits,
+    // MVP Phase 1 iter-2: provide the phase-aware fields the dialog reads.
+    currentPhase: "phase_2" as const,
+    isBetaUser: false,
+    organizationName: null,
   }),
 }));
 

--- a/tests/unit/components/shared/founder-inquiry-form.test.tsx
+++ b/tests/unit/components/shared/founder-inquiry-form.test.tsx
@@ -64,3 +64,63 @@ describe("FounderInquiryForm — hybrid label + example placeholder", () => {
     expect(messageField.placeholder).toBe("How can we help?");
   });
 });
+
+describe("FounderInquiryForm — pre-fill + hideSubmitterFields", () => {
+  it("renders submitter inputs by default (anonymous expired-link flow)", () => {
+    render(
+      <FounderInquiryForm type="expired_link_recovery" source="expired_link" />,
+    );
+
+    expect(screen.getByLabelText(/^name$/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/business name/i)).toBeInTheDocument();
+  });
+
+  it("hides submitter inputs when hideSubmitterFields=true (signed-in flow)", () => {
+    render(
+      <FounderInquiryForm
+        type="more_credits"
+        source="zero_balance"
+        defaultName="Anita"
+        defaultEmail="anita@example.com"
+        defaultBusinessName="Cafe Arabica"
+        hideSubmitterFields
+      />,
+    );
+
+    // Submitter fields are not in the DOM at all — we don't show them and
+    // then hide via CSS. Less visual noise, smaller form.
+    expect(screen.queryByLabelText(/^name$/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText(/^email/i),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText(/business name/i),
+    ).not.toBeInTheDocument();
+
+    // The message field still renders — that's the point of the form.
+    expect(screen.getByLabelText(/^message/i)).toBeInTheDocument();
+  });
+
+  it("pre-fills submitter inputs when defaultName/Email/BusinessName provided but hideSubmitterFields=false", () => {
+    render(
+      <FounderInquiryForm
+        type="beta_request"
+        source="pricing"
+        defaultName="Anita"
+        defaultEmail="anita@example.com"
+        defaultBusinessName="Cafe Arabica"
+      />,
+    );
+
+    expect(
+      (screen.getByLabelText(/^name$/i) as HTMLInputElement).value,
+    ).toBe("Anita");
+    expect((screen.getByLabelText(/email/i) as HTMLInputElement).value).toBe(
+      "anita@example.com",
+    );
+    expect(
+      (screen.getByLabelText(/business name/i) as HTMLInputElement).value,
+    ).toBe("Cafe Arabica");
+  });
+});


### PR DESCRIPTION
## Summary

Caught during the iter-2 smoke test: a beta user clicking "Request more credits" lands on a form that asks for name, email, and business name — fields they already gave us at signup and `/onboarding`. Same for Free users on `/pricing` or the zero-balance dialog. Friction with no benefit.

After this PR: signed-in users see the dialog open straight to the message box. Submitter fields are hidden because we already have what we need.

| Visitor | Submitter inputs | Pre-fill source |
|---|---|---|
| Anonymous on `/auth/beta-link-expired` | Visible (they have to give us a way to reply) | — |
| Anonymous on `/pricing` | Visible | — |
| Signed-in Free user (any surface) | **Hidden** | `session.user.name`, `session.user.email`, `User.organizationName` |
| Signed-in beta user (zero-balance flow) | **Hidden** | Same |

## How it's plumbed

`organizationName` was already on the User row (set during `/onboarding`) but not surfaced anywhere client-side. Added to:

- [src/app/api/credits/route.ts](src/app/api/credits/route.ts) response payload
- [src/app/api/dashboard/stats/route.ts](src/app/api/dashboard/stats/route.ts) response payload
- [src/components/providers/CreditsProvider.tsx](src/components/providers/CreditsProvider.tsx) state + exposed via `useCredits()`; `refreshCredits()` picks up changes after onboarding completes

Call sites updated to pass session/credits values down to `FounderInquiryForm`:

- [src/components/dashboard/OutOfCreditsDialog.tsx](src/components/dashboard/OutOfCreditsDialog.tsx) — new optional `submitterName/Email/BusinessName` props; auto-`hideSubmitterFields={true}` when name+email both present
- [src/components/dashboard/LowCreditWarning.tsx](src/components/dashboard/LowCreditWarning.tsx) — same prop shape
- [src/components/reviews/ResponsePanel.tsx](src/components/reviews/ResponsePanel.tsx) — sources from `useSession()` + `useCredits().organizationName`
- [src/app/(dashboard)/dashboard/reviews/[id]/page.tsx](src/app/(dashboard)/dashboard/reviews/[id]/page.tsx), [generate/page.tsx](src/app/(dashboard)/dashboard/reviews/[id]/generate/page.tsx) — same
- [src/app/(dashboard)/dashboard/page.tsx](src/app/(dashboard)/dashboard/page.tsx) — pipes session + organizationName into `LowCreditWarning`
- [src/app/pricing/pricing-client.tsx](src/app/pricing/pricing-client.tsx) — outside dashboard layout, no `CreditsProvider`; the existing `/api/credits` fetch (added in PR #92 for `isBetaUser`) now captures `organizationName` from the same payload, no extra round-trip

## Tests

7 new unit tests across 4 files:

- **`tests/unit/components/shared/founder-inquiry-form.test.tsx`** — 3 cases: anonymous shows submitter inputs, `hideSubmitterFields={true}` hides them entirely, partial pre-fill populates visible inputs.
- **`tests/unit/components/dashboard/out-of-credits-dialog.test.tsx`** — 2 cases: full name+email pre-fill hides inputs in the embedded form, missing email keeps them visible with what's known pre-filled.
- **`tests/unit/components/pricing/pricing-client.test.tsx`** — 2 cases: signed-in non-beta user opening the inquiry dialog gets hidden submitter inputs; anonymous visitor keeps them.
- **`tests/unit/components/reviews/response-panel.test.tsx`** — fixed pre-existing test that broke because `ResponsePanel` now reads `useSession()`; added a `next-auth/react` mock and the new `useCredits` fields.

## Test plan

- [x] `npm run lint:strict` clean
- [x] `npm run type-check` clean
- [x] `npx vitest run` — **668 passing**, 22 skipped (was 661 + 7 new). No regressions.
- [ ] CI: PR checks
- [ ] CI: E2E against staging after merge — existing iter-2 E2E hits `/pricing` while signed out, so submitter fields should still be visible (anon path unchanged)
- [ ] Manual smoke on staging:
  - [ ] Sign in as a beta user with 0 credits. Try to generate a response. Click "Request more credits". Confirm: no Name / Email / Business name inputs, just the Message field + Submit button. Submit. Verify founder email arrives with the right `replyTo` from the session.
  - [ ] Sign in as a Free user with 0 credits. Same flow with "Request beta access". Submitter fields hidden.
  - [ ] Sign in as a Free user, visit `/pricing`, click the banner "Request beta access →". Submitter fields hidden.
  - [ ] Sign out, visit `/pricing`, click the banner. Submitter fields **visible** (they have to give us a way to reply).
  - [ ] Sign out, visit `/auth/beta-link-expired`. Submitter fields **visible**.

## Out of scope (deferred per earlier call)

- `/dashboard/settings/profile` page to edit onboarding fields — to be filed as a follow-up issue. This PR is just about the missing pre-fill at the inquiry-form layer.
- "You've already requested beta access" hint — separate follow-up.
- "Grant beta access" admin button on FounderInquiry rows — separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)