### PR TITLE
fix(onboarding): refresh CreditsProvider after submit so organizationName flows immediately

### DIFF
--- a/src/app/(dashboard)/onboarding/page.tsx
+++ b/src/app/(dashboard)/onboarding/page.tsx
@@ -59,7 +59,7 @@ import { useCredits } from "@/components/providers/CreditsProvider";
 export default function OnboardingPage() {
   const router = useRouter();
   const { update: updateSession } = useSession();
-  const { isBetaUser } = useCredits();
+  const { isBetaUser, refreshCredits } = useCredits();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -110,6 +110,20 @@ export default function OnboardingPage() {
         await updateSession?.();
       } catch {
         // Non-fatal
+      }
+
+      // Refresh CreditsProvider state so the newly-saved organizationName
+      // (and any other onboarding fields it surfaces) is in memory before
+      // the user reaches /dashboard. Without this, the in-memory state
+      // stays at the value baked in when the dashboard layout first
+      // mounted (typically null for a fresh signup), and downstream
+      // surfaces — most notably FounderInquiryForm in the OutOfCreditsDialog
+      // — pre-fill businessName as null until the user signs out and back
+      // in. See iteration 2 follow-up.
+      try {
+        await refreshCredits();
+      } catch {
+        // Non-fatal — value will refresh on next dashboard load anyway.
       }
 
       router.push("/dashboard");


### PR DESCRIPTION
## Summary

**Bug caught in iter-2 smoke test:** A new user completing `/onboarding` had to log out and back in before their organisation name would pre-fill the `FounderInquiryForm` in the "Request more credits" / "Request beta access" dialogs. The DB write succeeded — but `CreditsProvider`'s in-memory state was frozen at the value from when the dashboard layout first mounted (`null` for a fresh signup). Client-side navigation to `/dashboard` keeps the layout instance alive, so the new `organizationName` never reached the in-memory store.

**Fix (single line):** call `refreshCredits()` right after `updateSession()` in the onboarding submit handler. `refreshCredits` hits `/api/dashboard/stats`, which already returns `organizationName` (PR #93), so this is the single missing kick that brings the state in line with the DB.

```ts
// in onboarding/page.tsx onSubmit, after updateSession()
try {
  await refreshCredits();
} catch {
  // Non-fatal — value will refresh on next dashboard load anyway.
}

router.push("/dashboard");
```

## Why no unit test

The only meaningful assertion would be *"refreshCredits is called after updateSession"* which requires deep mocking of `react-hook-form` to invoke the submit handler — heavy ceremony for a one-line sequencing change. The change is mechanical and the risk of regression is low.

The right shape of test here is an **E2E that completes `/onboarding` → opens a credit dialog → asserts the business name is pre-filled** (or rather, that submitter fields are hidden entirely because all three pre-fill values are present). That's covered by manual smoke today, and I'd file an E2E follow-up rather than block this fix.

## Files

- [src/app/(dashboard)/onboarding/page.tsx](src/app/(dashboard)/onboarding/page.tsx) — destructure `refreshCredits` from `useCredits()`, call it after `updateSession()`.

## Test plan

- [x] `npm run lint:strict` clean
- [x] `npm run type-check` clean
- [x] `npx vitest run` (component tests targeted) — 130 passing, no regressions
- [ ] CI: PR checks
- [ ] CI: E2E against staging after merge
- [ ] Manual smoke on staging:
  - [ ] Sign up as a fresh user via invite link
  - [ ] Complete onboarding with org name "Test Bakery"
  - [ ] Without logging out: drain credits to 0 in Supabase
  - [ ] Try to generate a response → "Request more credits" dialog opens
  - [ ] Click the CTA → inquiry form opens with submitter fields hidden (we have name, email, and business name)
  - [ ] Submit → admin email lands with "Test Bakery" in the body, no need for relogin

## Out of scope

- E2E test for onboarding → zero-balance flow (file as follow-up)
- `/dashboard/settings/profile` page (already on the follow-up list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)