### PR TITLE
feat(settings): add /dashboard/settings/profile page with autosave

### DIFF
--- a/src/app/(dashboard)/dashboard/settings/page.tsx
+++ b/src/app/(dashboard)/dashboard/settings/page.tsx
@@ -24,8 +24,7 @@ const settingsSections = [
     description: "Manage your personal information and account details.",
     href: "/dashboard/settings/profile",
     icon: User,
-    available: false,
-    comingSoon: true,
+    available: true,
   },
   {
     title: "Billing & Subscription",

--- a/src/app/(dashboard)/dashboard/settings/profile/page.tsx
+++ b/src/app/(dashboard)/dashboard/settings/profile/page.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { ProfileForm } from "@/components/settings";
+
+/**
+ * /dashboard/settings/profile — edit the fields captured at /onboarding plus
+ * display name. Replaces the "Coming Soon" placeholder on the settings index.
+ *
+ * Out of scope (file as separate work):
+ *  - Email change (needs re-verification flow)
+ *  - Password change UI (existing /auth/forgot-password flow is linked)
+ *  - GDPR data export / account deletion
+ */
+export default function ProfileSettingsPage() {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-4">
+        <Button variant="ghost" size="icon" asChild>
+          <Link href="/dashboard/settings">
+            <ArrowLeft className="h-4 w-4" />
+          </Link>
+        </Button>
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Profile</h1>
+          <p className="text-muted-foreground mt-2">
+            Update your account and business details.
+          </p>
+        </div>
+      </div>
+
+      <ProfileForm />
+    </div>
+  );
+}

--- a/src/app/api/user/settings/profile/route.ts
+++ b/src/app/api/user/settings/profile/route.ts
@@ -1,0 +1,250 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { settingsProfileUpdateSchema } from "@/lib/validations";
+
+/**
+ * PATCH /api/user/settings/profile
+ *
+ * Settings-page partial-update route. Distinct from PATCH /api/user/profile
+ * (the onboarding submission) because:
+ *
+ *  - This route accepts a partial body — any subset of editable fields, one
+ *    at a time. The onboarding route demands the full required-field set.
+ *  - This route never fires a FounderInquiry. Beta intent / challenge text
+ *    are signup-only signal; editing them post-signup makes no sense and
+ *    would create duplicate inquiries.
+ *  - This route updates the user's display name (User.name). The onboarding
+ *    route doesn't, because name is set at signup.
+ *  - locationName is an optional partial update here. If the user has no
+ *    Location row yet (somehow), one is created — same upsert semantics as
+ *    onboarding.
+ *
+ * All updates run in a single transaction so a name/location pair never lands
+ * half-applied. Same shape as the onboarding transaction in
+ * src/app/api/user/profile/route.ts.
+ */
+export async function PATCH(request: Request) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: { code: "UNAUTHORIZED", message: "Authentication required" },
+      },
+      { status: 401 },
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      {
+        success: false,
+        error: { code: "VALIDATION_ERROR", message: "Invalid request body" },
+      },
+      { status: 400 },
+    );
+  }
+
+  const parsed = settingsProfileUpdateSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          code: "VALIDATION_ERROR",
+          message: parsed.error.issues[0]?.message ?? "Invalid input",
+          details: parsed.error.flatten().fieldErrors,
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  const data = parsed.data;
+  const userId = session.user.id;
+
+  // Separate the user-row update from the location update because they live on
+  // different tables. Both happen in one transaction.
+  const userUpdate: Record<string, unknown> = {};
+  if (data.name !== undefined) userUpdate.name = data.name;
+  if (data.organizationName !== undefined) userUpdate.organizationName = data.organizationName;
+  if (data.industry !== undefined) userUpdate.industry = data.industry;
+  if (data.country !== undefined) userUpdate.country = data.country;
+  if (data.locationCountEstimate !== undefined)
+    userUpdate.locationCountEstimate = data.locationCountEstimate;
+  if (data.primaryPlatform !== undefined) userUpdate.primaryPlatform = data.primaryPlatform;
+
+  // Catch the unlikely case where every field in the payload was undefined
+  // after the optional-chain — refine guards a non-empty object but doesn't
+  // guarantee at least one non-undefined value at runtime when nullables are
+  // sent as `undefined`. Cheap defensive check.
+  if (Object.keys(userUpdate).length === 0 && data.locationName === undefined) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: { code: "VALIDATION_ERROR", message: "No fields to update" },
+      },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const result = await prisma.$transaction(async (tx) => {
+      let updatedUser = null;
+      if (Object.keys(userUpdate).length > 0) {
+        updatedUser = await tx.user.update({
+          where: { id: userId },
+          data: userUpdate,
+          select: {
+            id: true,
+            email: true,
+            name: true,
+            organizationName: true,
+            industry: true,
+            country: true,
+            locationCountEstimate: true,
+            primaryPlatform: true,
+            isBetaUser: true,
+            tier: true,
+          },
+        });
+      } else {
+        updatedUser = await tx.user.findUnique({
+          where: { id: userId },
+          select: {
+            id: true,
+            email: true,
+            name: true,
+            organizationName: true,
+            industry: true,
+            country: true,
+            locationCountEstimate: true,
+            primaryPlatform: true,
+            isBetaUser: true,
+            tier: true,
+          },
+        });
+      }
+
+      if (!updatedUser) {
+        // user.update would have thrown if the row didn't exist; findUnique
+        // can return null if the user was deleted concurrently.
+        throw new Error("USER_NOT_FOUND");
+      }
+
+      let location = null;
+      if (data.locationName !== undefined) {
+        const existingLocation = await tx.location.findFirst({
+          where: { userId },
+          orderBy: { createdAt: "asc" },
+        });
+        if (existingLocation) {
+          location = await tx.location.update({
+            where: { id: existingLocation.id },
+            data: { name: data.locationName },
+            select: { id: true, name: true },
+          });
+        } else {
+          location = await tx.location.create({
+            data: { userId, name: data.locationName },
+            select: { id: true, name: true },
+          });
+        }
+      }
+
+      return { user: updatedUser, location };
+    });
+
+    return NextResponse.json({
+      success: true,
+      data: { profile: result.user, location: result.location },
+    });
+  } catch (err) {
+    if (err instanceof Error && err.message === "USER_NOT_FOUND") {
+      return NextResponse.json(
+        {
+          success: false,
+          error: { code: "NOT_FOUND", message: "User not found" },
+        },
+        { status: 404 },
+      );
+    }
+    console.error("Settings profile update error:", err);
+    return NextResponse.json(
+      {
+        success: false,
+        error: { code: "INTERNAL_ERROR", message: "Failed to update profile" },
+      },
+      { status: 500 },
+    );
+  }
+}
+
+/**
+ * GET /api/user/settings/profile
+ *
+ * Returns the current profile shape for the settings page to seed its form
+ * state. Same fields as PATCH plus the user's first Location row.
+ */
+export async function GET() {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: { code: "UNAUTHORIZED", message: "Authentication required" },
+      },
+      { status: 401 },
+    );
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: session.user.id },
+    select: {
+      id: true,
+      email: true,
+      name: true,
+      organizationName: true,
+      industry: true,
+      country: true,
+      locationCountEstimate: true,
+      primaryPlatform: true,
+      isBetaUser: true,
+      tier: true,
+    },
+  });
+
+  if (!user) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: { code: "NOT_FOUND", message: "User not found" },
+      },
+      { status: 404 },
+    );
+  }
+
+  const location = await prisma.location.findFirst({
+    where: { userId: session.user.id },
+    orderBy: { createdAt: "asc" },
+    select: { id: true, name: true },
+  });
+
+  // Also expose whether the user has a credentials-account password set. The
+  // settings UI uses this to decide whether to show "Change password" — OAuth-
+  // only users have no password and no flow that makes sense for them.
+  const userWithPassword = await prisma.user.findUnique({
+    where: { id: session.user.id },
+    select: { password: true },
+  });
+  const hasPassword = Boolean(userWithPassword?.password);
+
+  return NextResponse.json({
+    success: true,
+    data: { profile: user, location, hasPassword },
+  });
+}

--- a/src/components/settings/ProfileForm.tsx
+++ b/src/components/settings/ProfileForm.tsx
@@ -1,0 +1,555 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import { useSession } from "next-auth/react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
+import {
+  Building2,
+  Briefcase,
+  Globe,
+  MapPin,
+  User as UserIcon,
+  Mail,
+  KeyRound,
+  Loader2,
+  Cloud,
+  CloudOff,
+} from "lucide-react";
+import Link from "next/link";
+import { toast } from "sonner";
+import {
+  INDUSTRIES,
+  COUNTRIES,
+  PLATFORMS,
+  VALIDATION_LIMITS,
+  TIER_LIMITS,
+  type Industry,
+  type Country,
+  type Platform,
+} from "@/lib/constants";
+import { useCredits } from "@/components/providers/CreditsProvider";
+
+interface ProfileData {
+  id: string;
+  email: string;
+  name: string | null;
+  organizationName: string | null;
+  industry: string | null;
+  country: string | null;
+  locationCountEstimate: number | null;
+  primaryPlatform: string | null;
+  isBetaUser: boolean;
+  tier: string;
+}
+
+interface LocationData {
+  id: string;
+  name: string;
+}
+
+// Auto-save debounce. Matches BrandVoiceForm for UX consistency.
+const AUTO_SAVE_DELAY = 1500;
+
+type SaveStatus = "saved" | "saving" | "unsaved";
+
+export function ProfileForm() {
+  const { update: updateSession } = useSession();
+  const { refreshCredits } = useCredits();
+
+  const [isLoading, setIsLoading] = useState(true);
+  const [saveStatus, setSaveStatus] = useState<SaveStatus>("saved");
+  const [profile, setProfile] = useState<ProfileData | null>(null);
+  const [location, setLocation] = useState<LocationData | null>(null);
+  const [hasPassword, setHasPassword] = useState(false);
+  const [isInitialized, setIsInitialized] = useState(false);
+
+  // Form state
+  const [name, setName] = useState("");
+  const [organizationName, setOrganizationName] = useState("");
+  const [industry, setIndustry] = useState<string>("");
+  const [country, setCountry] = useState<string>("");
+  const [locationName, setLocationName] = useState("");
+  const [locationCountEstimate, setLocationCountEstimate] = useState<string>("");
+  const [primaryPlatform, setPrimaryPlatform] = useState<string>("");
+
+  const saveTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    fetchProfile();
+  }, []);
+
+  const fetchProfile = async () => {
+    try {
+      const res = await fetch("/api/user/settings/profile");
+      const data = await res.json();
+
+      if (!res.ok || !data.success) {
+        throw new Error(data.error?.message || "Failed to fetch profile");
+      }
+
+      const p: ProfileData = data.data.profile;
+      const loc: LocationData | null = data.data.location;
+      setProfile(p);
+      setLocation(loc);
+      setHasPassword(Boolean(data.data.hasPassword));
+
+      setName(p.name ?? "");
+      setOrganizationName(p.organizationName ?? "");
+      setIndustry(p.industry ?? "");
+      setCountry(p.country ?? "");
+      setLocationName(loc?.name ?? "");
+      setLocationCountEstimate(
+        p.locationCountEstimate != null ? String(p.locationCountEstimate) : "",
+      );
+      setPrimaryPlatform(p.primaryPlatform ?? "");
+
+      // Delay enabling autosave so the initial fetch doesn't immediately
+      // trigger a save round-trip. Same pattern as BrandVoiceForm.
+      setTimeout(() => setIsInitialized(true), 100);
+    } catch (error) {
+      console.error("Error fetching profile:", error);
+      toast.error("Failed to load profile settings");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // Build the partial-update payload from currently-changed fields. Only
+  // includes a field if it differs from the saved value AND is non-empty for
+  // the conceptually-required fields (name, org, industry, country, location).
+  const buildChangedPayload = useCallback(() => {
+    if (!profile) return null;
+    const payload: Record<string, unknown> = {};
+
+    const trimmedName = name.trim();
+    if (trimmedName && trimmedName !== (profile.name ?? "")) {
+      payload.name = trimmedName;
+    }
+
+    const trimmedOrg = organizationName.trim();
+    if (trimmedOrg && trimmedOrg !== (profile.organizationName ?? "")) {
+      payload.organizationName = trimmedOrg;
+    }
+
+    if (industry && industry !== (profile.industry ?? "")) {
+      payload.industry = industry;
+    }
+
+    if (country && country !== (profile.country ?? "")) {
+      payload.country = country;
+    }
+
+    const trimmedLocation = locationName.trim();
+    if (trimmedLocation && trimmedLocation !== (location?.name ?? "")) {
+      payload.locationName = trimmedLocation;
+    }
+
+    // Optional fields use null to clear. Empty input string clears the value.
+    if (locationCountEstimate.trim() === "") {
+      if (profile.locationCountEstimate != null) {
+        payload.locationCountEstimate = null;
+      }
+    } else {
+      const parsed = Number(locationCountEstimate);
+      if (
+        Number.isFinite(parsed) &&
+        Number.isInteger(parsed) &&
+        parsed >= 1 &&
+        parsed <= VALIDATION_LIMITS.LOCATION_COUNT_MAX &&
+        parsed !== profile.locationCountEstimate
+      ) {
+        payload.locationCountEstimate = parsed;
+      }
+    }
+
+    if (primaryPlatform === "") {
+      if (profile.primaryPlatform != null) {
+        payload.primaryPlatform = null;
+      }
+    } else if (primaryPlatform !== (profile.primaryPlatform ?? "")) {
+      payload.primaryPlatform = primaryPlatform;
+    }
+
+    return payload;
+  }, [
+    profile,
+    location,
+    name,
+    organizationName,
+    industry,
+    country,
+    locationName,
+    locationCountEstimate,
+    primaryPlatform,
+  ]);
+
+  const performSave = useCallback(async () => {
+    const payload = buildChangedPayload();
+    if (!payload || Object.keys(payload).length === 0) {
+      setSaveStatus("saved");
+      return;
+    }
+
+    setSaveStatus("saving");
+
+    try {
+      const res = await fetch("/api/user/settings/profile", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const data = await res.json();
+      if (!res.ok || !data.success) {
+        throw new Error(data.error?.message || "Failed to save profile");
+      }
+
+      setProfile(data.data.profile);
+      if (data.data.location) setLocation(data.data.location);
+      setSaveStatus("saved");
+
+      // Push the changes downstream so the dashboard reflects them without
+      // a reload:
+      //  - session.user.name powers the welcome header; refresh JWT if name
+      //    changed.
+      //  - CreditsProvider holds organizationName + drives FounderInquiryForm
+      //    pre-fill; refresh so the new value is visible everywhere.
+      if (payload.name !== undefined) {
+        try {
+          await updateSession?.();
+        } catch {
+          // Non-fatal
+        }
+      }
+      if (
+        payload.organizationName !== undefined ||
+        payload.name !== undefined
+      ) {
+        try {
+          await refreshCredits();
+        } catch {
+          // Non-fatal
+        }
+      }
+    } catch (error) {
+      console.error("Error saving profile:", error);
+      setSaveStatus("unsaved");
+      toast.error(error instanceof Error ? error.message : "Failed to save");
+    }
+  }, [buildChangedPayload, refreshCredits, updateSession]);
+
+  // Autosave effect — same shape as BrandVoiceForm.
+  useEffect(() => {
+    if (!isInitialized || !profile) return;
+
+    const payload = buildChangedPayload();
+    const hasChanges = payload && Object.keys(payload).length > 0;
+
+    if (!hasChanges) {
+      setSaveStatus("saved");
+      return;
+    }
+
+    setSaveStatus("unsaved");
+
+    if (saveTimeoutRef.current) {
+      clearTimeout(saveTimeoutRef.current);
+    }
+    saveTimeoutRef.current = setTimeout(() => {
+      performSave();
+    }, AUTO_SAVE_DELAY);
+
+    return () => {
+      if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current);
+    };
+  }, [isInitialized, profile, buildChangedPayload, performSave]);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  // Render the tier / beta status as a friendly label.
+  const planLabel = profile?.isBetaUser
+    ? "Closed beta"
+    : profile?.tier
+      ? `${profile.tier[0]}${profile.tier.slice(1).toLowerCase()}` // FREE → Free
+      : "Free";
+
+  const planSubtext = profile?.isBetaUser
+    ? "150 response credits / 750 sentiment per month"
+    : profile?.tier === "STARTER"
+      ? `${TIER_LIMITS.STARTER.credits} response credits / ${TIER_LIMITS.STARTER.sentimentQuota} sentiment per month`
+      : profile?.tier === "GROWTH"
+        ? `${TIER_LIMITS.GROWTH.credits} response credits / ${TIER_LIMITS.GROWTH.sentimentQuota} sentiment per month`
+        : `${TIER_LIMITS.FREE.credits} response credits / ${TIER_LIMITS.FREE.sentimentQuota} sentiment per month`;
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div>
+              <CardTitle>Profile</CardTitle>
+              <CardDescription>
+                Your account details. Changes are saved automatically.
+              </CardDescription>
+            </div>
+            <div className="flex items-center gap-2 text-sm" data-testid="save-status">
+              {saveStatus === "saving" && (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+                  <span className="text-muted-foreground">Saving...</span>
+                </>
+              )}
+              {saveStatus === "saved" && (
+                <>
+                  <Cloud className="h-4 w-4 text-green-500" />
+                  <span className="text-green-500">Saved</span>
+                </>
+              )}
+              {saveStatus === "unsaved" && (
+                <>
+                  <CloudOff className="h-4 w-4 text-yellow-500" />
+                  <span className="text-yellow-500">Unsaved</span>
+                </>
+              )}
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-8">
+          {/* Account section — display name + read-only email + password link */}
+          <section className="space-y-4">
+            <h3 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground">
+              Account
+            </h3>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="name">Display name</Label>
+              <div className="relative">
+                <UserIcon className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                <Input
+                  id="name"
+                  placeholder="Your name"
+                  className="pl-10"
+                  maxLength={VALIDATION_LIMITS.NAME_MAX}
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                />
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Shown in the dashboard header (&quot;Welcome back, &lt;name&gt;&quot;) and on
+                emails we send you.
+              </p>
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="email">Email</Label>
+              <div className="relative">
+                <Mail className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                <Input
+                  id="email"
+                  type="email"
+                  className="pl-10 bg-muted/40"
+                  value={profile?.email ?? ""}
+                  disabled
+                  readOnly
+                />
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Contact support to change your email.
+              </p>
+            </div>
+
+            {hasPassword && (
+              <div className="space-y-1.5">
+                <Label>Password</Label>
+                <div>
+                  <Link
+                    href="/auth/forgot-password"
+                    className="inline-flex items-center gap-2 text-sm text-primary hover:underline"
+                  >
+                    <KeyRound className="h-4 w-4" />
+                    Change password
+                  </Link>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  We&apos;ll email you a reset link.
+                </p>
+              </div>
+            )}
+
+            <div className="space-y-1.5">
+              <Label>Plan</Label>
+              <div className="text-sm">
+                <span className="font-medium">{planLabel}</span>
+                <span className="text-muted-foreground"> — {planSubtext}</span>
+              </div>
+            </div>
+          </section>
+
+          <Separator />
+
+          {/* Business section — onboarding fields */}
+          <section className="space-y-4">
+            <h3 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground">
+              About your business
+            </h3>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="organizationName">Organization name</Label>
+              <div className="relative">
+                <Building2 className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                <Input
+                  id="organizationName"
+                  placeholder="e.g. The Bear Bakery"
+                  className="pl-10"
+                  maxLength={VALIDATION_LIMITS.ORGANIZATION_NAME_MAX}
+                  value={organizationName}
+                  onChange={(e) => setOrganizationName(e.target.value)}
+                />
+              </div>
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="space-y-1.5">
+                <Label htmlFor="industry">Industry</Label>
+                <Select
+                  value={industry}
+                  onValueChange={(value) => setIndustry(value as Industry)}
+                >
+                  <SelectTrigger id="industry">
+                    <div className="flex items-center gap-2 w-full">
+                      <Briefcase className="h-4 w-4 text-muted-foreground" />
+                      <SelectValue placeholder="Select industry" />
+                    </div>
+                  </SelectTrigger>
+                  <SelectContent>
+                    {INDUSTRIES.map((value) => (
+                      <SelectItem key={value} value={value}>
+                        {value}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-1.5">
+                <Label htmlFor="country">Country</Label>
+                <Select
+                  value={country}
+                  onValueChange={(value) => setCountry(value as Country)}
+                >
+                  <SelectTrigger id="country">
+                    <div className="flex items-center gap-2 w-full">
+                      <Globe className="h-4 w-4 text-muted-foreground" />
+                      <SelectValue placeholder="Select country" />
+                    </div>
+                  </SelectTrigger>
+                  <SelectContent>
+                    {COUNTRIES.map((value) => (
+                      <SelectItem key={value} value={value}>
+                        {value}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+          </section>
+
+          <Separator />
+
+          {/* Location section */}
+          <section className="space-y-4">
+            <h3 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground">
+              Your location
+            </h3>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="locationName">Location name</Label>
+              <div className="relative">
+                <MapPin className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                <Input
+                  id="locationName"
+                  placeholder='e.g. "The Bear Bakery — Shoreditch"'
+                  className="pl-10"
+                  maxLength={VALIDATION_LIMITS.LOCATION_NAME_MAX}
+                  value={locationName}
+                  onChange={(e) => setLocationName(e.target.value)}
+                />
+              </div>
+              <p className="text-xs text-muted-foreground">
+                A short label to identify this location. Not a postal address.
+              </p>
+            </div>
+          </section>
+
+          <Separator />
+
+          {/* Optional / informational */}
+          <section className="space-y-4">
+            <h3 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground">
+              Tell us more (optional)
+            </h3>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="space-y-1.5">
+                <Label htmlFor="locationCountEstimate">Total locations you operate</Label>
+                <Input
+                  id="locationCountEstimate"
+                  type="number"
+                  min={1}
+                  max={VALIDATION_LIMITS.LOCATION_COUNT_MAX}
+                  placeholder="e.g. 3"
+                  value={locationCountEstimate}
+                  onChange={(e) => setLocationCountEstimate(e.target.value)}
+                />
+              </div>
+
+              <div className="space-y-1.5">
+                <Label htmlFor="primaryPlatform">Primary review platform</Label>
+                <Select
+                  value={primaryPlatform || "__none__"}
+                  onValueChange={(value) =>
+                    setPrimaryPlatform(value === "__none__" ? "" : (value as Platform))
+                  }
+                >
+                  <SelectTrigger id="primaryPlatform">
+                    <SelectValue placeholder="Select platform" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="__none__">— None —</SelectItem>
+                    {PLATFORMS.map((value) => (
+                      <SelectItem key={value} value={value}>
+                        {value}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+          </section>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/settings/index.ts
+++ b/src/components/settings/index.ts
@@ -1,4 +1,5 @@
 export { BrandVoiceForm } from "./BrandVoiceForm";
+export { ProfileForm } from "./ProfileForm";
 export { ToneSelector } from "./ToneSelector";
 export { FormalitySlider } from "./FormalitySlider";
 export { KeyPhrasesInput } from "./KeyPhrasesInput";

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -170,6 +170,46 @@ export const updateProfileSchema = z.object({
     .nullable(),
 });
 
+// /dashboard/settings/profile partial-update schema. Used by the settings
+// page's autosave flow (PATCH /api/user/settings/profile). All fields are
+// optional — the client sends only the changed field. The server enforces
+// non-empty strings via z.string().min(1) for fields that are conceptually
+// required overall (name, organizationName, industry, country, locationName);
+// they just don't all have to arrive in the same request.
+export const settingsProfileUpdateSchema = z
+  .object({
+    name: z
+      .string()
+      .min(1, "Display name is required")
+      .max(VALIDATION_LIMITS.NAME_MAX, "Display name is too long")
+      .optional(),
+    organizationName: z
+      .string()
+      .min(1, "Organization name is required")
+      .max(VALIDATION_LIMITS.ORGANIZATION_NAME_MAX, "Organization name is too long")
+      .optional(),
+    industry: z.enum(INDUSTRIES).optional(),
+    country: z.enum(COUNTRIES).optional(),
+    // Edits the user's single Location row's name. Empty string is rejected —
+    // the form should hide the field rather than send a clearing update.
+    locationName: z
+      .string()
+      .min(1, "Location name is required")
+      .max(VALIDATION_LIMITS.LOCATION_NAME_MAX, "Location name is too long")
+      .optional(),
+    locationCountEstimate: z
+      .number()
+      .int()
+      .min(1)
+      .max(VALIDATION_LIMITS.LOCATION_COUNT_MAX)
+      .optional()
+      .nullable(),
+    primaryPlatform: z.enum(PLATFORMS).optional().nullable(),
+  })
+  .refine((data) => Object.keys(data).length > 0, {
+    message: "No fields to update",
+  });
+
 // Onboarding-specific schema with the mandatory fields actually required.
 // Used by the /onboarding form submit; the broader updateProfileSchema is
 // what a future "edit profile" surface would use.
@@ -246,6 +286,7 @@ export type BrandVoiceInput = z.infer<typeof brandVoiceSchema>;
 export type TestBrandVoiceInput = z.infer<typeof testBrandVoiceSchema>;
 export type UpdateProfileInput = z.infer<typeof updateProfileSchema>;
 export type OnboardingSubmitInput = z.infer<typeof onboardingSubmitSchema>;
+export type SettingsProfileUpdateInput = z.infer<typeof settingsProfileUpdateSchema>;
 export type CreateFounderInquiryInput = z.infer<typeof createFounderInquirySchema>;
 export type ResolveFounderInquiryInput = z.infer<typeof resolveFounderInquirySchema>;
 export type PaginationInput = z.infer<typeof paginationSchema>;

--- a/tests/unit/api/user/settings-profile.test.ts
+++ b/tests/unit/api/user/settings-profile.test.ts
@@ -1,0 +1,339 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// MVP Phase 1 follow-up: GET + PATCH /api/user/settings/profile
+// Settings-page partial-update route. Distinct from /api/user/profile
+// (the onboarding submission). See src/app/api/user/settings/profile/route.ts.
+
+const mockPrisma = vi.hoisted(() => {
+  const m = () => ({
+    findUnique: vi.fn(),
+    findFirst: vi.fn(),
+    update: vi.fn(),
+    create: vi.fn(),
+  });
+  return {
+    user: m(),
+    location: m(),
+    $transaction: vi.fn(),
+  };
+});
+
+const mockAuth = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/auth', () => ({ auth: mockAuth }));
+vi.mock('@/lib/prisma', () => ({ prisma: mockPrisma }));
+
+import { GET, PATCH } from '@/app/api/user/settings/profile/route';
+
+function makePatch(body: unknown): Request {
+  return new Request('http://localhost/api/user/settings/profile', {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // $transaction passes its callback the same mockPrisma so transactional
+  // assertions can verify the calls.
+  mockPrisma.$transaction.mockImplementation(
+    async (cb: (tx: typeof mockPrisma) => Promise<unknown>) => cb(mockPrisma),
+  );
+});
+
+describe('GET /api/user/settings/profile', () => {
+  it('returns 401 when not authenticated', async () => {
+    mockAuth.mockResolvedValue(null);
+
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 404 when the user row is missing', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'gone', email: 'a@x.com', name: 'A' } });
+    mockPrisma.user.findUnique.mockResolvedValue(null);
+
+    const res = await GET();
+    expect(res.status).toBe(404);
+  });
+
+  it('returns profile + location + hasPassword for an authenticated user', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'u-1', email: 'a@x.com', name: 'A' } });
+
+    // First findUnique: user select for profile fields.
+    // Second findUnique: hasPassword check.
+    mockPrisma.user.findUnique
+      .mockResolvedValueOnce({
+        id: 'u-1',
+        email: 'a@x.com',
+        name: 'Alice',
+        organizationName: 'Bear Bakery',
+        industry: 'Cafe',
+        country: 'United Kingdom',
+        locationCountEstimate: 3,
+        primaryPlatform: 'Google',
+        isBetaUser: true,
+        tier: 'FREE',
+      })
+      .mockResolvedValueOnce({ password: 'hashed-bcrypt-string' });
+
+    mockPrisma.location.findFirst.mockResolvedValue({
+      id: 'loc-1',
+      name: 'Bear Bakery — Shoreditch',
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+    expect(json.data.profile.name).toBe('Alice');
+    expect(json.data.profile.organizationName).toBe('Bear Bakery');
+    expect(json.data.profile.isBetaUser).toBe(true);
+    expect(json.data.location.name).toBe('Bear Bakery — Shoreditch');
+    expect(json.data.hasPassword).toBe(true);
+  });
+
+  it('returns hasPassword=false for OAuth-only users (no password row)', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'u-oauth', email: 'o@x.com', name: 'O' } });
+
+    mockPrisma.user.findUnique
+      .mockResolvedValueOnce({
+        id: 'u-oauth',
+        email: 'o@x.com',
+        name: 'OAuth User',
+        organizationName: null,
+        industry: null,
+        country: null,
+        locationCountEstimate: null,
+        primaryPlatform: null,
+        isBetaUser: false,
+        tier: 'FREE',
+      })
+      .mockResolvedValueOnce({ password: null });
+
+    mockPrisma.location.findFirst.mockResolvedValue(null);
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data.hasPassword).toBe(false);
+    expect(json.data.location).toBeNull();
+  });
+});
+
+describe('PATCH /api/user/settings/profile', () => {
+  it('returns 401 when not authenticated', async () => {
+    mockAuth.mockResolvedValue(null);
+
+    const res = await PATCH(makePatch({ name: 'Alice' }));
+    expect(res.status).toBe(401);
+    expect(mockPrisma.user.update).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for malformed JSON', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'u-1', email: 'a@x.com', name: 'A' } });
+
+    const req = new Request('http://localhost/api/user/settings/profile', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'not-json',
+    });
+    const res = await PATCH(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when the body is empty (no fields to update)', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'u-1', email: 'a@x.com', name: 'A' } });
+
+    const res = await PATCH(makePatch({}));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when industry is not in the closed set', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'u-1', email: 'a@x.com', name: 'A' } });
+
+    const res = await PATCH(
+      makePatch({ industry: 'Underwater Basket Weaving' }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when name is an empty string', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'u-1', email: 'a@x.com', name: 'A' } });
+
+    const res = await PATCH(makePatch({ name: '' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('updates only the name when only name is provided', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'u-1', email: 'a@x.com', name: 'A' } });
+    mockPrisma.user.update.mockResolvedValue({
+      id: 'u-1',
+      email: 'a@x.com',
+      name: 'Alice Updated',
+      organizationName: 'Bear Bakery',
+      industry: 'Cafe',
+      country: 'United Kingdom',
+      locationCountEstimate: null,
+      primaryPlatform: null,
+      isBetaUser: true,
+      tier: 'FREE',
+    });
+
+    const res = await PATCH(makePatch({ name: 'Alice Updated' }));
+    expect(res.status).toBe(200);
+
+    const json = await res.json();
+    expect(json.success).toBe(true);
+    expect(json.data.profile.name).toBe('Alice Updated');
+
+    // Only `name` should be in the update payload — partial update.
+    expect(mockPrisma.user.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'u-1' },
+        data: { name: 'Alice Updated' },
+      }),
+    );
+    expect(mockPrisma.location.update).not.toHaveBeenCalled();
+    expect(mockPrisma.location.create).not.toHaveBeenCalled();
+  });
+
+  it('updates only the organizationName + flows through CreditsProvider trigger', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'u-1', email: 'a@x.com', name: 'A' } });
+    mockPrisma.user.update.mockResolvedValue({
+      id: 'u-1',
+      organizationName: 'New Org Name',
+    });
+
+    const res = await PATCH(makePatch({ organizationName: 'New Org Name' }));
+    expect(res.status).toBe(200);
+
+    expect(mockPrisma.user.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: { organizationName: 'New Org Name' },
+      }),
+    );
+  });
+
+  it('renames the existing Location when locationName is provided', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'u-1', email: 'a@x.com', name: 'A' } });
+    mockPrisma.user.findUnique.mockResolvedValue({ id: 'u-1' });
+    mockPrisma.location.findFirst.mockResolvedValue({
+      id: 'loc-existing',
+      name: 'Default Location',
+    });
+    mockPrisma.location.update.mockResolvedValue({
+      id: 'loc-existing',
+      name: 'Shoreditch Branch',
+    });
+
+    const res = await PATCH(makePatch({ locationName: 'Shoreditch Branch' }));
+    expect(res.status).toBe(200);
+
+    expect(mockPrisma.location.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'loc-existing' },
+        data: { name: 'Shoreditch Branch' },
+      }),
+    );
+    expect(mockPrisma.location.create).not.toHaveBeenCalled();
+  });
+
+  it('creates a Location when none exists and locationName is provided', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'u-1', email: 'a@x.com', name: 'A' } });
+    mockPrisma.user.findUnique.mockResolvedValue({ id: 'u-1' });
+    mockPrisma.location.findFirst.mockResolvedValue(null);
+    mockPrisma.location.create.mockResolvedValue({
+      id: 'loc-new',
+      name: 'Shoreditch Branch',
+    });
+
+    const res = await PATCH(makePatch({ locationName: 'Shoreditch Branch' }));
+    expect(res.status).toBe(200);
+
+    expect(mockPrisma.location.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: { userId: 'u-1', name: 'Shoreditch Branch' },
+      }),
+    );
+  });
+
+  it('updates user + location in one combined call when both are provided', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'u-1', email: 'a@x.com', name: 'A' } });
+    mockPrisma.user.update.mockResolvedValue({
+      id: 'u-1',
+      organizationName: 'Bear Bakery',
+    });
+    mockPrisma.location.findFirst.mockResolvedValue({ id: 'loc-1' });
+    mockPrisma.location.update.mockResolvedValue({ id: 'loc-1' });
+
+    const res = await PATCH(
+      makePatch({
+        organizationName: 'Bear Bakery',
+        locationName: 'Bear Bakery — Shoreditch',
+      }),
+    );
+    expect(res.status).toBe(200);
+
+    expect(mockPrisma.user.update).toHaveBeenCalled();
+    expect(mockPrisma.location.update).toHaveBeenCalled();
+    // Both writes go through the same $transaction call.
+    expect(mockPrisma.$transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT fire a FounderInquiry on settings update (distinct from onboarding)', async () => {
+    // The onboarding route fires beta_request inquiries when intent is set;
+    // the settings route never does. This is the key behavioral difference.
+    mockAuth.mockResolvedValue({ user: { id: 'u-1', email: 'a@x.com', name: 'A' } });
+    mockPrisma.user.update.mockResolvedValue({
+      id: 'u-1',
+      organizationName: 'Some Org',
+    });
+
+    const res = await PATCH(
+      makePatch({
+        organizationName: 'Some Org',
+        // The settings schema doesn't even accept these — added here to
+        // confirm they're rejected, not silently used to spam founder.
+        signupIntent: 'yes',
+        signupChallengeText: 'I want beta access NOW',
+      }),
+    );
+    // The settings schema strips unknown fields. The route succeeds for the
+    // valid fields only; no founder inquiry was created.
+    expect([200, 400]).toContain(res.status);
+    // Either way: nothing fired
+    // (we didn't mock founderInquiry — it would have thrown if called).
+  });
+
+  it('clears locationCountEstimate when empty value provided', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'u-1', email: 'a@x.com', name: 'A' } });
+    mockPrisma.user.update.mockResolvedValue({
+      id: 'u-1',
+      locationCountEstimate: null,
+    });
+
+    const res = await PATCH(makePatch({ locationCountEstimate: null }));
+    expect(res.status).toBe(200);
+
+    expect(mockPrisma.user.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: { locationCountEstimate: null },
+      }),
+    );
+  });
+
+  it('returns 404 when the user has been deleted concurrently', async () => {
+    // Edge: the body is valid but only updates location, so the route falls
+    // back to findUnique to get the current user shape. If that returns null
+    // we throw USER_NOT_FOUND.
+    mockAuth.mockResolvedValue({ user: { id: 'gone', email: 'g@x.com', name: 'G' } });
+    mockPrisma.user.findUnique.mockResolvedValue(null);
+    mockPrisma.location.findFirst.mockResolvedValue(null);
+    mockPrisma.location.create.mockResolvedValue({ id: 'loc-new' });
+
+    const res = await PATCH(makePatch({ locationName: 'Some Place' }));
+    expect(res.status).toBe(404);
+  });
+});

--- a/tests/unit/components/settings/profile-form.test.tsx
+++ b/tests/unit/components/settings/profile-form.test.tsx
@@ -1,0 +1,314 @@
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// MVP Phase 1 follow-up: ProfileForm component on /dashboard/settings/profile.
+// See src/components/settings/ProfileForm.tsx.
+//
+// We use real timers here. The autosave debounce is 1500ms; the tests wait
+// it out with waitFor + a slightly-larger ceiling. Fake timers + waitFor mix
+// poorly because waitFor relies on real timers under the hood.
+
+const updateSessionMock = vi.fn();
+const refreshCreditsMock = vi.fn();
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => ({
+    data: { user: { id: "u-1", email: "a@x.com", name: "Alice" } },
+    update: updateSessionMock,
+    status: "authenticated",
+  }),
+}));
+
+vi.mock("@/components/providers/CreditsProvider", () => ({
+  useCredits: () => ({
+    credits: 150,
+    creditsTotal: 150,
+    creditsResetDate: "2026-06-15T00:00:00Z",
+    sentimentCredits: 750,
+    sentimentTotal: 750,
+    sentimentResetDate: "2026-06-15T00:00:00Z",
+    tier: "FREE",
+    isBetaUser: true,
+    currentPhase: "phase_1" as const,
+    organizationName: "Bear Bakery",
+    setCredits: vi.fn(),
+    refreshCredits: refreshCreditsMock,
+  }),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children, href, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+import { ProfileForm } from "@/components/settings/ProfileForm";
+
+const PROFILE_FIXTURE = {
+  id: "u-1",
+  email: "a@x.com",
+  name: "Alice",
+  organizationName: "Bear Bakery",
+  industry: "Cafe",
+  country: "United Kingdom",
+  locationCountEstimate: 3,
+  primaryPlatform: "Google",
+  isBetaUser: true,
+  tier: "FREE",
+};
+
+const LOCATION_FIXTURE = {
+  id: "loc-1",
+  name: "Bear Bakery — Shoreditch",
+};
+
+function makeGetResponse(overrides: Record<string, unknown> = {}) {
+  return {
+    ok: true,
+    json: async () => ({
+      success: true,
+      data: {
+        profile: { ...PROFILE_FIXTURE, ...((overrides.profile as object) ?? {}) },
+        location: (overrides.location as unknown) ?? LOCATION_FIXTURE,
+        hasPassword: (overrides.hasPassword as boolean) ?? true,
+      },
+    }),
+  };
+}
+
+function makePatchResponse(profileOverrides: Record<string, unknown> = {}) {
+  return {
+    ok: true,
+    json: async () => ({
+      success: true,
+      data: {
+        profile: { ...PROFILE_FIXTURE, ...profileOverrides },
+      },
+    }),
+  };
+}
+
+// Slight ceiling above the 1500ms debounce. Keeps tests under ~2s each.
+const AUTOSAVE_WAIT_MS = 2500;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("ProfileForm — render + fetch", () => {
+  it("seeds form fields from GET /api/user/settings/profile", async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce(makeGetResponse());
+
+    render(<ProfileForm />);
+
+    await waitFor(() => {
+      expect((screen.getByLabelText(/display name/i) as HTMLInputElement).value).toBe("Alice");
+    });
+    expect((screen.getByLabelText(/organization name/i) as HTMLInputElement).value).toBe(
+      "Bear Bakery",
+    );
+    expect((screen.getByLabelText(/location name/i) as HTMLInputElement).value).toBe(
+      "Bear Bakery — Shoreditch",
+    );
+    expect((screen.getByLabelText(/^email$/i) as HTMLInputElement).value).toBe("a@x.com");
+    expect((screen.getByLabelText(/^email$/i) as HTMLInputElement).disabled).toBe(true);
+    expect(screen.getByText(/closed beta/i)).toBeInTheDocument();
+  });
+
+  it("hides 'Change password' link for OAuth-only users", async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce(makeGetResponse({ hasPassword: false }));
+
+    render(<ProfileForm />);
+
+    // Wait for the initial fetch to populate so we can confidently assert
+    // the absence of the link.
+    await waitFor(() => {
+      expect(screen.getByLabelText(/display name/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/change password/i)).not.toBeInTheDocument();
+  });
+
+  it("shows 'Change password' link for credentials users", async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce(makeGetResponse({ hasPassword: true }));
+
+    render(<ProfileForm />);
+    await waitFor(() => {
+      expect(screen.getByText(/change password/i)).toBeInTheDocument();
+    });
+  });
+});
+
+describe("ProfileForm — autosave", () => {
+  it("PATCHes only the changed name field after the debounce", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(makeGetResponse())
+      .mockResolvedValueOnce(makePatchResponse({ name: "Alice Updated" }));
+    global.fetch = fetchMock;
+
+    render(<ProfileForm />);
+
+    await waitFor(() => {
+      expect((screen.getByLabelText(/display name/i) as HTMLInputElement).value).toBe("Alice");
+    });
+
+    const nameInput = screen.getByLabelText(/display name/i);
+    fireEvent.change(nameInput, { target: { value: "Alice Updated" } });
+
+    // Status flips to 'Unsaved' immediately
+    await waitFor(() => {
+      expect(screen.getByText(/^unsaved$/i)).toBeInTheDocument();
+    });
+
+    // Wait out the debounce and the PATCH round-trip
+    await waitFor(
+      () => {
+        const patchCall = fetchMock.mock.calls.find(
+          (c) => (c[1] as RequestInit)?.method === "PATCH",
+        );
+        expect(patchCall).toBeTruthy();
+      },
+      { timeout: AUTOSAVE_WAIT_MS },
+    );
+
+    const patchCall = fetchMock.mock.calls.find(
+      (c) => (c[1] as RequestInit)?.method === "PATCH",
+    );
+    expect(JSON.parse((patchCall![1] as RequestInit).body as string)).toEqual({
+      name: "Alice Updated",
+    });
+
+    // Name change triggers updateSession + refreshCredits
+    await waitFor(() => {
+      expect(updateSessionMock).toHaveBeenCalled();
+      expect(refreshCreditsMock).toHaveBeenCalled();
+    });
+  });
+
+  it("PATCHes only the changed organizationName field after the debounce", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(makeGetResponse())
+      .mockResolvedValueOnce(makePatchResponse({ organizationName: "New Org" }));
+    global.fetch = fetchMock;
+
+    render(<ProfileForm />);
+    await waitFor(() => {
+      expect((screen.getByLabelText(/organization name/i) as HTMLInputElement).value).toBe(
+        "Bear Bakery",
+      );
+    });
+
+    fireEvent.change(screen.getByLabelText(/organization name/i), {
+      target: { value: "New Org" },
+    });
+
+    await waitFor(
+      () => {
+        const patchCall = fetchMock.mock.calls.find(
+          (c) => (c[1] as RequestInit)?.method === "PATCH",
+        );
+        expect(patchCall).toBeTruthy();
+      },
+      { timeout: AUTOSAVE_WAIT_MS },
+    );
+
+    const patchCall = fetchMock.mock.calls.find(
+      (c) => (c[1] as RequestInit)?.method === "PATCH",
+    );
+    expect(JSON.parse((patchCall![1] as RequestInit).body as string)).toEqual({
+      organizationName: "New Org",
+    });
+
+    // organizationName change triggers refreshCredits (not updateSession)
+    await waitFor(() => {
+      expect(refreshCreditsMock).toHaveBeenCalled();
+    });
+  });
+
+  it("PATCHes only the changed locationName when location is edited", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(makeGetResponse())
+      .mockResolvedValueOnce(makePatchResponse());
+    global.fetch = fetchMock;
+
+    render(<ProfileForm />);
+    await waitFor(() => {
+      expect((screen.getByLabelText(/location name/i) as HTMLInputElement).value).toBe(
+        "Bear Bakery — Shoreditch",
+      );
+    });
+
+    fireEvent.change(screen.getByLabelText(/location name/i), {
+      target: { value: "New Branch" },
+    });
+
+    await waitFor(
+      () => {
+        const patchCall = fetchMock.mock.calls.find(
+          (c) => (c[1] as RequestInit)?.method === "PATCH",
+        );
+        expect(patchCall).toBeTruthy();
+      },
+      { timeout: AUTOSAVE_WAIT_MS },
+    );
+
+    const patchCall = fetchMock.mock.calls.find(
+      (c) => (c[1] as RequestInit)?.method === "PATCH",
+    );
+    expect(JSON.parse((patchCall![1] as RequestInit).body as string)).toEqual({
+      locationName: "New Branch",
+    });
+  });
+
+  it("does not PATCH when the field is changed back to its original value", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(makeGetResponse());
+    global.fetch = fetchMock;
+
+    render(<ProfileForm />);
+    await waitFor(() => {
+      expect((screen.getByLabelText(/display name/i) as HTMLInputElement).value).toBe("Alice");
+    });
+
+    const nameInput = screen.getByLabelText(/display name/i);
+    fireEvent.change(nameInput, { target: { value: "Alice Edited" } });
+    fireEvent.change(nameInput, { target: { value: "Alice" } });
+
+    // Wait longer than the debounce — no PATCH should fire
+    await new Promise((resolve) => setTimeout(resolve, AUTOSAVE_WAIT_MS));
+
+    const patchCalls = fetchMock.mock.calls.filter(
+      (c) => (c[1] as RequestInit)?.method === "PATCH",
+    );
+    expect(patchCalls.length).toBe(0);
+  });
+
+  it("does not PATCH when a required field is cleared to empty", async () => {
+    // buildChangedPayload drops required fields (name, org, etc.) that have
+    // been cleared. The field doesn't autosave; the user has to type
+    // something valid. Avoids spam validation errors mid-typing.
+    const fetchMock = vi.fn().mockResolvedValueOnce(makeGetResponse());
+    global.fetch = fetchMock;
+
+    render(<ProfileForm />);
+    await waitFor(() => {
+      expect((screen.getByLabelText(/display name/i) as HTMLInputElement).value).toBe("Alice");
+    });
+
+    fireEvent.change(screen.getByLabelText(/display name/i), { target: { value: "" } });
+
+    await new Promise((resolve) => setTimeout(resolve, AUTOSAVE_WAIT_MS));
+
+    const patchCalls = fetchMock.mock.calls.filter(
+      (c) => (c[1] as RequestInit)?.method === "PATCH",
+    );
+    expect(patchCalls.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Users could collect onboarding info — organisation name, industry, country, location name — but couldn't edit it after signup. Same for display name (set at signup, used in the dashboard header). The Profile entry on the settings index was a "Coming Soon" placeholder.

This PR makes Profile real. Same autosave UX as Brand Voice: 1.5s debounce + status indicator (Saved / Saving / Unsaved).

## Editable fields

| Field | Source | Note |
|---|---|---|
| Display name | `User.name` | Shown in dashboard header |
| Organisation name | `User.organizationName` | Onboarding field |
| Industry | `User.industry` | Closed-set dropdown |
| Country | `User.country` | Closed-set dropdown |
| Location name | `Location.name` | Renames user's single Location row |
| Locations operated (optional) | `User.locationCountEstimate` | — |
| Primary platform (optional) | `User.primaryPlatform` | — |

## Read-only

- **Email** — disabled input with "Contact support to change your email" hint
- **Password** — link to existing `/auth/forgot-password` flow. Hidden entirely for OAuth-only users (no password to reset)
- **Plan** — labelled "Closed beta" for `isBetaUser`, otherwise "Free / Starter / Growth" with credit allocation

## Plumbing

- **New schema** `settingsProfileUpdateSchema` in [src/lib/validations.ts](src/lib/validations.ts) — all fields optional (partial autosave) but each enforces non-empty for the conceptually-required ones. Distinct from `onboardingSubmitSchema` which demands the full required set.
- **New route** `PATCH/GET /api/user/settings/profile` in [src/app/api/user/settings/profile/route.ts](src/app/api/user/settings/profile/route.ts). Distinct from `/api/user/profile` (onboarding submission) because:
  - accepts partial bodies (autosave sends one field at a time)
  - never fires a FounderInquiry — that's onboarding-only signal
  - updates `User.name` (onboarding doesn't)
  - same Location upsert semantics
- **New component** [src/components/settings/ProfileForm.tsx](src/components/settings/ProfileForm.tsx) — mirrors `BrandVoiceForm`. After a save that changes name → `updateSession()` so the dashboard header reflects it. After a save that changes name OR organizationName → `refreshCredits()` so `CreditsProvider`'s in-memory state stays in sync (same lesson as PR #94).
- **Settings index** [src/app/(dashboard)/dashboard/settings/page.tsx](src/app/(dashboard)/dashboard/settings/page.tsx) — Profile row flipped from `available: false / comingSoon: true` to `available: true`.

## Tests (25 new, 693 total passing)

- **[tests/unit/api/user/settings-profile.test.ts](tests/unit/api/user/settings-profile.test.ts)** (17 cases):
  - 401/404 paths, GET shape including `hasPassword`
  - PATCH with partial bodies, empty body 400, invalid industry 400, empty-string name 400
  - name-only / org-only / location-only updates with the right partial-body shape
  - combined user+location updates run in a single transaction
  - no founder-inquiry firing (key behavioural difference vs onboarding)
- **[tests/unit/components/settings/profile-form.test.tsx](tests/unit/components/settings/profile-form.test.tsx)** (8 cases):
  - initial GET seeds the form fields
  - Change Password link visibility by `hasPassword`
  - autosave PATCH for each editable field with the correct partial body
  - revert-to-original doesn't PATCH
  - empty required field doesn't PATCH (no spam validation mid-typing)

## Test plan

- [x] `npm run lint:strict` clean
- [x] `npm run type-check` clean
- [x] `npx vitest run` — **693 passing**, 22 skipped (was 668 + 25 new). No regressions.
- [ ] CI: PR checks
- [ ] CI: E2E against staging after merge
- [ ] Manual smoke on staging:
  - [ ] Sign in (any account). Navigate to Settings → Profile.
  - [ ] Edit display name. Wait 1.5s. Status flips Saved. Reload — name persists. Header reads "Welcome back, <new name>".
  - [ ] Edit organisation name. Wait 1.5s. Drain credits to 0, try to generate a response → "Request more credits" → inquiry form shows new organisation name pre-filled (or fields hidden because pre-fill is complete).
  - [ ] Edit industry/country via dropdowns. Status flips Saved.
  - [ ] Edit location name. Wait 1.5s. Confirm Location row in Supabase has the new name.
  - [ ] OAuth-only user — Change password link is hidden.
  - [ ] Credentials user — clicking Change password lands on `/auth/forgot-password`.
  - [ ] Beta user — Plan section reads "Closed beta — 150 response credits / 750 sentiment per month".

## Out of scope (file as follow-ups)

- **Email change** — needs verification round-trip
- **Password change UI** — existing reset flow is linked
- **GDPR data export / account deletion** — separate compliance work

🤖 Generated with [Claude Code](https://claude.com/claude-code)