### PR TITLE
fix(settings): Change password link bounced signed-in users to /dashboard

### DIFF
--- a/src/app/(auth)/auth/forgot-password/page.tsx
+++ b/src/app/(auth)/auth/forgot-password/page.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import Link from "next/link";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { useSession } from "next-auth/react";
 import { Loader2, Mail, ArrowLeft, CheckCircle } from "lucide-react";
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -13,6 +14,10 @@ import { Label } from "@/components/ui/label";
 import { forgotPasswordSchema, type ForgotPasswordInput } from "@/lib/validations";
 
 export default function ForgotPasswordPage() {
+  const { data: session, status: sessionStatus } = useSession();
+  const isSignedIn = sessionStatus === "authenticated";
+  const sessionEmail = session?.user?.email ?? "";
+
   const [isLoading, setIsLoading] = useState(false);
   const [isSuccess, setIsSuccess] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -23,6 +28,10 @@ export default function ForgotPasswordPage() {
     formState: { errors },
   } = useForm<ForgotPasswordInput>({
     resolver: zodResolver(forgotPasswordSchema),
+    // Pre-fill the email field for signed-in users who arrived via the
+    // "Change password" link on /dashboard/settings/profile. They shouldn't
+    // have to re-type their own email to reset their password.
+    values: isSignedIn && sessionEmail ? { email: sessionEmail } : undefined,
   });
 
   const onSubmit = async (data: ForgotPasswordInput) => {
@@ -50,6 +59,11 @@ export default function ForgotPasswordPage() {
     }
   };
 
+  // Where to send the user "back" to: dashboard settings for signed-in users
+  // (the surface that brought them here), or the sign-in page otherwise.
+  const backHref = isSignedIn ? "/dashboard/settings/profile" : "/auth/signin";
+  const backLabel = isSignedIn ? "Back to profile settings" : "Back to sign in";
+
   if (isSuccess) {
     return (
       <Card>
@@ -59,18 +73,19 @@ export default function ForgotPasswordPage() {
           </div>
           <CardTitle className="text-2xl">Check your email</CardTitle>
           <CardDescription>
-            If an account exists with that email address, we&apos;ve sent a
-            password reset link.
+            {isSignedIn
+              ? "We've sent a password reset link to your email."
+              : "If an account exists with that email address, we've sent a password reset link."}
           </CardDescription>
         </CardHeader>
         <CardContent className="text-center">
           <p className="text-sm text-muted-foreground mb-4">
             The link will expire in 1 hour.
           </p>
-          <Link href="/auth/signin">
+          <Link href={backHref}>
             <Button variant="outline">
               <ArrowLeft className="mr-2 h-4 w-4" />
-              Back to sign in
+              {backLabel}
             </Button>
           </Link>
         </CardContent>
@@ -86,9 +101,13 @@ export default function ForgotPasswordPage() {
             R
           </div>
         </div>
-        <CardTitle className="text-2xl font-bold">Forgot password?</CardTitle>
+        <CardTitle className="text-2xl font-bold">
+          {isSignedIn ? "Reset your password" : "Forgot password?"}
+        </CardTitle>
         <CardDescription>
-          Enter your email and we&apos;ll send you a reset link
+          {isSignedIn
+            ? "We'll send a reset link to your email."
+            : "Enter your email and we'll send you a reset link"}
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
@@ -131,11 +150,11 @@ export default function ForgotPasswordPage() {
 
         <div className="text-center">
           <Link
-            href="/auth/signin"
+            href={backHref}
             className="text-sm text-primary hover:underline inline-flex items-center"
           >
             <ArrowLeft className="mr-1 h-3 w-3" />
-            Back to sign in
+            {backLabel}
           </Link>
         </div>
       </CardContent>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -24,13 +24,13 @@ const protectedApiRoutes = [
 // disclose that the route exists. See docs/MVP_Phase-1/MVP.md Section 13.1.
 const adminRoutes = ["/dashboard/admin", "/api/admin"];
 
-// Routes that are only for unauthenticated users
-const authRoutes = [
-  "/auth/signin",
-  "/auth/signup",
-  "/auth/forgot-password",
-  "/auth/reset-password",
-];
+// Routes that are only meaningful for unauthenticated users — authenticated
+// users get bounced to /dashboard. Sign-in and sign-up specifically; we keep
+// /auth/forgot-password and /auth/reset-password reachable for signed-in
+// users so the "Change password" link on /dashboard/settings/profile works.
+// Password-recovery flows operate the same regardless of session state
+// (they end with a click on a token link in the user's inbox).
+const authRoutes = ["/auth/signin", "/auth/signup"];
 
 function notFoundResponse(): NextResponse {
   return new NextResponse(null, { status: 404 });

--- a/tests/unit/components/auth/forgot-password.test.tsx
+++ b/tests/unit/components/auth/forgot-password.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// MVP Phase 1 follow-up: /auth/forgot-password is reachable for signed-in
+// users now (middleware fix). When signed in, the page should pre-fill the
+// email field and adjust copy so it doesn't read "forgot password?" to
+// someone who's clearly already authenticated.
+
+const useSessionMock = vi.fn();
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => useSessionMock(),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children, href, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+import ForgotPasswordPage from "@/app/(auth)/auth/forgot-password/page";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("ForgotPasswordPage", () => {
+  it("renders 'Forgot password?' copy + empty email field for signed-out visitors", () => {
+    useSessionMock.mockReturnValue({ data: null, status: "unauthenticated" });
+
+    render(<ForgotPasswordPage />);
+
+    expect(screen.getByText(/forgot password\?/i)).toBeInTheDocument();
+    // Description for signed-out users
+    expect(screen.getByText(/enter your email and we/i)).toBeInTheDocument();
+
+    const emailInput = screen.getByLabelText(/email/i) as HTMLInputElement;
+    expect(emailInput.value).toBe("");
+
+    // "Back to sign in" link for signed-out users
+    expect(
+      screen.getByRole("link", { name: /back to sign in/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders 'Reset your password' copy + pre-fills email for signed-in users", () => {
+    useSessionMock.mockReturnValue({
+      data: { user: { id: "u-1", email: "alice@example.com", name: "Alice" } },
+      status: "authenticated",
+    });
+
+    render(<ForgotPasswordPage />);
+
+    // Header copy adjusts for signed-in context — they haven't *forgotten*
+    // their password, they're just resetting it.
+    expect(screen.getByText(/reset your password/i)).toBeInTheDocument();
+    expect(screen.getByText(/we'll send a reset link to your email/i)).toBeInTheDocument();
+
+    // Email field is pre-filled from the session
+    const emailInput = screen.getByLabelText(/email/i) as HTMLInputElement;
+    expect(emailInput.value).toBe("alice@example.com");
+
+    // "Back to profile settings" link instead of "Back to sign in"
+    const backLink = screen.getByRole("link", {
+      name: /back to profile settings/i,
+    });
+    expect(backLink).toBeInTheDocument();
+    expect(backLink).toHaveAttribute("href", "/dashboard/settings/profile");
+
+    // No "Back to sign in" link
+    expect(
+      screen.queryByRole("link", { name: /back to sign in/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not pre-fill when authenticated but session has no email (defensive)", () => {
+    useSessionMock.mockReturnValue({
+      data: { user: { id: "u-1", email: null, name: "No Email" } },
+      status: "authenticated",
+    });
+
+    render(<ForgotPasswordPage />);
+
+    const emailInput = screen.getByLabelText(/email/i) as HTMLInputElement;
+    expect(emailInput.value).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary

**Bug:** The "Change password" link on `/dashboard/settings/profile` (added in PR #95) pointed at `/auth/forgot-password`, but [src/middleware.ts](src/middleware.ts) was redirecting *all* authenticated users away from `/auth/*` to `/dashboard`. So clicking the link silently bounced the user back to the dashboard.

## Fix

Narrow the middleware "auth routes" list:

```diff
- const authRoutes = ["/auth/signin", "/auth/signup", "/auth/forgot-password", "/auth/reset-password"];
+ const authRoutes = ["/auth/signin", "/auth/signup"];
```

Password-recovery routes work the same regardless of session state — they end with the user clicking a tokenised link in their inbox. Letting signed-in users hit `/auth/forgot-password` is the same trust model as letting any visitor use the form. No new attack surface.

## UX touches on the page when reached signed-in

[src/app/(auth)/auth/forgot-password/page.tsx](src/app/(auth)/auth/forgot-password/page.tsx) now reads `useSession()` and adjusts when authenticated:

- **Email field pre-filled** from `session.user.email` — signed-in users don't re-type their own address
- **Header** swaps from "Forgot password?" to "Reset your password" (awkward to ask someone already signed in if they "forgot")
- **Back link** swaps from "Back to sign in" → "Back to profile settings" pointing at `/dashboard/settings/profile`
- **Success-card description** drops the "if an account exists" hedge (we know it does — they're signed in)

## Tests

3 new cases in [tests/unit/components/auth/forgot-password.test.tsx](tests/unit/components/auth/forgot-password.test.tsx):
- Signed-out: original "Forgot password?" copy, empty email field, "Back to sign in" link
- Signed-in: "Reset your password" copy, pre-filled email, "Back to profile settings" link to `/dashboard/settings/profile`
- Defensive: signed-in but `session.user.email` is null → no pre-fill

## Test plan

- [x] `npm run lint:strict` clean
- [x] `npm run type-check` clean
- [x] `npx vitest run` — **696 passing**, 22 skipped (was 693 + 3 new). No regressions.
- [ ] CI: PR checks
- [ ] Manual smoke on staging:
  - [ ] Signed-in user visits `/dashboard/settings/profile`, clicks **Change password**. Lands on `/auth/forgot-password` (no redirect to `/dashboard`).
  - [ ] Email field is pre-filled. Header reads "Reset your password".
  - [ ] Submit the form. Reset email arrives.
  - [ ] Click the back link → lands on `/dashboard/settings/profile`.
  - [ ] Signed-out visitor still sees "Forgot password?" header and "Back to sign in" link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)