### PR TITLE
fix(onboarding): unify beta-intent challenge field copy with FounderInquiryForm

### DIFF
--- a/src/app/(dashboard)/onboarding/page.tsx
+++ b/src/app/(dashboard)/onboarding/page.tsx
@@ -369,13 +369,25 @@ export default function OnboardingPage() {
                   </RadioGroup>
                 </div>
 
+                {/* Unified with FounderInquiryForm (beta_request) — same label,
+                    hint and example placeholder so the founder reads
+                    consistently-shaped submissions regardless of source. The
+                    dynamic helper line below stays onboarding-specific: it
+                    tells the user that submitting here is equivalent to
+                    requesting beta access. */}
                 <div className="space-y-1.5">
-                  <Label htmlFor="signupChallengeText">
-                    Tell us about your review management challenge
+                  <Label
+                    htmlFor="signupChallengeText"
+                    className="flex flex-wrap items-baseline gap-x-1.5"
+                  >
+                    <span>Tell us about your business</span>
+                    <span className="text-xs italic text-muted-foreground font-normal">
+                      (what you do, what&apos;s painful about reviews today)
+                    </span>
                   </Label>
                   <Textarea
                     id="signupChallengeText"
-                    placeholder="What got you here? (e.g., responding to 50+ reviews/month manually, want consistent voice across locations…)"
+                    placeholder='e.g. "I run a small bakery in Shoreditch. Responding to Google reviews takes me ~30 min a day and I usually copy-paste the same few replies."'
                     rows={3}
                     maxLength={VALIDATION_LIMITS.SIGNUP_CHALLENGE_TEXT_MAX}
                     disabled={isSubmitting}


### PR DESCRIPTION
## Summary

Caught during smoke: the onboarding wizard's beta-intent challenge textarea and the `FounderInquiryForm` (both producing a `FounderInquiry` of `type=beta_request`) asked the user with **different copy** — including the "respond to 50+ reviews/month" framing that PR #92 deliberately removed from the inquiry form. The onboarding wizard got missed in that pass.

## Change

[src/app/(dashboard)/onboarding/page.tsx](src/app/(dashboard)/onboarding/page.tsx) — challenge textarea now uses the same label, italic hint, and Shoreditch-bakery example placeholder as `FounderInquiryForm`. Single visual change in one file.

| | Before | After |
|---|---|---|
| **Label** | "Tell us about your review management challenge" | "Tell us about your business" + *"(what you do, what's painful about reviews today)"* |
| **Placeholder** | "What got you here? (e.g., responding to 50+ reviews/month manually, want consistent voice across locations…)" | `e.g. "I run a small bakery in Shoreditch. Responding to Google reviews takes me ~30 min a day and I usually copy-paste the same few replies."` |

The onboarding-specific dynamic helper line below the textarea ("Submitting this will request beta access — the founder will reach out within 24 hours.") stays — it's contextual and useful only on this surface, not on `/pricing` or the zero-balance dialog.

## Why this matters

Same destination → same shape of submission. A founder reading `/dashboard/admin/founder-inquiries` should see consistently-framed messages regardless of whether they arrived via onboarding-intent or pricing-page CTA. And the rejection of the "50+ reviews/month" volume framing was a deliberate call (MVP.md Section 9; PR #92 decision log) — it shouldn't survive on one surface and not another.

## Test plan

- [x] `npm run lint:strict` clean
- [x] `npm run type-check` clean
- [x] `npx vitest run tests/unit/components/shared/founder-inquiry-form.test.tsx` — 7 passing (unchanged; sanity check that the shared component still renders the same)
- [ ] CI: PR checks
- [ ] CI: E2E against staging after merge
- [ ] Manual smoke on staging:
  - [ ] Sign up as a fresh non-beta user, land on `/onboarding`
  - [ ] Beta-intent section reads "Tell us about your business *(what you do, what's painful about reviews today)*"
  - [ ] Placeholder shows the Shoreditch-bakery example
  - [ ] Type something, answer "Yes" — submit. `FounderInquiry` appears in admin with `source=onboarding_intent` and message text.
  - [ ] Click "Request beta access" on `/pricing` from a different account — same label + hint + placeholder visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)