### PR TITLE
feat(profile): two-level Industry → Business type cascade

### DIFF
--- a/prisma/migrations/20260513093000_add_user_business_type/migration.sql
+++ b/prisma/migrations/20260513093000_add_user_business_type/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable: add nullable businessType column on users
+-- See docs/MVP_Phase-1/Business Universe.md for the closed-set values.
+-- Two-level cascade with industry (existing column).
+ALTER TABLE "users" ADD COLUMN "businessType" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -44,6 +44,12 @@ model User {
   // Collected via /onboarding wizard after signup. All nullable so existing users remain valid.
   organizationName      String?
   industry              String?
+  // businessType is the second-level cascade under industry (e.g. industry
+  // "Food & Beverage" → businessType "Restaurant"). Closed-set on the app
+  // layer; see BUSINESS_TYPES_BY_INDUSTRY in src/lib/constants.ts. Nullable
+  // because (a) industry "Other" has no business-type cascade, and (b) users
+  // who signed up before this column existed have no value yet.
+  businessType          String?
   country               String?
   locationCountEstimate Int?
   primaryPlatform       String?

--- a/src/app/(dashboard)/onboarding/page.tsx
+++ b/src/app/(dashboard)/onboarding/page.tsx
@@ -35,9 +35,12 @@ import {
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import {
   INDUSTRIES,
+  BUSINESS_TYPES_BY_INDUSTRY,
   COUNTRIES,
   PLATFORMS,
   VALIDATION_LIMITS,
+  type Industry,
+  type BusinessType,
 } from "@/lib/constants";
 import { onboardingSubmitSchema, type OnboardingSubmitInput } from "@/lib/validations";
 import { useCredits } from "@/components/providers/CreditsProvider";
@@ -74,9 +77,22 @@ export default function OnboardingPage() {
   });
 
   const industry = watch("industry");
+  const businessType = watch("businessType");
   const country = watch("country");
   const primaryPlatform = watch("primaryPlatform");
   const signupIntent = watch("signupIntent");
+
+  // Cascade: businessType options depend on industry. When industry changes
+  // we clear the previously-selected businessType so it can't be stale (e.g.,
+  // user picked Retail → "Pharmacy", then changed industry to Hospitality —
+  // "Pharmacy" must not silently survive).
+  const businessTypeOptions =
+    industry && industry !== "Other"
+      ? BUSINESS_TYPES_BY_INDUSTRY[industry as Industry]
+      : [];
+
+  // Industry "Other" has no cascade — hide the second dropdown entirely.
+  const showBusinessType = Boolean(industry) && industry !== "Other";
 
   const onSubmit = async (data: OnboardingSubmitInput) => {
     setIsSubmitting(true);
@@ -89,6 +105,8 @@ export default function OnboardingPage() {
         body: JSON.stringify({
           organizationName: data.organizationName.trim(),
           industry: data.industry,
+          // businessType is null when industry is "Other" (no cascade).
+          businessType: data.businessType ?? null,
           country: data.country,
           locationName: data.locationName.trim(),
           locationCountEstimate: data.locationCountEstimate ?? null,
@@ -183,11 +201,15 @@ export default function OnboardingPage() {
                   <Label htmlFor="industry">Industry *</Label>
                   <Select
                     value={industry ?? ""}
-                    onValueChange={(value) =>
+                    onValueChange={(value) => {
                       setValue("industry", value as OnboardingSubmitInput["industry"], {
                         shouldValidate: true,
-                      })
-                    }
+                      });
+                      // Reset the cascade — clear businessType so a stale
+                      // value (e.g. Pharmacy chosen under Retail) can't
+                      // survive a switch to a different industry.
+                      setValue("businessType", null, { shouldValidate: true });
+                    }}
                     disabled={isSubmitting}
                   >
                     <SelectTrigger id="industry">
@@ -239,6 +261,40 @@ export default function OnboardingPage() {
                   )}
                 </div>
               </div>
+
+              {/* Business type — second-level cascade. Hidden when industry
+                  is "Other" (no list to show) or unset. */}
+              {showBusinessType && (
+                <div className="space-y-1.5">
+                  <Label htmlFor="businessType">Business type *</Label>
+                  <Select
+                    value={businessType ?? ""}
+                    onValueChange={(value) =>
+                      setValue("businessType", value as BusinessType, {
+                        shouldValidate: true,
+                      })
+                    }
+                    disabled={isSubmitting}
+                  >
+                    <SelectTrigger id="businessType">
+                      <div className="flex items-center gap-2 w-full">
+                        <Briefcase className="h-4 w-4 text-muted-foreground" />
+                        <SelectValue placeholder="Select business type" />
+                      </div>
+                    </SelectTrigger>
+                    <SelectContent>
+                      {businessTypeOptions.map((value) => (
+                        <SelectItem key={value} value={value}>
+                          {value}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  {errors.businessType && (
+                    <p className="text-xs text-red-600">{errors.businessType.message}</p>
+                  )}
+                </div>
+              )}
 
               <div className="grid gap-4 sm:grid-cols-2">
                 <div className="space-y-1.5">

--- a/src/app/api/user/profile/route.ts
+++ b/src/app/api/user/profile/route.ts
@@ -115,6 +115,9 @@ export async function PATCH(request: Request) {
       data: {
         organizationName: data.organizationName,
         industry: data.industry,
+        // Cascade pair — businessType is null when industry is "Other".
+        // See refineIndustryBusinessTypePair in src/lib/validations.ts.
+        businessType: data.businessType ?? null,
         country: data.country,
         locationCountEstimate: data.locationCountEstimate ?? null,
         primaryPlatform: data.primaryPlatform ?? null,
@@ -127,6 +130,7 @@ export async function PATCH(request: Request) {
         name: true,
         organizationName: true,
         industry: true,
+        businessType: true,
         country: true,
         locationCountEstimate: true,
         primaryPlatform: true,

--- a/src/app/api/user/settings/profile/route.ts
+++ b/src/app/api/user/settings/profile/route.ts
@@ -73,6 +73,12 @@ export async function PATCH(request: Request) {
   if (data.name !== undefined) userUpdate.name = data.name;
   if (data.organizationName !== undefined) userUpdate.organizationName = data.organizationName;
   if (data.industry !== undefined) userUpdate.industry = data.industry;
+  // businessType is the cascade partner. The Zod superRefine has already
+  // verified the pair is internally consistent — if industry changed and the
+  // form sent both, we trust them. If only industry changed (cascade reset
+  // server-side), the form is expected to send businessType = null too;
+  // the route doesn't auto-null it because explicit > inferred.
+  if (data.businessType !== undefined) userUpdate.businessType = data.businessType;
   if (data.country !== undefined) userUpdate.country = data.country;
   if (data.locationCountEstimate !== undefined)
     userUpdate.locationCountEstimate = data.locationCountEstimate;
@@ -105,6 +111,7 @@ export async function PATCH(request: Request) {
             name: true,
             organizationName: true,
             industry: true,
+            businessType: true,
             country: true,
             locationCountEstimate: true,
             primaryPlatform: true,
@@ -121,6 +128,7 @@ export async function PATCH(request: Request) {
             name: true,
             organizationName: true,
             industry: true,
+            businessType: true,
             country: true,
             locationCountEstimate: true,
             primaryPlatform: true,
@@ -210,6 +218,7 @@ export async function GET() {
       name: true,
       organizationName: true,
       industry: true,
+      businessType: true,
       country: true,
       locationCountEstimate: true,
       primaryPlatform: true,

--- a/src/components/settings/ProfileForm.tsx
+++ b/src/components/settings/ProfileForm.tsx
@@ -35,11 +35,13 @@ import Link from "next/link";
 import { toast } from "sonner";
 import {
   INDUSTRIES,
+  BUSINESS_TYPES_BY_INDUSTRY,
   COUNTRIES,
   PLATFORMS,
   VALIDATION_LIMITS,
   TIER_LIMITS,
   type Industry,
+  type BusinessType,
   type Country,
   type Platform,
 } from "@/lib/constants";
@@ -51,6 +53,7 @@ interface ProfileData {
   name: string | null;
   organizationName: string | null;
   industry: string | null;
+  businessType: string | null;
   country: string | null;
   locationCountEstimate: number | null;
   primaryPlatform: string | null;
@@ -83,6 +86,7 @@ export function ProfileForm() {
   const [name, setName] = useState("");
   const [organizationName, setOrganizationName] = useState("");
   const [industry, setIndustry] = useState<string>("");
+  const [businessType, setBusinessType] = useState<string>("");
   const [country, setCountry] = useState<string>("");
   const [locationName, setLocationName] = useState("");
   const [locationCountEstimate, setLocationCountEstimate] = useState<string>("");
@@ -112,6 +116,7 @@ export function ProfileForm() {
       setName(p.name ?? "");
       setOrganizationName(p.organizationName ?? "");
       setIndustry(p.industry ?? "");
+      setBusinessType(p.businessType ?? "");
       setCountry(p.country ?? "");
       setLocationName(loc?.name ?? "");
       setLocationCountEstimate(
@@ -147,8 +152,23 @@ export function ProfileForm() {
       payload.organizationName = trimmedOrg;
     }
 
-    if (industry && industry !== (profile.industry ?? "")) {
+    // Industry + businessType travel as a cascade pair. If industry changed
+    // we must also clear/refresh businessType in the same payload so the
+    // server-side cross-field check sees a consistent pair. If only
+    // businessType changed (industry untouched), we send businessType alone.
+    const industryChanged = industry && industry !== (profile.industry ?? "");
+    const businessTypeChanged = businessType !== (profile.businessType ?? "");
+    if (industryChanged) {
       payload.industry = industry;
+      // industry == "Other" => no cascade => businessType must be null.
+      // Otherwise send whatever the user has currently picked (may be empty
+      // string if they haven't picked yet; we coerce that to null so the
+      // server treats it as cleared, which is correct mid-edit).
+      payload.businessType =
+        industry === "Other" || businessType === "" ? null : businessType;
+    } else if (businessTypeChanged) {
+      // Industry stayed the same; only businessType moved.
+      payload.businessType = businessType === "" ? null : businessType;
     }
 
     if (country && country !== (profile.country ?? "")) {
@@ -193,6 +213,7 @@ export function ProfileForm() {
     name,
     organizationName,
     industry,
+    businessType,
     country,
     locationName,
     locationCountEstimate,
@@ -434,7 +455,15 @@ export function ProfileForm() {
                 <Label htmlFor="industry">Industry</Label>
                 <Select
                   value={industry}
-                  onValueChange={(value) => setIndustry(value as Industry)}
+                  onValueChange={(value) => {
+                    setIndustry(value as Industry);
+                    // Reset the cascade locally so the second dropdown
+                    // doesn't surface a stale value (e.g. "Pharmacy" still
+                    // selected after switching from Retail to Hospitality).
+                    // buildChangedPayload couples the two so the PATCH body
+                    // stays internally consistent.
+                    setBusinessType("");
+                  }}
                 >
                   <SelectTrigger id="industry">
                     <div className="flex items-center gap-2 w-full">
@@ -474,6 +503,34 @@ export function ProfileForm() {
                 </Select>
               </div>
             </div>
+
+            {/* Business type — second-level cascade. Hidden when industry
+                is "Other" (no list to show) or unset. */}
+            {industry && industry !== "Other" && (
+              <div className="space-y-1.5">
+                <Label htmlFor="businessType">Business type</Label>
+                <Select
+                  value={businessType}
+                  onValueChange={(value) => setBusinessType(value as BusinessType)}
+                >
+                  <SelectTrigger id="businessType">
+                    <div className="flex items-center gap-2 w-full">
+                      <Briefcase className="h-4 w-4 text-muted-foreground" />
+                      <SelectValue placeholder="Select business type" />
+                    </div>
+                  </SelectTrigger>
+                  <SelectContent>
+                    {(BUSINESS_TYPES_BY_INDUSTRY[industry as Industry] ?? []).map(
+                      (value) => (
+                        <SelectItem key={value} value={value}>
+                          {value}
+                        </SelectItem>
+                      ),
+                    )}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
           </section>
 
           <Separator />

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -129,19 +129,125 @@ export const BETA_PLAN = {
 export const BETA_INVITE_EXPIRY_DAYS = 60;
 
 // MVP Phase 1: Profile registration choices (see MVP.md Section 9).
-// Kept small and self-explanatory — "Other" exists as a soft escape hatch for
-// industries we don't yet recognise. Tracking these as a closed set lets us
-// segment beta users without free-text noise.
+//
+// Two-level cascade. INDUSTRIES is the top-level category the user picks
+// first; BUSINESS_TYPES_BY_INDUSTRY is the dependent dropdown keyed on the
+// industry. Both lists are closed sets with "Other" as a soft escape hatch.
+//
+// Source: docs/MVP_Phase-1/Business Universe.md. Healthcare is intentionally
+// excluded for the MVP — the prompt engineering for GDPR/HIPAA-safe replies
+// hasn't been validated. We'll add it when there's a clear demand signal.
+//
+// IMPORTANT: when industry is "Other" we don't show the businessType dropdown
+// at all. Server-side validation must therefore allow businessType to be
+// absent in that case.
 export const INDUSTRIES = [
-  "Restaurant",
-  "Cafe",
-  "Hotel",
+  "Food & Beverage",
+  "Hospitality",
   "Retail",
   "E-commerce",
-  "Services",
+  "Health, Wellness & Beauty",
+  "Automotive",
+  "Leisure & Entertainment",
+  "Professional Services",
   "Other",
 ] as const;
 export type Industry = (typeof INDUSTRIES)[number];
+
+// Business types — second-level cascade. Each industry has its own list with
+// "Other" at the end as the escape hatch. "Other" industry has no list (we
+// hide the second dropdown entirely in the UI).
+export const BUSINESS_TYPES_BY_INDUSTRY = {
+  "Food & Beverage": [
+    "Restaurant",
+    "Franchise restaurant",
+    "Cafe / coffee shop",
+    "Fast casual",
+    "Ghost kitchen",
+    "Food delivery brand",
+    "Bakery / dessert",
+    "Other",
+  ],
+  Hospitality: [
+    "Boutique hotel",
+    "Hotel franchise",
+    "Serviced apartment",
+    "Hostel",
+    "Resort",
+    "Vacation rental management",
+    "Other",
+  ],
+  Retail: [
+    "Eyeglasses / optical",
+    "Clothing",
+    "Shoe",
+    "Independent retail (fashion, home, lifestyle)",
+    "Supermarket / grocery",
+    "Pharmacy",
+    "Electronics / tech retail",
+    "Sporting goods",
+    "Pet supply",
+    "Furniture / home decor",
+    "Other",
+  ],
+  "E-commerce": [
+    "Amazon third-party seller",
+    "Shopify store",
+    "WooCommerce / WordPress store",
+    "Etsy seller",
+    "Multi-brand e-commerce",
+    "Other",
+  ],
+  "Health, Wellness & Beauty": [
+    "Spa",
+    "Gym / fitness studio",
+    "Hair salon",
+    "Beauty clinic (aesthetics, laser)",
+    "Yoga / pilates studio",
+    "Other",
+  ],
+  Automotive: [
+    "Car dealership group",
+    "Auto repair",
+    "Car rental (regional)",
+    "Tyre / service centre",
+    "Other",
+  ],
+  "Leisure & Entertainment": [
+    "Cinema (independent/regional)",
+    "Escape room",
+    "Bowling / activity centre",
+    "Golf club / driving range",
+    "Trampoline / indoor activity park",
+    "Other",
+  ],
+  "Professional Services": [
+    "Co-working space",
+    "Accountancy firm",
+    "Real estate / lettings agency",
+    "Cleaning service",
+    "Removal company",
+    "Other",
+  ],
+  // "Other" industry has no business-type cascade — the UI hides the second
+  // dropdown and the schema accepts businessType as null. Empty array kept for
+  // a stable shape: callers can do BUSINESS_TYPES_BY_INDUSTRY[industry] ?? [].
+  Other: [],
+} as const satisfies Record<Industry, readonly string[]>;
+
+// Union type of every business-type string across all industries, plus "Other".
+// Used by the Zod enum + Prisma column to keep things type-safe end-to-end.
+export type BusinessType =
+  (typeof BUSINESS_TYPES_BY_INDUSTRY)[keyof typeof BUSINESS_TYPES_BY_INDUSTRY][number];
+
+// Flat array of every valid business-type string (de-duplicated). Used by
+// Zod to validate the field. "Other" appears in many sub-lists so we
+// deduplicate via Set.
+export const BUSINESS_TYPES = Array.from(
+  new Set(
+    Object.values(BUSINESS_TYPES_BY_INDUSTRY).flat() as readonly string[],
+  ),
+) as readonly BusinessType[];
 
 // Subset of countries — beta will start in a few markets, full list isn't worth
 // the validation overhead until we have real demand from elsewhere. Add as

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -5,11 +5,69 @@ import {
   RESPONSE_TONES,
   VALIDATION_LIMITS,
   INDUSTRIES,
+  BUSINESS_TYPES,
+  BUSINESS_TYPES_BY_INDUSTRY,
   COUNTRIES,
   SIGNUP_INTENTS,
   FOUNDER_INQUIRY_TYPES,
   FOUNDER_INQUIRY_SOURCES,
+  type Industry,
 } from "./constants";
+
+// Cross-field check: businessType must belong to the chosen industry. Used
+// by both the onboarding and settings schemas via superRefine. When industry
+// is "Other" the businessType cascade is hidden in the UI and the value is
+// expected to be null/undefined — we don't enforce a match in that case.
+//
+// Callers pass the partial-update flag because the rules differ:
+//   - onboarding: businessType is REQUIRED when industry is not "Other"
+//   - settings:   businessType is OPTIONAL (partial update), but if both
+//                 industry and businessType are provided they must match
+function refineIndustryBusinessTypePair(
+  data: { industry?: string | null; businessType?: string | null },
+  ctx: z.RefinementCtx,
+  options: { requireBusinessType: boolean },
+): void {
+  const industry = data.industry as Industry | null | undefined;
+  const businessType = data.businessType;
+
+  // Nothing to check if industry isn't provided.
+  if (!industry) return;
+
+  // "Other" industry: no cascade. businessType must be empty.
+  if (industry === "Other") {
+    if (businessType) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["businessType"],
+        message: "Business type is not valid when industry is Other",
+      });
+    }
+    return;
+  }
+
+  // Industry has a cascade. businessType (when present) must be in the list.
+  const allowed = BUSINESS_TYPES_BY_INDUSTRY[industry] ?? [];
+  if (businessType) {
+    if (!(allowed as readonly string[]).includes(businessType)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["businessType"],
+        message: "Selected business type is not valid for the chosen industry",
+      });
+    }
+    return;
+  }
+
+  // businessType missing. Only the onboarding schema treats this as an error.
+  if (options.requireBusinessType) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["businessType"],
+      message: "Please select a business type",
+    });
+  }
+}
 
 /**
  * Zod validation schemas for BrandsIQ
@@ -146,6 +204,7 @@ export const updateProfileSchema = z.object({
   // field at a time without re-submitting everything.
   organizationName: z.string().min(1).max(VALIDATION_LIMITS.ORGANIZATION_NAME_MAX).optional(),
   industry: z.enum(INDUSTRIES).optional(),
+  businessType: z.enum(BUSINESS_TYPES).optional().nullable(),
   country: z.enum(COUNTRIES).optional(),
   locationName: z.string().min(1).max(VALIDATION_LIMITS.LOCATION_NAME_MAX).optional(),
 
@@ -189,6 +248,10 @@ export const settingsProfileUpdateSchema = z
       .max(VALIDATION_LIMITS.ORGANIZATION_NAME_MAX, "Organization name is too long")
       .optional(),
     industry: z.enum(INDUSTRIES).optional(),
+    // businessType is the second-level cascade. Allowed to be null when
+    // industry is "Other" (no cascade) or when the user has cleared it.
+    // superRefine below enforces that the value matches the industry.
+    businessType: z.enum(BUSINESS_TYPES).optional().nullable(),
     country: z.enum(COUNTRIES).optional(),
     // Edits the user's single Location row's name. Empty string is rejected —
     // the form should hide the field rather than send a clearing update.
@@ -208,31 +271,42 @@ export const settingsProfileUpdateSchema = z
   })
   .refine((data) => Object.keys(data).length > 0, {
     message: "No fields to update",
+  })
+  .superRefine((data, ctx) => {
+    refineIndustryBusinessTypePair(data, ctx, { requireBusinessType: false });
   });
 
 // Onboarding-specific schema with the mandatory fields actually required.
 // Used by the /onboarding form submit; the broader updateProfileSchema is
 // what a future "edit profile" surface would use.
-export const onboardingSubmitSchema = z.object({
-  organizationName: z.string().min(1, "Organization name is required").max(VALIDATION_LIMITS.ORGANIZATION_NAME_MAX),
-  industry: z.enum(INDUSTRIES, { message: "Please select an industry" }),
-  country: z.enum(COUNTRIES, { message: "Please select a country" }),
-  locationName: z.string().min(1, "Location name is required").max(VALIDATION_LIMITS.LOCATION_NAME_MAX),
-  locationCountEstimate: z
-    .number()
-    .int()
-    .min(1)
-    .max(VALIDATION_LIMITS.LOCATION_COUNT_MAX)
-    .optional()
-    .nullable(),
-  primaryPlatform: z.enum(PLATFORMS).optional().nullable(),
-  signupIntent: z.enum(SIGNUP_INTENTS).optional().nullable(),
-  signupChallengeText: z
-    .string()
-    .max(VALIDATION_LIMITS.SIGNUP_CHALLENGE_TEXT_MAX)
-    .optional()
-    .nullable(),
-});
+export const onboardingSubmitSchema = z
+  .object({
+    organizationName: z.string().min(1, "Organization name is required").max(VALIDATION_LIMITS.ORGANIZATION_NAME_MAX),
+    industry: z.enum(INDUSTRIES, { message: "Please select an industry" }),
+    // businessType is required when industry isn't "Other" (superRefine
+    // enforces). Sent as null/undefined when industry is "Other"; the UI
+    // hides the second dropdown in that case.
+    businessType: z.enum(BUSINESS_TYPES).optional().nullable(),
+    country: z.enum(COUNTRIES, { message: "Please select a country" }),
+    locationName: z.string().min(1, "Location name is required").max(VALIDATION_LIMITS.LOCATION_NAME_MAX),
+    locationCountEstimate: z
+      .number()
+      .int()
+      .min(1)
+      .max(VALIDATION_LIMITS.LOCATION_COUNT_MAX)
+      .optional()
+      .nullable(),
+    primaryPlatform: z.enum(PLATFORMS).optional().nullable(),
+    signupIntent: z.enum(SIGNUP_INTENTS).optional().nullable(),
+    signupChallengeText: z
+      .string()
+      .max(VALIDATION_LIMITS.SIGNUP_CHALLENGE_TEXT_MAX)
+      .optional()
+      .nullable(),
+  })
+  .superRefine((data, ctx) => {
+    refineIndustryBusinessTypePair(data, ctx, { requireBusinessType: true });
+  });
 
 // MVP Phase 1 founder-inquiry schemas. See MVP.md Section 13.4.
 // The form is used in four places (expired-link recovery, pricing-page CTA,

--- a/tests/integration/onboarding-flow.test.ts
+++ b/tests/integration/onboarding-flow.test.ts
@@ -49,7 +49,8 @@ describe.skipIf(!canRunIntegration)('Onboarding Flow (Integration)', () => {
         where: { id: user.id },
         data: {
           organizationName: 'Cafe Test',
-          industry: 'Cafe',
+          industry: 'Food & Beverage',
+          businessType: 'Cafe / coffee shop',
           country: 'United Kingdom',
           signupIntent: 'yes',
           signupChallengeText: '50 reviews/month, want consistent voice.',
@@ -73,7 +74,8 @@ describe.skipIf(!canRunIntegration)('Onboarding Flow (Integration)', () => {
 
     const updated = await db.user.findUnique({ where: { id: user.id } });
     expect(updated?.organizationName).toBe('Cafe Test');
-    expect(updated?.industry).toBe('Cafe');
+    expect(updated?.industry).toBe('Food & Beverage');
+    expect(updated?.businessType).toBe('Cafe / coffee shop');
     expect(updated?.signupIntent).toBe('yes');
 
     const inquiry = await db.founderInquiry.findFirst({ where: { userId: user.id } });
@@ -112,7 +114,8 @@ describe.skipIf(!canRunIntegration)('Onboarding Flow (Integration)', () => {
         where: { id: betaUser.id },
         data: {
           organizationName: 'Beta Org',
-          industry: 'Restaurant',
+          industry: 'Food & Beverage',
+          businessType: 'Restaurant',
           country: 'Ireland',
           signupIntent: 'yes', // The user clicked it, but it doesn't fire an inquiry
         },
@@ -184,7 +187,7 @@ describe.skipIf(!canRunIntegration)('Onboarding Flow (Integration)', () => {
       await db.$transaction(async (tx) => {
         await tx.user.update({
           where: { id: user.id },
-          data: { organizationName: 'Will Be Rolled Back', industry: 'Cafe', country: 'United Kingdom' },
+          data: { organizationName: 'Will Be Rolled Back', industry: 'Food & Beverage', businessType: 'Cafe / coffee shop', country: 'United Kingdom' },
         });
         await tx.location.create({
           data: { userId: user.id, name: 'Will Be Rolled Back Too' },

--- a/tests/unit/api/user/profile.test.ts
+++ b/tests/unit/api/user/profile.test.ts
@@ -47,7 +47,11 @@ function makeRequest(body: unknown): Request {
 
 const validProfile = {
   organizationName: 'The Bear Bakery',
-  industry: 'Cafe',
+  // Two-level cascade. "Food & Beverage" is the top-level industry,
+  // "Cafe / coffee shop" is the second-level businessType under it.
+  // The old single-level "Cafe" value is no longer valid.
+  industry: 'Food & Beverage',
+  businessType: 'Cafe / coffee shop',
   country: 'United Kingdom',
   locationName: 'The Bear Bakery — Shoreditch',
 };
@@ -77,7 +81,8 @@ describe('PATCH /api/user/profile', () => {
     const res = await PATCH(
       makeRequest({
         organizationName: 'Cafe',
-        industry: 'Cafe',
+        industry: 'Food & Beverage',
+        businessType: 'Cafe / coffee shop',
         // country missing
         locationName: 'X',
       }),
@@ -93,6 +98,84 @@ describe('PATCH /api/user/profile', () => {
       makeRequest({
         ...validProfile,
         industry: 'Underwater Basket Weaving',
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when businessType is missing for a non-Other industry', async () => {
+    // Cascade superRefine: businessType is required unless industry is "Other".
+    mockAuth.mockResolvedValue({ user: { id: 'u-1', email: 'a@x.com', name: 'A' } });
+
+    const { businessType: _omitted, ...withoutBusinessType } = validProfile;
+    void _omitted;
+    const res = await PATCH(makeRequest(withoutBusinessType));
+    expect(res.status).toBe(400);
+    expect(mockPrisma.user.update).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when businessType does not belong to the chosen industry', async () => {
+    // "Pharmacy" lives under Retail. Sending it with Food & Beverage should
+    // be rejected by the superRefine cross-field check.
+    mockAuth.mockResolvedValue({ user: { id: 'u-1', email: 'a@x.com', name: 'A' } });
+
+    const res = await PATCH(
+      makeRequest({
+        ...validProfile,
+        industry: 'Food & Beverage',
+        businessType: 'Pharmacy',
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('accepts industry="Other" with no businessType', async () => {
+    // "Other" industry hides the cascade. businessType must be absent or null.
+    mockAuth.mockResolvedValue({ user: { id: 'u-1', email: 'a@x.com', name: 'A' } });
+    mockPrisma.user.findUnique.mockResolvedValue({
+      id: 'u-1',
+      email: 'a@x.com',
+      name: 'A',
+      isBetaUser: false,
+      organizationName: null,
+    });
+    mockPrisma.user.update.mockResolvedValue({
+      id: 'u-1',
+      email: 'a@x.com',
+      name: 'A',
+      organizationName: 'Wholly Unique Thing',
+      industry: 'Other',
+      businessType: null,
+      country: 'United Kingdom',
+      isBetaUser: false,
+      tier: 'FREE',
+    });
+    mockPrisma.location.findFirst.mockResolvedValue(null);
+    mockPrisma.location.create.mockResolvedValue({ id: 'loc-1' });
+
+    const res = await PATCH(
+      makeRequest({
+        organizationName: 'Wholly Unique Thing',
+        industry: 'Other',
+        // No businessType
+        country: 'United Kingdom',
+        locationName: 'HQ',
+      }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects industry="Other" when businessType is sent', async () => {
+    // The cascade is hidden for "Other"; the form should send null. If the
+    // client sends a businessType anyway it's an internally inconsistent
+    // payload — reject it.
+    mockAuth.mockResolvedValue({ user: { id: 'u-1', email: 'a@x.com', name: 'A' } });
+
+    const res = await PATCH(
+      makeRequest({
+        ...validProfile,
+        industry: 'Other',
+        businessType: 'Cafe / coffee shop',
       }),
     );
     expect(res.status).toBe(400);
@@ -120,7 +203,8 @@ describe('PATCH /api/user/profile', () => {
       email: 'a@x.com',
       name: 'A',
       organizationName: 'The Bear Bakery',
-      industry: 'Cafe',
+      industry: 'Food & Beverage',
+      businessType: 'Cafe / coffee shop',
       country: 'United Kingdom',
       isBetaUser: false,
       tier: 'FREE',

--- a/tests/unit/api/user/settings-profile.test.ts
+++ b/tests/unit/api/user/settings-profile.test.ts
@@ -69,7 +69,8 @@ describe('GET /api/user/settings/profile', () => {
         email: 'a@x.com',
         name: 'Alice',
         organizationName: 'Bear Bakery',
-        industry: 'Cafe',
+        industry: 'Food & Beverage',
+        businessType: 'Cafe / coffee shop',
         country: 'United Kingdom',
         locationCountEstimate: 3,
         primaryPlatform: 'Google',
@@ -159,6 +160,67 @@ describe('PATCH /api/user/settings/profile', () => {
     expect(res.status).toBe(400);
   });
 
+  it('returns 400 when businessType does not belong to the chosen industry', async () => {
+    // Cascade superRefine: Pharmacy lives under Retail, not Food & Beverage.
+    mockAuth.mockResolvedValue({ user: { id: 'u-1', email: 'a@x.com', name: 'A' } });
+
+    const res = await PATCH(
+      makePatch({
+        industry: 'Food & Beverage',
+        businessType: 'Pharmacy',
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('accepts industry + matching businessType as a paired update', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'u-1', email: 'a@x.com', name: 'A' } });
+    mockPrisma.user.update.mockResolvedValue({
+      id: 'u-1',
+      industry: 'Retail',
+      businessType: 'Pharmacy',
+    });
+
+    const res = await PATCH(
+      makePatch({ industry: 'Retail', businessType: 'Pharmacy' }),
+    );
+    expect(res.status).toBe(200);
+
+    // Both fields land in the user update
+    expect(mockPrisma.user.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          industry: 'Retail',
+          businessType: 'Pharmacy',
+        }),
+      }),
+    );
+  });
+
+  it('accepts industry="Other" with businessType cleared to null', async () => {
+    // The form sends businessType=null when industry switches to "Other".
+    mockAuth.mockResolvedValue({ user: { id: 'u-1', email: 'a@x.com', name: 'A' } });
+    mockPrisma.user.update.mockResolvedValue({
+      id: 'u-1',
+      industry: 'Other',
+      businessType: null,
+    });
+
+    const res = await PATCH(
+      makePatch({ industry: 'Other', businessType: null }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects industry="Other" with a non-null businessType', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'u-1', email: 'a@x.com', name: 'A' } });
+
+    const res = await PATCH(
+      makePatch({ industry: 'Other', businessType: 'Cafe / coffee shop' }),
+    );
+    expect(res.status).toBe(400);
+  });
+
   it('returns 400 when name is an empty string', async () => {
     mockAuth.mockResolvedValue({ user: { id: 'u-1', email: 'a@x.com', name: 'A' } });
 
@@ -173,7 +235,8 @@ describe('PATCH /api/user/settings/profile', () => {
       email: 'a@x.com',
       name: 'Alice Updated',
       organizationName: 'Bear Bakery',
-      industry: 'Cafe',
+      industry: 'Food & Beverage',
+      businessType: 'Cafe / coffee shop',
       country: 'United Kingdom',
       locationCountEstimate: null,
       primaryPlatform: null,

--- a/tests/unit/components/settings/profile-form.test.tsx
+++ b/tests/unit/components/settings/profile-form.test.tsx
@@ -55,7 +55,9 @@ const PROFILE_FIXTURE = {
   email: "a@x.com",
   name: "Alice",
   organizationName: "Bear Bakery",
-  industry: "Cafe",
+  // Two-level cascade.
+  industry: "Food & Beverage",
+  businessType: "Cafe / coffee shop",
   country: "United Kingdom",
   locationCountEstimate: 3,
   primaryPlatform: "Google",


### PR DESCRIPTION
## Summary

Per [docs/MVP_Phase-1/Business Universe.md](docs/MVP_Phase-1/Business%20Universe.md), the flat Industry dropdown wasn't expressive enough and mixed categories with business types (e.g. "Cafe" sat alongside "Retail"). Replace with a two-level cascade:

- **Level 1 — Industry** (8 + Other)
- **Level 2 — Business type** (dependent on chosen industry)
- When industry is **"Other"** the second dropdown is hidden and `businessType` is stored as `null`

Healthcare is intentionally omitted for MVP per the source doc — prompt engineering for GDPR/HIPAA-safe replies hasn't been validated. "chain" stripped from every business-type label (it's descriptive, not the actual business type).

## Industry / Business type mapping

| Industry | Business types |
|---|---|
| Food & Beverage | Restaurant, Franchise restaurant, Cafe / coffee shop, Fast casual, Ghost kitchen, Food delivery brand, Bakery / dessert, Other |
| Hospitality | Boutique hotel, Hotel franchise, Serviced apartment, Hostel, Resort, Vacation rental management, Other |
| Retail | Eyeglasses / optical, Clothing, Shoe, Independent retail, Supermarket / grocery, Pharmacy, Electronics / tech retail, Sporting goods, Pet supply, Furniture / home decor, Other |
| E-commerce | Amazon third-party seller, Shopify store, WooCommerce / WordPress store, Etsy seller, Multi-brand e-commerce, Other |
| Health, Wellness & Beauty | Spa, Gym / fitness studio, Hair salon, Beauty clinic, Yoga / pilates studio, Other |
| Automotive | Car dealership group, Auto repair, Car rental, Tyre / service centre, Other |
| Leisure & Entertainment | Cinema, Escape room, Bowling / activity centre, Golf club / driving range, Trampoline / indoor activity park, Other |
| Professional Services | Co-working space, Accountancy firm, Real estate / lettings agency, Cleaning service, Removal company, Other |
| Other | *(no cascade — second dropdown hidden)* |

## Files

- [prisma/schema.prisma](prisma/schema.prisma) + new migration `20260513093000_add_user_business_type` — nullable `User.businessType` column
- [src/lib/constants.ts](src/lib/constants.ts) — new `INDUSTRIES` (8 + Other), `BUSINESS_TYPES_BY_INDUSTRY` map, `BUSINESS_TYPES` flat enum, `BusinessType` type
- [src/lib/validations.ts](src/lib/validations.ts) — shared `refineIndustryBusinessTypePair()` helper called via `superRefine` on both onboarding and settings schemas
- [src/app/api/user/profile/route.ts](src/app/api/user/profile/route.ts), [src/app/api/user/settings/profile/route.ts](src/app/api/user/settings/profile/route.ts) — accept + persist + return `businessType`
- [src/app/(dashboard)/onboarding/page.tsx](src/app/(dashboard)/onboarding/page.tsx), [src/components/settings/ProfileForm.tsx](src/components/settings/ProfileForm.tsx) — cascade dropdowns; industry change clears businessType; second dropdown hidden when industry is unset or "Other"

## Cascade behaviour

- **Industry change** → businessType is reset client-side, *and* sent as part of the same PATCH so the server never sees a stale pair
- **Industry "Other"** → second dropdown hidden, payload sends `businessType: null`
- **Server-side validation** → `refineIndustryBusinessTypePair` enforces:
  - onboarding: `businessType` is **required** when industry isn't "Other"
  - settings: `businessType` is **optional** (partial update) but if both fields present, must match the cascade

## Tests

704 passing (up from 696, +8 net):

- **profile.test.ts** (`PATCH /api/user/profile`): +4 cascade cases — missing businessType for non-Other industry; mismatched pair (Pharmacy under Food & Beverage); industry="Other" with null businessType (accepted); industry="Other" with businessType present (rejected)
- **settings-profile.test.ts** (`PATCH /api/user/settings/profile`): +4 mirror cases for partial-update
- All existing fixtures updated from the old single-level values (Cafe / Restaurant / Hotel) to the new cascade pair

## Test plan

- [x] `npm run lint:strict` clean
- [x] `npm run type-check` clean
- [x] `npx vitest run` — **704 passing**, 22 skipped. No regressions.
- [ ] CI: PR checks
- [ ] CI: E2E against staging after merge
- [ ] Manual smoke on staging:
  - [ ] Sign up fresh via invite link. `/onboarding` Industry dropdown shows the 9 new categories. Pick "Food & Beverage" → Business type dropdown appears with 7 + Other options.
  - [ ] Pick "Restaurant", complete onboarding. DB row shows `industry='Food & Beverage'`, `businessType='Restaurant'`.
  - [ ] Visit `/dashboard/settings/profile`. Both dropdowns pre-populated. Change Industry to Retail — Business type clears. Pick Pharmacy. Wait 1.5s. DB row updates atomically (both fields).
  - [ ] Change Industry to "Other". Second dropdown disappears. DB row: `industry='Other'`, `businessType=null`.

## Migration safety

- Schema change is **additive** (new nullable column) — reversible.
- **No backfill required** — only 3 test users across staging+prod, all of which have stale old-format `industry` values that will simply not match the new closed set if rendered. The user can fix via `/dashboard/settings/profile` when they next sign in. (Confirmed with founder.)

## Out of scope (follow-ups)

- One-time "complete your business type" prompt for users whose `businessType` is null and `industry` is not Other — file as separate work
- PostHog event taxonomy for industry/businessType segmentation — iteration 3 territory

🤖 Generated with [Claude Code](https://claude.com/claude-code)