### PR TITLE
fix(onboarding): hard-navigate to /dashboard after submit to dodge JWT cookie race

### DIFF
--- a/src/app/(dashboard)/onboarding/page.tsx
+++ b/src/app/(dashboard)/onboarding/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useSession } from "next-auth/react";
@@ -60,7 +59,9 @@ import { useCredits } from "@/components/providers/CreditsProvider";
  * enough (max 7 visible) that one screen is less friction than a wizard.
  */
 export default function OnboardingPage() {
-  const router = useRouter();
+  // Note: we deliberately use window.location.href below for the post-submit
+  // redirect rather than router.push, to dodge a NextAuth session-update /
+  // cookie-commit race against client-side navigation. See onSubmit().
   const { update: updateSession } = useSession();
   const { isBetaUser, refreshCredits } = useCredits();
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -144,7 +145,15 @@ export default function OnboardingPage() {
         // Non-fatal — value will refresh on next dashboard load anyway.
       }
 
-      router.push("/dashboard");
+      // Hard navigation rather than router.push so the next request to
+      // /dashboard is a fresh server round-trip with the updated session
+      // cookie. updateSession() above refreshes the JWT (so middleware
+      // reads hasOnboarded=true and lets us through the onboarding gate),
+      // but client-side navigation races against the cookie commit in
+      // some browsers — we observed staging E2E failures where the
+      // middleware kept bouncing back to /onboarding after a successful
+      // submit. A full reload eliminates the race.
+      window.location.href = "/dashboard";
     } catch {
       setError("Failed to save your profile. Please check your connection and try again.");
     } finally {


### PR DESCRIPTION
## Summary

**Bug from PR #99 staging deploy:** complete the onboarding form, get bounced back to `/onboarding` with the form re-mounted empty. Same failure mode hit the staging E2E `core-flow.spec.ts` test ([run 25797616051](https://github.com/prajeenv/BrandsIQ/actions/runs/25797616051)).

**Root cause:** NextAuth v5's `useSession().update()` resolves on the client as soon as the server response lands, but the browser commits the `Set-Cookie` payload asynchronously. `router.push("/dashboard")` races against that commit:

1. Form submits → DB updated → response includes new JWT cookie
2. `await updateSession()` resolves
3. `router.push("/dashboard")` triggers client-side nav
4. Middleware reads `getToken()` → still sees the **previous** JWT → `hasOnboarded=false`
5. Redirect back to `/onboarding`
6. Form re-mounts with empty state — user sees blank fields, thinks the save failed

**Fix:** replace `router.push("/dashboard")` with `window.location.href = "/dashboard"`. A full navigation forces the browser to flush pending `Set-Cookie` headers before the next request fires. Middleware then reads the fresh JWT with `hasOnboarded=true` and lets the request through.

## Trade-off

Brief flash of white during full reload vs. client-side transition. Acceptable for a flow that runs once per account lifetime. The credits/settings page autosave still uses `updateSession()` without a hard reload — those don't bounce through middleware so there's no race there.

## Files

- [src/app/(dashboard)/onboarding/page.tsx](src/app/(dashboard)/onboarding/page.tsx) — `router.push` → `window.location.href`; removed unused `useRouter` import + hook call

## Out of scope

The staging E2E `core-flow` test will keep failing until the **test user is also onboarded in staging DB** (their `organizationName` is null). One-time SQL UPDATE — separate work, not a code change:

```sql
UPDATE users SET
  "organizationName" = 'E2E Test Co',
  industry = 'Food & Beverage',
  "businessType" = 'Restaurant',
  country = 'United Kingdom'
WHERE email = '<e2e-test-user-email>';
```

I'll happily run this once we've confirmed the email + agree on values.

## Test plan

- [x] `npm run lint:strict` clean
- [x] `npm run type-check` clean
- [x] Existing middleware tests still pass (race fix doesn't change middleware behaviour)
- [ ] CI: PR checks
- [ ] Manual smoke on staging after merge:
  - [ ] Sign in as a fresh un-onboarded user → land on `/onboarding`
  - [ ] Fill all required fields, submit → land on `/dashboard` (full reload, brief flash, then dashboard)
  - [ ] DB row: `organizationName` populated; subsequent navigations to `/dashboard` stay there

🤖 Generated with [Claude Code](https://claude.com/claude-code)