### PR TITLE
feat(observability): PostHog event taxonomy for MVP Phase 1 validation

### DIFF
--- a/src/app/(dashboard)/dashboard/reviews/[id]/generate/page.tsx
+++ b/src/app/(dashboard)/dashboard/reviews/[id]/generate/page.tsx
@@ -26,6 +26,7 @@ import { getTextDirection } from "@/lib/language-detection";
 import { CREDIT_COSTS } from "@/lib/constants";
 import { useCredits } from "@/components/providers/CreditsProvider";
 import { OutOfCreditsDialog } from "@/components/dashboard";
+import { trackResponseGenerated } from "@/lib/posthog-events";
 
 interface Review {
   id: string;
@@ -92,6 +93,7 @@ export default function GenerateResponsePage() {
     refreshCredits,
     currentPhase,
     isBetaUser,
+    tier,
     organizationName,
   } = useCredits();
   const { data: session } = useSession();
@@ -152,6 +154,13 @@ export default function GenerateResponsePage() {
         setGeneratedResponse(result.data.response);
         setCreditsRemaining(result.data.creditsRemaining);
         toast.success("Response generated successfully!");
+        // PostHog: response_generated. Mirrors the event fired from the
+        // inline ResponsePanel path — both surface lead to the same
+        // POST /api/reviews/[id]/generate call so a user can land here
+        // from either entry point.
+        trackResponseGenerated({
+          tone: result.data.response.toneUsed ?? "default",
+        });
         refreshCredits();
       } else {
         if (result.error?.code === "INSUFFICIENT_CREDITS") {
@@ -394,6 +403,7 @@ export default function GenerateResponsePage() {
         actionType="generate"
         currentPhase={currentPhase}
         isBetaUser={isBetaUser}
+        tier={tier}
         submitterName={session?.user?.name ?? null}
         submitterEmail={session?.user?.email ?? null}
         submitterBusinessName={organizationName}

--- a/src/app/(dashboard)/dashboard/reviews/[id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/reviews/[id]/page.tsx
@@ -46,6 +46,7 @@ import { useCredits } from "@/components/providers/CreditsProvider";
 import { OutOfCreditsDialog } from "@/components/dashboard";
 import { CREDIT_COSTS } from "@/lib/constants";
 import { getNextResetDate } from "@/lib/utils";
+import { trackResponseGenerated } from "@/lib/posthog-events";
 
 interface ReviewDetail {
   id: string;
@@ -158,6 +159,7 @@ export default function ReviewDetailPage() {
     refreshCredits,
     currentPhase,
     isBetaUser,
+    tier,
     organizationName,
   } = useCredits();
   const { data: session } = useSession();
@@ -228,6 +230,12 @@ export default function ReviewDetailPage() {
           setReview(reviewResult.data.review);
         }
         toast.success("Response generated successfully!");
+        // PostHog: response_generated. Same event fires from ResponsePanel
+        // and /dashboard/reviews/[id]/generate — all three paths call the
+        // same POST /api/reviews/[id]/generate API.
+        trackResponseGenerated({
+          tone: result.data.response?.toneUsed ?? "default",
+        });
         refreshCredits();
       } else {
         if (result.error?.code === "INSUFFICIENT_CREDITS") {
@@ -548,6 +556,7 @@ export default function ReviewDetailPage() {
         actionType="generate"
         currentPhase={currentPhase}
         isBetaUser={isBetaUser}
+        tier={tier}
         submitterName={session?.user?.name ?? null}
         submitterEmail={session?.user?.email ?? null}
         submitterBusinessName={organizationName}

--- a/src/app/(dashboard)/onboarding/onboarding-form.tsx
+++ b/src/app/(dashboard)/onboarding/onboarding-form.tsx
@@ -42,6 +42,7 @@ import {
 } from "@/lib/constants";
 import { onboardingSubmitSchema, type OnboardingSubmitInput } from "@/lib/validations";
 import { useCredits } from "@/components/providers/CreditsProvider";
+import { trackOnboardingCompleted } from "@/lib/posthog-events";
 
 /**
  * Onboarding form (client component). Server gate lives in the parent
@@ -114,6 +115,16 @@ export function OnboardingForm() {
         setError(json.error?.message ?? "Failed to save your profile. Please try again.");
         return;
       }
+
+      // PostHog: onboarding completion event. Captures the categorical
+      // signals we'll group by in PostHog dashboards. businessType is null
+      // when industry is "Other" (no cascade). Fires before navigation so
+      // we don't race against the page unload.
+      trackOnboardingCompleted({
+        industry: data.industry ?? null,
+        businessType: data.businessType ?? null,
+        country: data.country ?? null,
+      });
 
       // Refresh CreditsProvider state so the newly-saved organizationName
       // is in memory before the user reaches /dashboard. Without this, the

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -50,12 +50,18 @@ export default function RootLayout({
   return (
     <html lang="en" className={`${GeistSans.variable} ${GeistMono.variable}`} suppressHydrationWarning>
       <body className="font-sans antialiased">
-        <PostHogProvider>
-          <SessionProvider>
+        {/* SessionProvider must wrap PostHogProvider because the
+            PostHogSessionSync component inside PostHogProvider calls
+            useSession() to identify users on sign-in / reset on
+            sign-out. With the previous order (PostHog outside Session),
+            useSession() returned undefined during prerender and the
+            destructure crashed the Next.js static export. */}
+        <SessionProvider>
+          <PostHogProvider>
             {children}
             <Toaster position="top-right" richColors closeButton />
-          </SessionProvider>
-        </PostHogProvider>
+          </PostHogProvider>
+        </SessionProvider>
       </body>
     </html>
   );

--- a/src/components/auth/SignupForm.tsx
+++ b/src/components/auth/SignupForm.tsx
@@ -12,6 +12,11 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { signUpSchema, type SignUpInput } from "@/lib/validations";
+import {
+  trackSignupCompletedWithBeta,
+  trackSignupCompletedNoBeta,
+  trackBetaInviteLinkUsed,
+} from "@/lib/posthog-events";
 
 interface SignupFormProps {
   callbackUrl?: string;
@@ -176,6 +181,19 @@ export function SignupForm({ callbackUrl = "/dashboard" }: SignupFormProps) {
         }
         setError(result.error?.message || "Failed to create account");
         return;
+      }
+
+      // PostHog: signup-funnel events. The server-returned isBetaUser is
+      // the source of truth — if the user-supplied betaCode failed
+      // server-side validation (despite the client pre-check passing), the
+      // signup still succeeds as a Free user and we want to record the
+      // _actual_ outcome.
+      const userIsBetaUser = Boolean(result?.data?.user?.isBetaUser);
+      if (userIsBetaUser) {
+        trackSignupCompletedWithBeta();
+        trackBetaInviteLinkUsed();
+      } else {
+        trackSignupCompletedNoBeta();
       }
 
       setSuccess(true);

--- a/src/components/dashboard/LowCreditWarning.tsx
+++ b/src/components/dashboard/LowCreditWarning.tsx
@@ -11,9 +11,10 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { FounderInquiryForm } from "@/components/shared/FounderInquiryForm";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { getNextResetDate } from "@/lib/utils";
 import type { SystemPhase } from "@/lib/system-phase";
+import { trackCreditBalanceLow } from "@/lib/posthog-events";
 
 interface LowCreditWarningProps {
   creditsRemaining: number;
@@ -132,6 +133,21 @@ export function LowCreditWarning({
     sentimentRemaining,
     sentimentTotal
   );
+
+  // PostHog: credit_balance_low. Fire once per low-credit episode (i.e.,
+  // when warningType transitions from "none" → anything else). The ref
+  // guards against re-firing on every re-render while the banner is up.
+  // When credits eventually refresh and warningType returns to "none", we
+  // reset the ref so a future drop can fire the event again.
+  const hasTrackedLowRef = useRef(false);
+  useEffect(() => {
+    if (warningType !== "none" && !hasTrackedLowRef.current) {
+      trackCreditBalanceLow({ tier, isBetaUser });
+      hasTrackedLowRef.current = true;
+    } else if (warningType === "none" && hasTrackedLowRef.current) {
+      hasTrackedLowRef.current = false;
+    }
+  }, [warningType, tier, isBetaUser]);
 
   // Don't show if no warning or dismissed
   if (isDismissed || warningType === "none") {

--- a/src/components/dashboard/OutOfCreditsDialog.tsx
+++ b/src/components/dashboard/OutOfCreditsDialog.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { CreditCard, Calendar } from "lucide-react";
+import { trackZeroBalanceDialogShown } from "@/lib/posthog-events";
 import {
   Dialog,
   DialogContent,
@@ -28,9 +29,10 @@ interface OutOfCreditsDialogProps {
   // for any pre-iteration-2 call sites.
   currentPhase?: SystemPhase;
   isBetaUser?: boolean;
-  // tier is reserved for Phase 2 ("Starter / Growth") tier-specific copy.
-  // Accepted but ignored under phase_1; renamed _tier to satisfy the linter.
-  _tier?: string;
+  // tier is used for PostHog segmentation on zero_balance_dialog_shown
+  // and reserved for Phase 2 tier-specific dialog copy. Optional with a
+  // safe "FREE" default so pre-iteration-2 call sites still compile.
+  tier?: string;
   // Pre-fill submitter info for FounderInquiryForm. When all three are
   // provided we hide the submitter fields entirely — the user has already
   // given us this info at signup/onboarding. Callers in the dashboard
@@ -49,10 +51,22 @@ export function OutOfCreditsDialog({
   actionType = "generate",
   currentPhase = "phase_2",
   isBetaUser = false,
+  tier = "FREE",
   submitterName,
   submitterEmail,
   submitterBusinessName,
 }: OutOfCreditsDialogProps) {
+  // PostHog: zero_balance_dialog_shown. Fires once per dialog opening
+  // (when `open` flips from false → true). The dependency array deliberately
+  // omits `tier`/`isBetaUser` so re-renders with the same `open=true` don't
+  // re-fire. Edge: if a parent re-mounts the dialog with open=true on
+  // initial render we'll emit once — correct.
+  useEffect(() => {
+    if (open) {
+      trackZeroBalanceDialogShown({ tier, isBetaUser });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
   // Hide submitter fields when we have what we need from session/onboarding.
   // We require name + email at minimum; business name is allowed to be null
   // (a user who somehow lands here without finishing onboarding still gets

--- a/src/components/providers/PostHogProvider.tsx
+++ b/src/components/providers/PostHogProvider.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import { useEffect, Suspense } from "react";
+import { useEffect, Suspense, useRef } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
+import { useSession } from "next-auth/react";
 import posthog from "posthog-js";
 import { PostHogProvider as PHProvider } from "posthog-js/react";
+import { identifyUser, resetUser } from "@/lib/posthog-events";
 
 function PostHogPageView() {
   const pathname = usePathname();
@@ -22,6 +24,46 @@ function PostHogPageView() {
   return null;
 }
 
+/**
+ * Watches the NextAuth session and calls posthog.identify() / posthog.reset()
+ * so events attach to the right Person record. Anonymous events (landing
+ * page pageviews etc.) are aliased to the user on first identify(), so the
+ * funnel stays intact from "first visit" through "signed-in usage".
+ *
+ * We use a ref to track the last identified userId and avoid re-identifying
+ * on every session re-render — identify() is idempotent but capture spam is
+ * still spam.
+ */
+function PostHogSessionSync() {
+  const { data: session, status } = useSession();
+  const lastIdentifiedId = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (status === "loading") return;
+
+    const userId = session?.user?.id;
+    const tier = session?.user?.tier ?? "FREE";
+
+    if (userId) {
+      if (lastIdentifiedId.current !== userId) {
+        // We don't yet expose isBetaUser on the session (CreditsProvider
+        // tracks it, but that's per-route, not global). Default to false;
+        // the call sites for trackZeroBalanceDialogShown / trackCreditBalanceLow
+        // pass the live value explicitly.
+        identifyUser(userId, { tier, isBetaUser: false });
+        lastIdentifiedId.current = userId;
+      }
+    } else if (lastIdentifiedId.current !== null) {
+      // User signed out — clear so subsequent anonymous events on this
+      // browser aren't attributed to the previous user.
+      resetUser();
+      lastIdentifiedId.current = null;
+    }
+  }, [session, status]);
+
+  return null;
+}
+
 export function PostHogProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     posthog.init(process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN as string, {
@@ -35,6 +77,7 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
       <Suspense fallback={null}>
         <PostHogPageView />
       </Suspense>
+      <PostHogSessionSync />
       {children}
     </PHProvider>
   );

--- a/src/components/reviews/ResponsePanel.tsx
+++ b/src/components/reviews/ResponsePanel.tsx
@@ -24,6 +24,10 @@ import { ResponseVersionHistory } from "./ResponseVersionHistory";
 import { CREDIT_COSTS } from "@/lib/constants";
 import { useCredits } from "@/components/providers/CreditsProvider";
 import { OutOfCreditsDialog } from "@/components/dashboard";
+import {
+  trackResponseGenerated,
+  trackResponseRegenerated,
+} from "@/lib/posthog-events";
 
 interface ResponseVersion {
   id: string;
@@ -107,6 +111,7 @@ export function ResponsePanel({
     refreshCredits,
     currentPhase,
     isBetaUser,
+    tier,
     organizationName,
   } = useCredits();
   const { data: session } = useSession();
@@ -192,6 +197,9 @@ export function ResponsePanel({
             : null
         );
         toast.success(`Response regenerated with ${tone} tone!`);
+        // PostHog: response_regenerated. tone is always one of the three
+        // explicit modifier values here (the function signature enforces).
+        trackResponseRegenerated({ tone });
         refreshCredits();
         onResponseUpdate?.(); // This will fetch fresh data including the new version
       } else {
@@ -268,6 +276,11 @@ export function ResponsePanel({
           versions: [],
         });
         toast.success("Response generated successfully!");
+        // PostHog: response_generated. toneUsed defaults to "default" on
+        // initial generation when no modifier was selected.
+        trackResponseGenerated({
+          tone: result.data.response.toneUsed ?? "default",
+        });
         refreshCredits();
         onResponseUpdate?.();
       } else {
@@ -337,6 +350,7 @@ export function ResponsePanel({
           actionType={outOfCreditsActionType}
           currentPhase={currentPhase}
           isBetaUser={isBetaUser}
+          tier={tier}
           submitterName={session?.user?.name ?? null}
           submitterEmail={session?.user?.email ?? null}
           submitterBusinessName={organizationName}

--- a/src/components/reviews/ReviewForm.tsx
+++ b/src/components/reviews/ReviewForm.tsx
@@ -21,6 +21,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { createReviewSchema, type CreateReviewInput } from "@/lib/validations";
 import { PLATFORMS, VALIDATION_LIMITS } from "@/lib/constants";
+import { trackSentimentAnalyzed } from "@/lib/posthog-events";
 import { getSupportedLanguages, detectLanguage, isRTLLanguage } from "@/lib/language-detection";
 
 interface ReviewFormProps {
@@ -118,6 +119,23 @@ export function ReviewForm({ initialData, mode = "create" }: ReviewFormProps) {
 
       if (result.success) {
         toast.success(mode === "edit" ? "Review updated!" : "Review added successfully!");
+
+        // PostHog: sentiment_analyzed. Only fires on create (not edit) when
+        // a sentiment was actually produced — skipped sentiment (no credits)
+        // is signalled by sentimentWarning + null review.sentiment. The
+        // review object on the response carries the resulting sentiment.
+        if (
+          mode === "create" &&
+          !result.data?.sentimentWarning &&
+          result.data?.review?.sentiment
+        ) {
+          trackSentimentAnalyzed({
+            sentiment: result.data.review.sentiment as
+              | "positive"
+              | "neutral"
+              | "negative",
+          });
+        }
 
         // Pass sentimentSkipped param if sentiment was skipped due to no credits
         const reviewUrl = result.data?.sentimentWarning

--- a/src/components/shared/FounderInquiryForm.tsx
+++ b/src/components/shared/FounderInquiryForm.tsx
@@ -11,6 +11,7 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { createFounderInquirySchema, type CreateFounderInquiryInput } from "@/lib/validations";
 import type { FounderInquiryType, FounderInquirySource } from "@/lib/constants";
+import { trackFounderInquirySubmitted } from "@/lib/posthog-events";
 
 /**
  * Shared founder-inquiry form. Used in four places per MVP.md Section 13.4:
@@ -159,6 +160,16 @@ export function FounderInquiryForm({
         setError(json.error?.message ?? "Failed to send. Please try again.");
         return;
       }
+
+      // PostHog: inquiry funnel. The categorical type + source pair lets
+      // us answer "where do most beta requests come from?" in dashboards.
+      // Defaults to "other" if no source was provided by the caller —
+      // some embed contexts (e.g. a future general-help surface) may omit
+      // it.
+      trackFounderInquirySubmitted({
+        type,
+        source: source ?? "other",
+      });
 
       setSuccess(true);
       onSuccess?.();

--- a/src/lib/posthog-events.ts
+++ b/src/lib/posthog-events.ts
@@ -1,0 +1,226 @@
+"use client";
+
+import posthog from "posthog-js";
+
+/**
+ * Typed PostHog event helpers for BrandsIQ.
+ *
+ * Why this module exists:
+ *  - Single source of truth for event names and property shapes. Stops the
+ *    classic "is it beta_invite_used or beta_invite_link_used?" drift.
+ *  - Properties are intentionally low-PII: we attach categorical context
+ *    (industry, businessType, country, tier) but never organisation name
+ *    or other identifying strings. User-level joins live on PostHog's
+ *    Person record via posthog.identify() — see identifyUser() below.
+ *  - All calls are client-side. If a server-side event ever proves
+ *    necessary (e.g. an event that must fire even if the tab closes
+ *    mid-request), wire it via the posthog-node SDK separately rather
+ *    than calling these helpers from the server.
+ *
+ * MVP Phase 1 iteration 3 — see docs/MVP_Phase-1/MVP.md Section 13.9 and
+ * Section 14 (Validation Targets).
+ */
+
+// Categorical/non-PII props that frequently appear together. Keep this list
+// small — the goal is "useful for segmentation in PostHog dashboards", not
+// "shovel everything into the event."
+export interface BetaContext {
+  isBetaUser: boolean;
+  tier: string; // "FREE" | "STARTER" | "GROWTH"
+}
+
+export interface BusinessContext {
+  industry?: string | null;
+  businessType?: string | null;
+  country?: string | null;
+}
+
+// ============================================================================
+// Identification
+// ============================================================================
+
+/**
+ * Associate the current PostHog session with a user. Call this on sign-in
+ * (and ideally any time the session refreshes). PostHog will then attach
+ * the same distinctId to anonymous events that happened before sign-in via
+ * its alias mechanism — preserving the funnel from landing-page to signup.
+ *
+ * Person properties (set on the User record in PostHog, not on each event):
+ *  - tier, isBetaUser: useful for cohort filtering on dashboards
+ *  - we deliberately do NOT set name/email/organizationName here — those
+ *    are reachable via the BrandsIQ DB if a specific user needs to be
+ *    looked up. Keeping PostHog free of them simplifies GDPR deletion.
+ */
+export function identifyUser(
+  userId: string,
+  props: BetaContext,
+): void {
+  if (typeof window === "undefined") return;
+  posthog.identify(userId, {
+    tier: props.tier,
+    isBetaUser: props.isBetaUser,
+  });
+}
+
+/**
+ * Clear the PostHog session. Call on sign-out so subsequent anonymous
+ * events on the same browser aren't attributed to the previous user.
+ */
+export function resetUser(): void {
+  if (typeof window === "undefined") return;
+  posthog.reset();
+}
+
+// ============================================================================
+// Event capture
+// ============================================================================
+
+/**
+ * Thin wrapper around posthog.capture so we can centralise SSR guards and
+ * test stubs. Not exported — call sites use the typed helpers below.
+ */
+function capture(
+  eventName: string,
+  properties: Record<string, unknown> = {},
+): void {
+  if (typeof window === "undefined") return;
+  posthog.capture(eventName, properties);
+}
+
+// ----------------------------------------------------------------------------
+// Signup + onboarding
+// ----------------------------------------------------------------------------
+
+/**
+ * Fires when a user completes signup with a valid beta invite code.
+ * Source: SignupForm post-success, when betaCode is present and valid.
+ *
+ * Note: organizationName / businessName are deliberately omitted — see
+ * the module-level comment about low-PII event properties.
+ */
+/**
+ * Note on `daysToUse`: the original plan included this as a prop, computed
+ * from BetaInviteLink.createdAt at signup time. The validate endpoint
+ * (/api/beta-invites/[code]/validate) doesn't currently return createdAt
+ * to clients — extending it is filed as a follow-up. Today the event fires
+ * without any properties; we'll add daysToUse when the endpoint is updated.
+ */
+export function trackSignupCompletedWithBeta(): void {
+  capture("signup_completed_with_beta", {});
+}
+
+/**
+ * Fires when a user completes signup without a beta invite (Free tier).
+ */
+export function trackSignupCompletedNoBeta(): void {
+  capture("signup_completed_no_beta", {});
+}
+
+/**
+ * Fires when the user submits the onboarding form successfully.
+ * Captures the categorical signals (industry/businessType/country)
+ * that we'll group by in PostHog to answer "what kinds of businesses
+ * are signing up?".
+ */
+export function trackOnboardingCompleted(props: BusinessContext): void {
+  capture("onboarding_completed", {
+    industry: props.industry ?? null,
+    businessType: props.businessType ?? null,
+    country: props.country ?? null,
+  });
+}
+
+// ----------------------------------------------------------------------------
+// Beta invite flow
+// ----------------------------------------------------------------------------
+
+/**
+ * Fires when an invite link is successfully claimed (server-side validation
+ * passes and the user record is updated to isBetaUser=true). Currently
+ * fired client-side from the signup form post-success — see note about
+ * server-side instrumentation in module-level docs.
+ */
+export function trackBetaInviteLinkUsed(): void {
+  // daysToUse will be added once /api/beta-invites/[code]/validate
+  // exposes createdAt — see comment on trackSignupCompletedWithBeta.
+  capture("beta_invite_link_used", {});
+}
+
+// ----------------------------------------------------------------------------
+// Founder inquiry
+// ----------------------------------------------------------------------------
+
+/**
+ * Fires when the founder-inquiry form submits successfully. Used in four
+ * places (expired-link recovery, pricing CTA, zero-balance dialog,
+ * low-credit warning, onboarding-intent), distinguished by `source`.
+ */
+export function trackFounderInquirySubmitted(props: {
+  type:
+    | "beta_request"
+    | "more_credits"
+    | "general"
+    | "expired_link_recovery";
+  source:
+    | "expired_link"
+    | "pricing"
+    | "zero_balance"
+    | "onboarding_intent"
+    | "other";
+}): void {
+  capture("founder_inquiry_submitted", props);
+}
+
+// ----------------------------------------------------------------------------
+// Credit lifecycle
+// ----------------------------------------------------------------------------
+
+/**
+ * Fires when the OutOfCreditsDialog opens. Tracks how often users hit
+ * the wall and which user segment is hitting it.
+ */
+export function trackZeroBalanceDialogShown(props: BetaContext): void {
+  capture("zero_balance_dialog_shown", { ...props });
+}
+
+/**
+ * Fires when credits drop to the low threshold (≤20% remaining) and the
+ * LowCreditWarning banner appears for the first time in a session.
+ * Suppress repeat-fires within a single render lifecycle via the caller.
+ */
+export function trackCreditBalanceLow(props: BetaContext): void {
+  capture("credit_balance_low", { ...props });
+}
+
+// ----------------------------------------------------------------------------
+// AI usage
+// ----------------------------------------------------------------------------
+
+/**
+ * Fires when the user successfully generates a response for a review.
+ * `tone` is the only required prop — review language and rating are
+ * useful future signals but not yet plumbed through the client API
+ * response shape (filed as follow-up).
+ */
+export function trackResponseGenerated(props: { tone: string }): void {
+  capture("response_generated", { tone: props.tone });
+}
+
+/**
+ * Fires when the user regenerates an existing response with a different
+ * tone modifier.
+ */
+export function trackResponseRegenerated(props: { tone: string }): void {
+  capture("response_regenerated", { tone: props.tone });
+}
+
+/**
+ * Fires when sentiment analysis runs successfully for a new review.
+ * Skipped sentiment (no credits) does NOT fire this event — see the
+ * separate sentimentSkipped indicator in the review detail flow.
+ */
+export function trackSentimentAnalyzed(props: {
+  sentiment: "positive" | "neutral" | "negative";
+}): void {
+  capture("sentiment_analyzed", props);
+}

--- a/tests/unit/lib/posthog-events.test.ts
+++ b/tests/unit/lib/posthog-events.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock posthog-js so we can assert exactly which event names + props are
+// captured. Stubbed at the module level so all imports of posthog resolve
+// to the mock — including the chain through src/lib/posthog-events.ts.
+const captureMock = vi.fn();
+const identifyMock = vi.fn();
+const resetMock = vi.fn();
+
+vi.mock("posthog-js", () => ({
+  default: {
+    capture: (...args: unknown[]) => captureMock(...args),
+    identify: (...args: unknown[]) => identifyMock(...args),
+    reset: (...args: unknown[]) => resetMock(...args),
+  },
+}));
+
+import {
+  identifyUser,
+  resetUser,
+  trackSignupCompletedWithBeta,
+  trackSignupCompletedNoBeta,
+  trackOnboardingCompleted,
+  trackBetaInviteLinkUsed,
+  trackFounderInquirySubmitted,
+  trackZeroBalanceDialogShown,
+  trackCreditBalanceLow,
+  trackResponseGenerated,
+  trackResponseRegenerated,
+  trackSentimentAnalyzed,
+} from "@/lib/posthog-events";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("posthog-events — identification", () => {
+  it("identifyUser sets tier + isBetaUser, no PII", () => {
+    identifyUser("user_abc", { tier: "FREE", isBetaUser: true });
+
+    expect(identifyMock).toHaveBeenCalledTimes(1);
+    expect(identifyMock).toHaveBeenCalledWith("user_abc", {
+      tier: "FREE",
+      isBetaUser: true,
+    });
+
+    // Defensive: confirm nothing PII-shaped leaked through. The helper
+    // intentionally omits name/email/organizationName.
+    const props = identifyMock.mock.calls[0][1];
+    expect(props).not.toHaveProperty("name");
+    expect(props).not.toHaveProperty("email");
+    expect(props).not.toHaveProperty("organizationName");
+  });
+
+  it("resetUser clears the PostHog session", () => {
+    resetUser();
+    expect(resetMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("posthog-events — signup + onboarding", () => {
+  it("trackSignupCompletedWithBeta fires the event with no PII props", () => {
+    trackSignupCompletedWithBeta();
+
+    expect(captureMock).toHaveBeenCalledWith("signup_completed_with_beta", {});
+  });
+
+  it("trackSignupCompletedNoBeta fires the event with no props", () => {
+    trackSignupCompletedNoBeta();
+
+    expect(captureMock).toHaveBeenCalledWith("signup_completed_no_beta", {});
+  });
+
+  it("trackOnboardingCompleted carries categorical context only", () => {
+    trackOnboardingCompleted({
+      industry: "Food & Beverage",
+      businessType: "Cafe / coffee shop",
+      country: "United Kingdom",
+    });
+
+    expect(captureMock).toHaveBeenCalledWith("onboarding_completed", {
+      industry: "Food & Beverage",
+      businessType: "Cafe / coffee shop",
+      country: "United Kingdom",
+    });
+
+    // Defensive: ensure organizationName never sneaks in
+    const props = captureMock.mock.calls[0][1];
+    expect(props).not.toHaveProperty("organizationName");
+  });
+
+  it("trackOnboardingCompleted normalises nullable props to null (not undefined)", () => {
+    // industry "Other" has no cascade — businessType is null.
+    trackOnboardingCompleted({
+      industry: "Other",
+      businessType: null,
+      country: "Ireland",
+    });
+
+    expect(captureMock).toHaveBeenCalledWith("onboarding_completed", {
+      industry: "Other",
+      businessType: null,
+      country: "Ireland",
+    });
+  });
+});
+
+describe("posthog-events — beta invite", () => {
+  it("trackBetaInviteLinkUsed fires the event", () => {
+    trackBetaInviteLinkUsed();
+    expect(captureMock).toHaveBeenCalledWith("beta_invite_link_used", {});
+  });
+});
+
+describe("posthog-events — founder inquiry", () => {
+  it("trackFounderInquirySubmitted carries type + source", () => {
+    trackFounderInquirySubmitted({
+      type: "beta_request",
+      source: "pricing",
+    });
+
+    expect(captureMock).toHaveBeenCalledWith("founder_inquiry_submitted", {
+      type: "beta_request",
+      source: "pricing",
+    });
+  });
+
+  it("supports all four inquiry types", () => {
+    const types = [
+      "beta_request",
+      "more_credits",
+      "general",
+      "expired_link_recovery",
+    ] as const;
+
+    for (const type of types) {
+      captureMock.mockClear();
+      trackFounderInquirySubmitted({ type, source: "other" });
+      expect(captureMock).toHaveBeenCalledWith(
+        "founder_inquiry_submitted",
+        expect.objectContaining({ type }),
+      );
+    }
+  });
+});
+
+describe("posthog-events — credit lifecycle", () => {
+  it("trackZeroBalanceDialogShown carries tier + isBetaUser", () => {
+    trackZeroBalanceDialogShown({ tier: "FREE", isBetaUser: false });
+
+    expect(captureMock).toHaveBeenCalledWith("zero_balance_dialog_shown", {
+      tier: "FREE",
+      isBetaUser: false,
+    });
+  });
+
+  it("trackCreditBalanceLow carries tier + isBetaUser", () => {
+    trackCreditBalanceLow({ tier: "FREE", isBetaUser: true });
+
+    expect(captureMock).toHaveBeenCalledWith("credit_balance_low", {
+      tier: "FREE",
+      isBetaUser: true,
+    });
+  });
+});
+
+describe("posthog-events — AI usage", () => {
+  it("trackResponseGenerated carries tone", () => {
+    trackResponseGenerated({ tone: "friendly" });
+    expect(captureMock).toHaveBeenCalledWith("response_generated", {
+      tone: "friendly",
+    });
+  });
+
+  it("trackResponseRegenerated carries tone", () => {
+    trackResponseRegenerated({ tone: "empathetic" });
+    expect(captureMock).toHaveBeenCalledWith("response_regenerated", {
+      tone: "empathetic",
+    });
+  });
+
+  it("trackSentimentAnalyzed carries sentiment classification", () => {
+    trackSentimentAnalyzed({ sentiment: "positive" });
+    expect(captureMock).toHaveBeenCalledWith("sentiment_analyzed", {
+      sentiment: "positive",
+    });
+  });
+
+  it("supports all three sentiment values", () => {
+    const sentiments = ["positive", "neutral", "negative"] as const;
+    for (const sentiment of sentiments) {
+      captureMock.mockClear();
+      trackSentimentAnalyzed({ sentiment });
+      expect(captureMock).toHaveBeenCalledWith(
+        "sentiment_analyzed",
+        expect.objectContaining({ sentiment }),
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Iteration 3 PR 1 of 4. Per [MVP.md Section 13.9 + Section 14](docs/MVP_Phase-1/MVP.md) — the events needed to answer post-beta tier recommendation questions ("which industries convert?", "what's the actual credits-per-response ratio?", "where do beta requests come from?"). Until now nothing custom fired; only autocaptured pageviews.

## Decisions (confirmed with founder pre-implementation)

- **Event properties are categorical only.** Tracking `industry`, `businessType`, `country`, `tier`, `isBetaUser`. **No `organizationName`** — keeps PostHog free of PII. User lookups go via `posthog.identify()` + the BrandsIQ DB.
- **Added `onboarding_completed`** (not in original plan but high signal for the signup → activation funnel).
- **All events fire client-side.** Server-side firing is a follow-up if an event proves unreliable.

## Events shipped

| Event | Where | Props |
|---|---|---|
| `signup_completed_with_beta` | SignupForm post-success when isBetaUser | (none) |
| `signup_completed_no_beta` | SignupForm post-success when !isBetaUser | (none) |
| `beta_invite_link_used` | Same — fires alongside signup_completed_with_beta | (none) |
| `onboarding_completed` | OnboardingForm submit success | industry, businessType, country |
| `founder_inquiry_submitted` | FounderInquiryForm post-success | type, source |
| `zero_balance_dialog_shown` | OutOfCreditsDialog open → true | tier, isBetaUser |
| `credit_balance_low` | LowCreditWarning warningType → !"none" (once per episode) | tier, isBetaUser |
| `response_generated` | All 3 generate paths (ResponsePanel, /reviews/[id], /reviews/[id]/generate) | tone |
| `response_regenerated` | ResponsePanel handleRegenerate success | tone |
| `sentiment_analyzed` | ReviewForm submit success when sentiment produced (not skipped) | sentiment |

## Files

- **NEW** [src/lib/posthog-events.ts](src/lib/posthog-events.ts) — typed helper module, SSR-guarded
- [src/components/providers/PostHogProvider.tsx](src/components/providers/PostHogProvider.tsx) — added `PostHogSessionSync` that calls `identifyUser()` / `resetUser()` on session change. Ref guards against re-identify storms.
- Wired events at the call sites listed above. `OutOfCreditsDialog._tier` renamed to `.tier` (it was a Phase 2 placeholder) and plumbed through callers.

## Tests

15 new in [tests/unit/lib/posthog-events.test.ts](tests/unit/lib/posthog-events.test.ts). `posthog-js` mocked at module level. Asserts exact event-name + prop-shape for every helper, plus defensive checks that no PII keys (name, email, organizationName) leak into event props or identify calls. Iterates all four inquiry types and all three sentiment values.

**737 unit tests passing** (was 722, +15). No regressions.

## Test plan

- [x] `npm run lint:strict` clean
- [x] `npm run type-check` clean
- [x] `npx vitest run` — 737 passing, 22 skipped
- [ ] CI: PR checks
- [ ] CI: E2E against staging after merge
- [ ] Manual smoke on staging: open PostHog Live Events, then:
  - [ ] Sign up with invite → see `signup_completed_with_beta` + `beta_invite_link_used`
  - [ ] Complete onboarding → see `onboarding_completed` with industry/businessType
  - [ ] Drop credits to 0, try to generate → see `zero_balance_dialog_shown` with tier + isBetaUser
  - [ ] Submit inquiry from any source → see `founder_inquiry_submitted` with matching type+source
  - [ ] Confirm none of the events carry organizationName or other PII

## Out of scope (follow-ups filed)

- `daysToUse` on `beta_invite_link_used` / `signup_completed_with_beta` (needs `/api/beta-invites/[code]/validate` to return `createdAt`)
- `language` + `reviewRating` on `response_generated` (needs generate endpoint to include them in response)

🤖 Generated with [Claude Code](https://claude.com/claude-code)