### PR TITLE
fix(posthog): persist tier + isBetaUser on the Person record

### DIFF
--- a/src/components/providers/PostHogProvider.tsx
+++ b/src/components/providers/PostHogProvider.tsx
@@ -30,34 +30,37 @@ function PostHogPageView() {
  * page pageviews etc.) are aliased to the user on first identify(), so the
  * funnel stays intact from "first visit" through "signed-in usage".
  *
- * We use a ref to track the last identified userId and avoid re-identifying
- * on every session re-render — identify() is idempotent but capture spam is
- * still spam.
+ * The dedupe key is `userId:tier:isBetaUser` rather than just userId — when
+ * tier or isBetaUser change (e.g. founder grants beta access after sign-in),
+ * we re-identify so the Person record reflects the new state. Without this,
+ * the initial identify wins and subsequent property changes never make it to
+ * PostHog. (This was the bug fixed in the PR that introduced this comment.)
  */
 function PostHogSessionSync() {
   const { data: session, status } = useSession();
-  const lastIdentifiedId = useRef<string | null>(null);
+  const lastIdentifiedStateRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (status === "loading") return;
 
     const userId = session?.user?.id;
     const tier = session?.user?.tier ?? "FREE";
+    const isBetaUser = session?.user?.isBetaUser ?? false;
 
     if (userId) {
-      if (lastIdentifiedId.current !== userId) {
-        // We don't yet expose isBetaUser on the session (CreditsProvider
-        // tracks it, but that's per-route, not global). Default to false;
-        // the call sites for trackZeroBalanceDialogShown / trackCreditBalanceLow
-        // pass the live value explicitly.
-        identifyUser(userId, { tier, isBetaUser: false });
-        lastIdentifiedId.current = userId;
+      // Re-identify whenever any tracked attribute changes, not just on
+      // user-id change. Cheap (one identify call per change) and keeps
+      // PostHog's Person record in sync.
+      const stateKey = `${userId}:${tier}:${isBetaUser}`;
+      if (lastIdentifiedStateRef.current !== stateKey) {
+        identifyUser(userId, { tier, isBetaUser });
+        lastIdentifiedStateRef.current = stateKey;
       }
-    } else if (lastIdentifiedId.current !== null) {
+    } else if (lastIdentifiedStateRef.current !== null) {
       // User signed out — clear so subsequent anonymous events on this
       // browser aren't attributed to the previous user.
       resetUser();
-      lastIdentifiedId.current = null;
+      lastIdentifiedStateRef.current = null;
     }
   }, [session, status]);
 
@@ -69,6 +72,13 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
     posthog.init(process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN as string, {
       api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
       capture_pageview: false, // Manually captured via PostHogPageView for App Router
+      // Explicit Person profile policy: only create/update Person records for
+      // users we've called identify() on. Default in posthog-js v1.117+ but
+      // worth being explicit so future PostHog version bumps don't silently
+      // change behaviour. Our identify() call lives in PostHogSessionSync
+      // below — anonymous traffic stays anonymous, authenticated users get
+      // a full Person record with tier + isBetaUser.
+      person_profiles: "identified_only",
     });
   }, []);
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -70,6 +70,11 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
           name: user.name,
           image: user.image,
           tier: user.tier,
+          // Surfaced so the jwt callback can stash it on the session for
+          // PostHog identification (PostHogSessionSync reads it).
+          // isBetaUser changes very rarely (founder-granted) so JWT-staleness
+          // isn't an issue here — the next sign-in picks up any change.
+          isBetaUser: user.isBetaUser,
         };
       },
     }),
@@ -152,17 +157,20 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       if (user) {
         token.id = user.id;
         token.tier = (user as { tier?: string }).tier || "FREE";
+        token.isBetaUser =
+          (user as { isBetaUser?: boolean }).isBetaUser ?? false;
       }
 
       // For OAuth, fetch the latest user data from database
       if (account?.provider === "google" && token.email) {
         const dbUser = await prisma.user.findUnique({
           where: { email: token.email },
-          select: { id: true, tier: true },
+          select: { id: true, tier: true, isBetaUser: true },
         });
         if (dbUser) {
           token.id = dbUser.id;
           token.tier = dbUser.tier || "FREE";
+          token.isBetaUser = dbUser.isBetaUser;
         }
       }
 
@@ -181,6 +189,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         session.user.id = token.id as string;
         session.user.tier = (token.tier as string) || "FREE";
         session.user.isFounder = token.isFounder ?? false;
+        session.user.isBetaUser = token.isBetaUser ?? false;
       }
       return session;
     },

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -11,11 +11,19 @@ declare module "next-auth" {
       // Exposed on the session so client components like Sidebar can render
       // founder-only UI without needing to read FOUNDER_EMAILS in the browser.
       isFounder: boolean;
+      // Reflects User.isBetaUser at sign-in time. Used by PostHogSessionSync
+      // to attach the beta flag to the PostHog Person record so dashboards
+      // can filter cohorts by beta status. The value is fixed for the
+      // session — isBetaUser changes very rarely (founder-granted) so the
+      // next sign-in picks up any change. Real-time per-route value is on
+      // CreditsProvider for downstream UI.
+      isBetaUser: boolean;
     } & DefaultSession["user"];
   }
 
   interface User extends DefaultUser {
     tier?: string;
+    isBetaUser?: boolean;
   }
 }
 
@@ -24,5 +32,6 @@ declare module "next-auth/jwt" {
     id?: string;
     tier?: string;
     isFounder?: boolean;
+    isBetaUser?: boolean;
   }
 }

--- a/tests/unit/components/providers/posthog-session-sync.test.tsx
+++ b/tests/unit/components/providers/posthog-session-sync.test.tsx
@@ -1,0 +1,316 @@
+import { render, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useState } from "react";
+
+// Mock posthog-js completely so we can assert call counts and args.
+// init / capture are stubbed; identify and reset are what we actually
+// care about for PostHogSessionSync's behaviour.
+const initMock = vi.fn();
+const captureMock = vi.fn();
+const identifyMock = vi.fn();
+const resetMock = vi.fn();
+
+vi.mock("posthog-js", () => ({
+  default: {
+    init: (...args: unknown[]) => initMock(...args),
+    capture: (...args: unknown[]) => captureMock(...args),
+    identify: (...args: unknown[]) => identifyMock(...args),
+    reset: (...args: unknown[]) => resetMock(...args),
+  },
+}));
+
+// posthog-js/react just provides a passthrough provider for context — stub
+// it so we don't pull in React DevTools dependencies in jsdom.
+vi.mock("posthog-js/react", () => ({
+  PostHogProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+// next/navigation — PostHogPageView reads pathname / searchParams. We
+// give it stable defaults so the autocapture-pageview useEffect doesn't
+// interfere with our identify assertions.
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+// next-auth/react — useSession is the input we vary across tests via a
+// controllable state hook. The mock module is created once; each test
+// flips a top-level mutable shape that the hook reads.
+type FakeSession = {
+  data: {
+    user: { id: string; tier: string; isBetaUser: boolean };
+  } | null;
+  status: "loading" | "authenticated" | "unauthenticated";
+};
+
+let fakeSession: FakeSession = {
+  data: null,
+  status: "unauthenticated",
+};
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => fakeSession,
+}));
+
+import { PostHogProvider } from "@/components/providers/PostHogProvider";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fakeSession = { data: null, status: "unauthenticated" };
+});
+
+/**
+ * Helper component that swaps the session state and re-renders the provider.
+ * We can't change the module-level fakeSession and expect React to react,
+ * so we wrap the provider in a tiny stateful host that triggers a re-render
+ * when we call setSession from outside (via a ref).
+ */
+function ProviderHarness({
+  initialSession,
+}: {
+  initialSession: FakeSession;
+}) {
+  const [, setTick] = useState(0);
+  // Expose a forceUpdate by re-rendering when session ref changes.
+  if (fakeSession !== initialSession) {
+    fakeSession = initialSession;
+  }
+
+  return (
+    <PostHogProvider>
+      <div data-testid="child">
+        <button onClick={() => setTick((t) => t + 1)}>tick</button>
+      </div>
+    </PostHogProvider>
+  );
+}
+
+describe("PostHogSessionSync", () => {
+  it("calls posthog.identify once on initial signed-in mount with tier + isBetaUser", async () => {
+    fakeSession = {
+      data: {
+        user: { id: "user_abc", tier: "FREE", isBetaUser: true },
+      },
+      status: "authenticated",
+    };
+
+    render(<ProviderHarness initialSession={fakeSession} />);
+
+    await waitFor(() => {
+      expect(identifyMock).toHaveBeenCalledTimes(1);
+    });
+    expect(identifyMock).toHaveBeenCalledWith("user_abc", {
+      tier: "FREE",
+      isBetaUser: true,
+    });
+  });
+
+  it("does NOT call identify when status is 'loading'", async () => {
+    fakeSession = {
+      data: null,
+      status: "loading",
+    };
+
+    render(<ProviderHarness initialSession={fakeSession} />);
+
+    // Give effects a chance to run
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(identifyMock).not.toHaveBeenCalled();
+    expect(resetMock).not.toHaveBeenCalled();
+  });
+
+  it("calls posthog.reset when a previously-identified user signs out", async () => {
+    // First: signed in
+    const authedSession: FakeSession = {
+      data: {
+        user: { id: "user_abc", tier: "FREE", isBetaUser: false },
+      },
+      status: "authenticated",
+    };
+
+    const { rerender } = render(
+      <ProviderHarness initialSession={authedSession} />,
+    );
+
+    await waitFor(() => {
+      expect(identifyMock).toHaveBeenCalledTimes(1);
+    });
+
+    // Then: signed out
+    const signedOutSession: FakeSession = {
+      data: null,
+      status: "unauthenticated",
+    };
+    fakeSession = signedOutSession;
+    rerender(<ProviderHarness initialSession={signedOutSession} />);
+
+    await waitFor(() => {
+      expect(resetMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("re-identifies when tier changes for the same user", async () => {
+    // Start as FREE
+    const freeSession: FakeSession = {
+      data: {
+        user: { id: "user_abc", tier: "FREE", isBetaUser: false },
+      },
+      status: "authenticated",
+    };
+
+    const { rerender } = render(
+      <ProviderHarness initialSession={freeSession} />,
+    );
+
+    await waitFor(() => {
+      expect(identifyMock).toHaveBeenCalledTimes(1);
+    });
+    expect(identifyMock).toHaveBeenLastCalledWith("user_abc", {
+      tier: "FREE",
+      isBetaUser: false,
+    });
+
+    // Upgrade to STARTER — same user id, different tier. This is the bug
+    // the PR fixed — the previous code keyed dedupe on userId alone, so
+    // this second identify was silently skipped.
+    const starterSession: FakeSession = {
+      data: {
+        user: { id: "user_abc", tier: "STARTER", isBetaUser: false },
+      },
+      status: "authenticated",
+    };
+    fakeSession = starterSession;
+    rerender(<ProviderHarness initialSession={starterSession} />);
+
+    await waitFor(() => {
+      expect(identifyMock).toHaveBeenCalledTimes(2);
+    });
+    expect(identifyMock).toHaveBeenLastCalledWith("user_abc", {
+      tier: "STARTER",
+      isBetaUser: false,
+    });
+  });
+
+  it("re-identifies when isBetaUser flips for the same user", async () => {
+    // Start non-beta
+    const nonBetaSession: FakeSession = {
+      data: {
+        user: { id: "user_abc", tier: "FREE", isBetaUser: false },
+      },
+      status: "authenticated",
+    };
+
+    const { rerender } = render(
+      <ProviderHarness initialSession={nonBetaSession} />,
+    );
+
+    await waitFor(() => {
+      expect(identifyMock).toHaveBeenCalledTimes(1);
+    });
+
+    // Founder grants beta — isBetaUser flips. On next sign-in this would
+    // reach the JWT and arrive here; the harness simulates that flip.
+    const betaSession: FakeSession = {
+      data: {
+        user: { id: "user_abc", tier: "FREE", isBetaUser: true },
+      },
+      status: "authenticated",
+    };
+    fakeSession = betaSession;
+    rerender(<ProviderHarness initialSession={betaSession} />);
+
+    await waitFor(() => {
+      expect(identifyMock).toHaveBeenCalledTimes(2);
+    });
+    expect(identifyMock).toHaveBeenLastCalledWith("user_abc", {
+      tier: "FREE",
+      isBetaUser: true,
+    });
+  });
+
+  it("does NOT re-identify when session re-renders with identical values", async () => {
+    // Mounts ref-state to confirm dedupe key works for the unchanged case.
+    const session: FakeSession = {
+      data: {
+        user: { id: "user_abc", tier: "FREE", isBetaUser: false },
+      },
+      status: "authenticated",
+    };
+
+    const { rerender } = render(
+      <ProviderHarness initialSession={session} />,
+    );
+
+    await waitFor(() => {
+      expect(identifyMock).toHaveBeenCalledTimes(1);
+    });
+
+    // Re-render with the same session shape. Should not fire identify
+    // again — dedupe key is the same.
+    rerender(<ProviderHarness initialSession={session} />);
+
+    // Give effects a chance to run
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(identifyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-identifies when a different user signs in after reset", async () => {
+    // User A signs in
+    const userA: FakeSession = {
+      data: {
+        user: { id: "user_a", tier: "FREE", isBetaUser: false },
+      },
+      status: "authenticated",
+    };
+    const { rerender } = render(<ProviderHarness initialSession={userA} />);
+
+    await waitFor(() => {
+      expect(identifyMock).toHaveBeenCalledTimes(1);
+    });
+
+    // Sign out
+    const signedOut: FakeSession = { data: null, status: "unauthenticated" };
+    fakeSession = signedOut;
+    rerender(<ProviderHarness initialSession={signedOut} />);
+    await waitFor(() => {
+      expect(resetMock).toHaveBeenCalledTimes(1);
+    });
+
+    // User B signs in (different id)
+    const userB: FakeSession = {
+      data: {
+        user: { id: "user_b", tier: "STARTER", isBetaUser: true },
+      },
+      status: "authenticated",
+    };
+    fakeSession = userB;
+    rerender(<ProviderHarness initialSession={userB} />);
+
+    await waitFor(() => {
+      expect(identifyMock).toHaveBeenCalledTimes(2);
+    });
+    expect(identifyMock).toHaveBeenLastCalledWith("user_b", {
+      tier: "STARTER",
+      isBetaUser: true,
+    });
+  });
+});
+
+describe("PostHogProvider init", () => {
+  it("calls posthog.init with person_profiles=identified_only", async () => {
+    fakeSession = { data: null, status: "unauthenticated" };
+
+    render(<ProviderHarness initialSession={fakeSession} />);
+
+    await waitFor(() => {
+      expect(initMock).toHaveBeenCalled();
+    });
+
+    // Second argument to init is the options object
+    const initOptions = initMock.mock.calls[0][1];
+    expect(initOptions).toMatchObject({
+      person_profiles: "identified_only",
+      capture_pageview: false,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

**Bug surfaced during PR #104 smoke test:** PostHog Person records for signed-in users had no `tier` or `isBetaUser` properties. The `identifyUser()` call ran but the props didn't stick. This broke cohort filtering in PostHog dashboards — queries like *"show me onboarding_completed events for beta users only"* would return nothing because the Person filter had no data to match against.

## Two underlying causes

1. **`PostHogSessionSync` hardcoded `isBetaUser: false`** because the NextAuth session didn't expose it. `session.user.tier` was plumbed but `isBetaUser` was only tracked in `CreditsProvider` (per-route, not globally).

2. **The dedupe ref keyed on `userId` alone.** Even after fixing (1), re-identifies triggered by tier/isBetaUser changes would have been silently skipped because `lastIdentifiedId.current === userId` is true after the first identify.

## The fix

### a) Add `isBetaUser` to JWT + session

Mirror the `isFounder` / `tier` pattern. `authorize()` returns `User.isBetaUser`; jwt callback stashes it on the token for credentials sign-in and re-reads from DB for OAuth; session callback exposes it as `session.user.isBetaUser`.

**Trade-off:** the value is fixed for the session — a founder-granted beta flag only takes effect on the user's next sign-in. Acceptable because `isBetaUser` changes are extremely rare.

### b) Revise dedupe key

```typescript
// Before
if (lastIdentifiedId.current !== userId) {
  identifyUser(userId, { tier, isBetaUser: false });
  lastIdentifiedId.current = userId;
}

// After
const stateKey = `${userId}:${tier}:${isBetaUser}`;
if (lastIdentifiedStateRef.current !== stateKey) {
  identifyUser(userId, { tier, isBetaUser });
  lastIdentifiedStateRef.current = stateKey;
}
```

Any change to any of those three triggers a fresh identify.

### c) Set `person_profiles: "identified_only"` explicitly

It's the posthog-js v1.117+ default, but being explicit removes ambiguity about which mode is active and avoids surprises if posthog-js changes defaults in a future version.

## Files

- [src/lib/auth.ts](src/lib/auth.ts) — authorize returns `isBetaUser`; jwt + session callbacks plumb it through
- [src/types/next-auth.d.ts](src/types/next-auth.d.ts) — session.user.isBetaUser + JWT.isBetaUser type augmentation
- [src/components/providers/PostHogProvider.tsx](src/components/providers/PostHogProvider.tsx) — revised PostHogSessionSync dedupe + explicit init option
- [tests/unit/components/providers/posthog-session-sync.test.tsx](tests/unit/components/providers/posthog-session-sync.test.tsx) — NEW, 8 cases

## Tests

8 new in posthog-session-sync.test.tsx. Mocks `posthog-js` + `next-auth/react` and exercises every state transition:
- Initial signed-in identify fires once with full props
- Loading status is a no-op
- Sign-out triggers reset
- Tier change re-identifies (the bug we fixed)
- isBetaUser flip re-identifies (the bug we fixed)
- Identical re-render does NOT re-identify
- Fresh identify after a different user signs in post-reset
- `posthog.init` is called with `person_profiles: "identified_only"`

**Total suite: 745 passing** (was 737, +8). No regressions.

## Smoke test plan after deploy

1. Sign in as a beta user on staging
2. PostHog → click distinct ID on any of your events → Person page
3. **Properties** section should now show `tier: "FREE"` + `isBetaUser: true`
4. Confirm filtering: PostHog → Events → filter by `Person.isBetaUser=true` — should return your events
5. Compare against an existing event from PR #104's smoke session — those Person records will still be empty (they identified during the broken window) but will auto-correct on the user's next sign-in

## Out of scope

Backfilling Person properties for existing test users who identified during PR #104's broken window. They auto-correct on next sign-in (the dedupe key change ensures a fresh identify fires).

🤖 Generated with [Claude Code](https://claude.com/claude-code)