### PR TITLE
fix(sentry): restore default client integrations so uncaught errors are captured

### DIFF
--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -7,7 +7,17 @@ Sentry.init({
   tracesSampleRate: 0,
   replaysSessionSampleRate: 0,
   replaysOnErrorSampleRate: 0,
-  integrations: [],
+  // NOTE: previously `integrations: []`, which removed Sentry's default
+  // integration set — including `globalHandlers`, the integration that
+  // hooks window.onerror / unhandledrejection. With it gone, uncaught
+  // client errors logged to the console were never sent to Sentry
+  // (verified via /sentry-example-page: error appeared in console, never
+  // in Sentry Issues). Omitting `integrations` entirely restores the
+  // SDK defaults so uncaught errors are captured. We deliberately do NOT
+  // re-enable Replay (replaysSessionSampleRate/replaysOnErrorSampleRate
+  // stay 0) and keep tracesSampleRate 0 — error capture only, no perf or
+  // session-replay cost. The server and edge configs already use
+  // defaults; only the client config had this override.
 });
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;


### PR DESCRIPTION
## Summary

`src/instrumentation-client.ts` passed `integrations: []` to `Sentry.init`, which strips Sentry's entire default integration set — including `globalHandlers`, the integration that hooks `window.onerror` / `unhandledrejection`. The SDK initialised and connected fine, but **had nothing listening for uncaught errors**, so they only ever reached the browser console and never Sentry.

This is **bug 2** of the Sentry investigation. Bug 1 (stale `NEXT_PUBLIC_SENTRY_DSN` pointing at a rotated-out key → 403s in console) was already fixed by updating the Vercel env var. With the DSN corrected, the test error still didn't reach Sentry — because of this second, independent bug.

## How it was found

Staging smoke via `/sentry-example-page`:

```
Uncaught Error: Sentry client test error
    at onClick (page-d583c4e1a0707348.js:1:700)
    ...
```

Error logged to console → never appeared in Sentry Issues. Classic signature of "SDK connected but no error-capture handler attached."

## Fix

Omit `integrations` entirely so Sentry installs its client defaults (`globalHandlers`, `breadcrumbs`, `dedupe`, `httpContext`, …). One-line change.

`sentry.server.config.ts` and `sentry.edge.config.ts` already use defaults — only the client config had the override. (There's a stale unmerged branch `feat/add-sentry-error-tracking` whose commit *"restore default Sentry integrations for server and edge"* was solving the server/edge side of this; that's no longer present in server/edge, only client remained broken.)

## Scope (kept deliberately minimal)

- `tracesSampleRate` stays `0` — no performance-tracing cost
- `replays*SampleRate` stay `0` — Replay is opt-in for `@sentry/nextjs` client (not in the default set), so these stay harmless no-ops
- **Environment tagging is NOT touched here.** `environment: process.env.NODE_ENV` is always `"production"` on Vercel, so staging and prod are indistinguishable in Sentry. That's a real issue but separate — tracked as a follow-up, not bundled into this fix.

## Test plan

- [x] `npm run lint:strict` clean
- [x] `npm run type-check` clean
- [x] `npm run build` — 44/44 static pages render
- [x] provider unit tests still green (Sentry init isn't exercised in test env — `enabled: NODE_ENV === "production"` no-ops it)
- [ ] **Manual verification post-deploy (the real test):**
  1. Merge → staging redeploys
  2. Visit `/sentry-example-page` on staging, click "Throw client error"
  3. Sentry → Issues → Errors & Outages → `Sentry client test error` appears within ~1 min
  4. Repeat on production after promote

## Why this gates iteration 3 PR 2

PR 2 adds `Sentry.captureException()` calls across the phase-1 paths. No point shipping that instrumentation while the client SDK can't even capture an uncaught throw. **Once the `/sentry-example-page` error lands in Sentry, PR 2 can proceed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)