### PR TITLE
feat(observability): Sentry coverage for MVP Phase 1 paths

### DIFF
--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import bcrypt from "bcryptjs";
+import * as Sentry from "@sentry/nextjs";
 import { prisma } from "@/lib/prisma";
 import { signUpSchema } from "@/lib/validations";
 import { sendVerificationEmail } from "@/lib/email";
@@ -9,6 +10,10 @@ import { BETA_PLAN, TIER_LIMITS } from "@/lib/constants";
 import { getCurrentPhase } from "@/lib/system-phase";
 
 export async function POST(request: Request) {
+  // Hoisted so the catch block can tag the Sentry event by whether the
+  // failing signup was on the beta-code path (the riskier one — it touches
+  // BetaInviteLink + allocation in a transaction) vs a plain Free signup.
+  let betaCodeProvided = false;
   try {
     // Rate limiting
     const ip = getClientIP(request);
@@ -40,6 +45,7 @@ export async function POST(request: Request) {
     }
 
     const { email, password, name, betaCode } = validation.data;
+    betaCodeProvided = Boolean(betaCode);
 
     // Check if user already exists
     const existingUser = await prisma.user.findUnique({
@@ -194,6 +200,12 @@ export async function POST(request: Request) {
     );
   } catch (error) {
     console.error("Signup error:", error);
+    Sentry.captureException(error, {
+      tags: {
+        area: betaCodeProvided ? "phase_1_signup_beta" : "phase_1_signup",
+      },
+      extra: { betaCodeProvided },
+    });
     return NextResponse.json(
       {
         success: false,

--- a/src/app/api/beta-invites/[code]/validate/route.ts
+++ b/src/app/api/beta-invites/[code]/validate/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import * as Sentry from "@sentry/nextjs";
 import { prisma } from "@/lib/prisma";
 
 type RouteParams = { params: Promise<{ code: string }> };
@@ -20,10 +21,26 @@ export async function GET(_request: Request, { params }: RouteParams) {
     });
   }
 
-  const invite = await prisma.betaInviteLink.findUnique({
-    where: { code },
-    select: { expiresAt: true, usedAt: true },
-  });
+  let invite;
+  try {
+    invite = await prisma.betaInviteLink.findUnique({
+      where: { code },
+      select: { expiresAt: true, usedAt: true },
+    });
+  } catch (error) {
+    // A DB failure here means we can't tell the signup form whether the
+    // invite is good. Capture loudly — a systematic failure would silently
+    // block legitimate beta signups. Fail safe toward "doesn't exist": the
+    // form routes that to the expired-link recovery page (graceful) rather
+    // than crashing the signup flow.
+    Sentry.captureException(error, {
+      tags: { area: "phase_1_invite_validation" },
+    });
+    return NextResponse.json({
+      success: true,
+      data: { valid: false, expired: false, used: false, exists: false },
+    });
+  }
 
   if (!invite) {
     return NextResponse.json({

--- a/src/app/api/founder-inquiries/route.ts
+++ b/src/app/api/founder-inquiries/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import * as Sentry from "@sentry/nextjs";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { createFounderInquirySchema } from "@/lib/validations";
@@ -94,17 +95,38 @@ export async function POST(request: Request) {
     );
   }
 
-  const inquiry = await prisma.founderInquiry.create({
-    data: {
-      type: data.type,
-      source: data.source ?? null,
-      userId: session?.user?.id ?? null,
-      submitterName,
-      submitterEmail,
-      businessName: data.businessName ?? null,
-      message: data.message,
-    },
-  });
+  let inquiry;
+  try {
+    inquiry = await prisma.founderInquiry.create({
+      data: {
+        type: data.type,
+        source: data.source ?? null,
+        userId: session?.user?.id ?? null,
+        submitterName,
+        submitterEmail,
+        businessName: data.businessName ?? null,
+        message: data.message,
+      },
+    });
+  } catch (error) {
+    // A failed insert here means a prospect's beta request / more-credits
+    // ask is lost entirely. Capture loudly and return a structured 500 so
+    // the form can show a retry rather than an unhandled crash.
+    Sentry.captureException(error, {
+      tags: { area: "phase_1_founder_inquiry" },
+      extra: { type: data.type, source: data.source ?? null },
+    });
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "Could not submit your request. Please try again.",
+        },
+      },
+      { status: 500, headers: rateLimitResult.headers },
+    );
+  }
 
   // Notify the founder via Resend. Non-blocking from the user's perspective;
   // wrapped in catch so an email send failure doesn't fail the inquiry.
@@ -118,6 +140,15 @@ export async function POST(request: Request) {
     inquiryId: inquiry.id,
   }).catch((err) => {
     console.error("Failed to send founder inquiry notification:", err);
+    // The inquiry row IS saved (the founder can still see it in the admin
+    // view), so this is a warning, not an error — but a systematically
+    // failing notification means the founder isn't getting real-time
+    // alerts and should know.
+    Sentry.captureException(err, {
+      level: "warning",
+      tags: { area: "phase_1_founder_inquiry" },
+      extra: { inquiryId: inquiry.id, channel: "email_notification" },
+    });
   });
 
   return NextResponse.json(

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -4,6 +4,7 @@ import Google from "next-auth/providers/google";
 import { PrismaAdapter } from "@auth/prisma-adapter";
 import bcrypt from "bcryptjs";
 import { cookies } from "next/headers";
+import * as Sentry from "@sentry/nextjs";
 import { prisma } from "./prisma";
 import { SESSION_CONFIG, BETA_PLAN, TIER_LIMITS } from "./constants";
 import { getCurrentPhase } from "./system-phase";
@@ -234,8 +235,13 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         } catch (error) {
           // Reading cookies can fail in some edge runtime contexts; treat as
           // no-cookie. The user will be created as Free — visible failure
-          // mode rather than a silent crash.
+          // mode rather than a silent crash. Capture to Sentry so we can see
+          // how often OAuth signups silently miss their beta invite (this
+          // directly costs a beta user their 150/750 allocation).
           console.error("[auth.events.signIn] failed to read invite cookie:", error);
+          Sentry.captureException(error, {
+            tags: { area: "phase_1_oauth_invite_cookie" },
+          });
         }
       }
 
@@ -245,46 +251,77 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
 
       // Apply allocation, mark invite used (if any), create default brand
       // voice — all atomically so the user can't end up half-initialized.
-      await prisma.$transaction(async (tx) => {
-        await tx.user.update({
-          where: { id: user.id! },
-          data: {
-            credits: allocation.credits,
-            tier: "FREE",
-            isBetaUser,
-            sentimentCredits: allocation.sentimentQuota,
-            creditsResetDate: resetDate,
-            sentimentResetDate: resetDate,
-          },
-        });
-
-        await tx.brandVoice.create({
-          data: {
-            userId: user.id!,
-            tone: "professional",
-            formality: 3,
-            keyPhrases: ["Thank you", "We appreciate your feedback"],
-            styleNotes: "Be genuine and empathetic",
-          },
-        });
-
-        if (appliedCode) {
-          await tx.betaInviteLink.update({
-            where: { code: appliedCode },
+      //
+      // This is the single most important path to instrument: a silent
+      // failure here means a beta user (entitled to 150/750) gets created
+      // as Free (15/35), or a user ends up with no brand voice. We capture
+      // to Sentry AND re-throw — failing loudly is correct. NextAuth surfaces
+      // the error; better the user sees a sign-in failure they can retry
+      // than silently lose their beta allocation. The $transaction already
+      // guarantees atomicity (no half-applied state).
+      try {
+        await prisma.$transaction(async (tx) => {
+          await tx.user.update({
+            where: { id: user.id! },
             data: {
-              usedAt: new Date(),
-              usedByUserId: user.id!,
+              credits: allocation.credits,
+              tier: "FREE",
+              isBetaUser,
+              sentimentCredits: allocation.sentimentQuota,
+              creditsResetDate: resetDate,
+              sentimentResetDate: resetDate,
             },
           });
-        }
-      });
 
-      // Best-effort cookie cleanup (don't crash signup if it fails)
+          await tx.brandVoice.create({
+            data: {
+              userId: user.id!,
+              tone: "professional",
+              formality: 3,
+              keyPhrases: ["Thank you", "We appreciate your feedback"],
+              styleNotes: "Be genuine and empathetic",
+            },
+          });
+
+          if (appliedCode) {
+            await tx.betaInviteLink.update({
+              where: { code: appliedCode },
+              data: {
+                usedAt: new Date(),
+                usedByUserId: user.id!,
+              },
+            });
+          }
+        });
+      } catch (error) {
+        Sentry.captureException(error, {
+          tags: { area: "phase_1_beta_allocation" },
+          extra: {
+            userId: user.id,
+            isBetaUser,
+            appliedCode,
+            allocation,
+          },
+        });
+        // Re-throw — do NOT swallow. A failed allocation must not result in
+        // a silently-Free beta user.
+        throw error;
+      }
+
+      // Best-effort cookie cleanup (don't crash signup if it fails). The
+      // cookie is short-lived (10-min Max-Age) so a failed delete is
+      // genuinely harmless — it'll expire on its own. Capture to Sentry at
+      // a lower severity so we can spot if it's failing systematically
+      // (which could indicate an edge-runtime cookie API problem) without
+      // it ever blocking a sign-in.
       try {
         const cookieStore = await cookies();
         cookieStore.delete(INVITE_COOKIE_NAME);
-      } catch {
-        // ignore
+      } catch (error) {
+        Sentry.captureException(error, {
+          level: "warning",
+          tags: { area: "phase_1_oauth_invite_cookie" },
+        });
       }
     },
   },

--- a/tests/unit/api/beta-invites/validate.test.ts
+++ b/tests/unit/api/beta-invites/validate.test.ts
@@ -65,6 +65,25 @@ describe('GET /api/beta-invites/[code]/validate', () => {
     expect(json.data).toEqual({ valid: false, expired: false, used: false, exists: false });
   });
 
+  it('fails safe to exists=false when the DB lookup throws (Sentry-instrumented path)', async () => {
+    // The route captures to Sentry (no-op in test env) and returns a
+    // graceful "doesn't exist" rather than crashing the signup flow.
+    mockPrisma.betaInviteLink.findUnique.mockRejectedValue(
+      new Error('connection reset'),
+    );
+
+    const res = await callValidate('DB-IS-DOWN');
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+    expect(json.data).toEqual({
+      valid: false,
+      expired: false,
+      used: false,
+      exists: false,
+    });
+  });
+
   it('rejects codes longer than 64 chars without hitting the DB', async () => {
     const longCode = 'a'.repeat(65);
     const res = await callValidate(longCode);

--- a/tests/unit/api/founder-inquiries/founder-inquiries.test.ts
+++ b/tests/unit/api/founder-inquiries/founder-inquiries.test.ts
@@ -218,4 +218,30 @@ describe('POST /api/founder-inquiries', () => {
     expect(json.success).toBe(true);
     expect(json.data.inquiryId).toBe('inq-3');
   });
+
+  it('returns a structured 500 (not an unhandled crash) when the inquiry insert fails', async () => {
+    // Sentry-instrumented path (capture is a no-op in test env). The point
+    // is the response is a clean INTERNAL_ERROR the form can retry on,
+    // rather than an unhandled rejection / generic crash.
+    mockAuth.mockResolvedValue(null);
+    mockPrisma.founderInquiry.create.mockRejectedValue(
+      new Error('unique constraint violated'),
+    );
+
+    const res = await POST(
+      makeRequest({
+        type: 'beta_request',
+        source: 'pricing',
+        submitterEmail: 'anita@example.com',
+        message: 'Please let me in',
+      }),
+    );
+
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.success).toBe(false);
+    expect(json.error.code).toBe('INTERNAL_ERROR');
+    // Email notification must NOT be attempted if the row never saved.
+    expect(mockEmail.sendFounderInquiryNotification).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

Iteration 3 PR 2 of 4. Per [MVP.md Section 13.10](docs/MVP_Phase-1/MVP.md). With the Sentry pipeline now verified working (DSN env-var fixed; `/sentry-example-page` errors confirmed reaching Sentry Issues — the issue is `JAVASCRIPT-NEXTJS-1`, 10 events, 1mo old), instrument the five new phase-1 server paths so failures surface instead of failing silently.

## Tag taxonomy (`area: phase_1_*`)

| Tag | Location |
|---|---|
| `phase_1_beta_allocation` | `src/lib/auth.ts` — `events.signIn` allocation transaction |
| `phase_1_oauth_invite_cookie` | `src/lib/auth.ts` — invite-cookie read + cleanup |
| `phase_1_signup_beta` / `phase_1_signup` | `src/app/api/auth/signup` catch (tagged by whether a betaCode was involved) |
| `phase_1_founder_inquiry` | `src/app/api/founder-inquiries` — insert + notification email |
| `phase_1_invite_validation` | `src/app/api/beta-invites/[code]/validate` |

## Re-throw policy — deliberately per-path, by blast radius

- **Beta allocation (the critical one).** The `events.signIn` transaction (sets credits/tier/`isBetaUser`, creates BrandVoice, marks invite used) was **previously unprotected**. A throw here silently left a beta user as Free (15/35 vs 150/750) or with no brand voice. Now: capture with full context (`userId`, `isBetaUser`, `appliedCode`, `allocation`) **then re-throw**. Failing loudly is correct — a retryable sign-in error beats a silently-downgraded beta user. `$transaction` already guarantees no half-applied state.
- **Invite validation.** DB lookup was unprotected (a throw 500'd the signup pre-check). Now captures and **fails safe** toward `exists:false` — the form routes that to expired-link recovery (graceful) instead of crashing a legitimate beta signup.
- **Founder inquiry.** The `prisma.create` was unprotected (unhandled crash → lost beta request). Now captures + returns a structured `INTERNAL_ERROR` 500 the form can retry on. The fire-and-forget notification email `.catch` also captures, at `level: warning` (row IS saved; only the real-time alert is degraded).
- **OAuth invite cookie.** Read failure already had try/catch + `console.error`; added capture. Cleanup failure captured at `level: warning` (10-min cookie self-expires — harmless, swallowed).

## Out of scope (follow-up)

Environment tagging — `NODE_ENV` is always `"production"` on Vercel so staging and prod Sentry events are indistinguishable. Real issue, deliberately kept out to keep this PR surgical. Tracked.

## Tests

- `+1` validate test: DB throw → fail-safe `exists:false` response
- `+1` founder-inquiry test: insert throw → structured 500, email NOT attempted
- signup change is purely additive to its existing catch (same 500 response) → existing tests cover it
- Captures are no-ops outside production (`enabled: NODE_ENV === "production"`) so test/local-dev unaffected

**747 unit tests passing** (was 745). `lint:strict`, `type-check`, `build` all clean.

## Verification plan (post-merge, on staging then prod)

1. `/sentry-example-page` still works (regression check — Sentry pipeline)
2. Force a founder-inquiry DB failure (e.g. temporarily break the table in a scratch env) → Sentry issue tagged `area:phase_1_founder_inquiry`
3. Spot-check the Sentry Issues filter by `area` tag to confirm the taxonomy is queryable

🤖 Generated with [Claude Code](https://claude.com/claude-code)