### PR TITLE
fix(reviews): attach locationId on review creation

### DIFF
--- a/src/app/api/reviews/route.ts
+++ b/src/app/api/reviews/route.ts
@@ -103,18 +103,47 @@ export async function POST(request: NextRequest) {
       sentimentAnalyzed = true;
     }
 
-    // Create review
-    const review = await prisma.review.create({
-      data: {
-        userId: session.user.id,
-        platform,
-        reviewText,
-        rating,
-        reviewerName,
-        reviewDate: reviewDate ? new Date(reviewDate) : null,
-        detectedLanguage: finalLanguage,
-        sentiment,
-      },
+    // Resolve the user's Location and create the review atomically.
+    //
+    // MVP enforces exactly one Location per user (MVP.md Section 7), so we
+    // attach the review to the user's single Location — same "first/only
+    // location" pattern used in the onboarding + settings-profile routes.
+    //
+    // Defensive create: every user that reaches "add review" has been
+    // through the onboarding gate (PR #103), which creates a Location. But
+    // if a Location is somehow missing we create a "Default Location"
+    // inline rather than inserting a review with a null locationId. This
+    // keeps the data clean (prerequisite for the iteration-3 NOT NULL
+    // contract migration) and self-heals the row. Wrapped in a transaction
+    // so a review can never be created without its Location, even under a
+    // concurrent request.
+    const review = await prisma.$transaction(async (tx) => {
+      let location = await tx.location.findFirst({
+        where: { userId: session.user.id },
+        orderBy: { createdAt: "asc" },
+        select: { id: true },
+      });
+
+      if (!location) {
+        location = await tx.location.create({
+          data: { userId: session.user.id, name: "Default Location" },
+          select: { id: true },
+        });
+      }
+
+      return tx.review.create({
+        data: {
+          userId: session.user.id,
+          locationId: location.id,
+          platform,
+          reviewText,
+          rating,
+          reviewerName,
+          reviewDate: reviewDate ? new Date(reviewDate) : null,
+          detectedLanguage: finalLanguage,
+          sentiment,
+        },
+      });
     });
 
     // Log sentiment usage and deduct credits if analyzed

--- a/tests/unit/api/reviews/reviews-crud.test.ts
+++ b/tests/unit/api/reviews/reviews-crud.test.ts
@@ -23,6 +23,7 @@ const mockPrisma = vi.hoisted(() => {
   return {
     user: m(),
     review: m(),
+    location: m(),
     reviewResponse: m(),
     responseVersion: m(),
     brandVoice: m(),
@@ -157,6 +158,8 @@ describe('POST /api/reviews', () => {
   it('creates review with auto-detected language and returns 201', async () => {
     mockPrisma.user.findUnique.mockResolvedValueOnce(baseUser);
     mockPrisma.review.findFirst.mockResolvedValueOnce(null); // no duplicate
+    // Location lookup inside the create transaction — user has one.
+    mockPrisma.location.findFirst.mockResolvedValueOnce({ id: 'loc-1' });
     mockPrisma.review.create.mockResolvedValueOnce(baseReview);
     // $transaction for sentiment logging (array style)
     mockPrisma.sentimentUsage.create.mockResolvedValueOnce({});
@@ -173,12 +176,23 @@ describe('POST /api/reviews', () => {
     expect(json.data.review.detectedLanguage).toBe('English');
     expect(json.data.sentimentAnalyzed).toBe(true);
     expect(mockPrisma.review.create).toHaveBeenCalledTimes(1);
+    // The review is attached to the user's existing Location, not created fresh.
+    expect(mockPrisma.location.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { userId: mockSession.user.id } }),
+    );
+    expect(mockPrisma.location.create).not.toHaveBeenCalled();
+    expect(mockPrisma.review.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ locationId: 'loc-1' }),
+      }),
+    );
   });
 
   it('skips sentiment when user has no sentiment credits and still creates review', async () => {
     const userNoSentiment = { ...baseUser, sentimentCredits: 0 };
     mockPrisma.user.findUnique.mockResolvedValueOnce(userNoSentiment);
     mockPrisma.review.findFirst.mockResolvedValueOnce(null);
+    mockPrisma.location.findFirst.mockResolvedValueOnce({ id: 'loc-1' });
 
     const reviewNoSentiment = { ...baseReview, sentiment: null };
     mockPrisma.review.create.mockResolvedValueOnce(reviewNoSentiment);
@@ -193,8 +207,42 @@ describe('POST /api/reviews', () => {
     expect(json.data.review.sentiment).toBeNull();
     expect(json.data.sentimentAnalyzed).toBe(false);
     expect(json.data.sentimentWarning).toBe('Sentiment analysis skipped: no credits remaining');
-    // No sentiment logging calls since analysis was skipped
-    expect(mockPrisma.$transaction).not.toHaveBeenCalled();
+    // Sentiment logging was skipped (no credits). The sentiment-usage
+    // transaction must not run — assert on the specific call rather than
+    // $transaction overall, since the location+review create now also
+    // uses a (callback-style) $transaction.
+    expect(mockPrisma.sentimentUsage.create).not.toHaveBeenCalled();
+  });
+
+  it('creates a Default Location inline when the user somehow has none', async () => {
+    // Defensive path: every user normally onboards (which creates a
+    // Location) before reaching "add review", but if a Location is missing
+    // we create one inline rather than inserting a null-locationId review.
+    mockPrisma.user.findUnique.mockResolvedValueOnce(baseUser);
+    mockPrisma.review.findFirst.mockResolvedValueOnce(null);
+    mockPrisma.location.findFirst.mockResolvedValueOnce(null); // no location!
+    mockPrisma.location.create.mockResolvedValueOnce({ id: 'loc-new' });
+    mockPrisma.review.create.mockResolvedValueOnce(baseReview);
+    mockPrisma.sentimentUsage.create.mockResolvedValueOnce({});
+    mockPrisma.user.update.mockResolvedValueOnce({});
+
+    const req = createRequest('/api/reviews', { method: 'POST', body: validBody });
+
+    const res = await POST(req);
+    const json = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(json.success).toBe(true);
+    expect(mockPrisma.location.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: { userId: mockSession.user.id, name: 'Default Location' },
+      }),
+    );
+    expect(mockPrisma.review.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ locationId: 'loc-new' }),
+      }),
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

**Iteration 3 PR 3a** — the prerequisite for the planned `Review.locationId` NOT NULL contract migration (PR 3b).

`POST /api/reviews` has **never set `Review.locationId`** since the column was added in iteration 1. The iteration-1 backfill script only fixed reviews that existed *at backfill time*; every review created through the app since then has `locationId = NULL`.

### Empirical proof (founder ran the count query)

| Env | null `locationId` |
|---|---|
| Production | **0** (no review activity since backfill — ~3 test users) |
| Staging | **13** (E2E + smoke-test activity accumulated unparented rows) |

The 13 staging nulls are the smoking gun: review creation drops `locationId`.

### Why this blocks PR 3b

You cannot `ALTER COLUMN "locationId" SET NOT NULL` while review creation keeps inserting nulls — the constraint would make `prisma.review.create` throw and **break "add review" for every user**. The constraint can only land *after* this fix bakes and both envs verify 0 nulls.

## The fix

Resolve the user's Location and create the review atomically in a `$transaction`:
- MVP enforces one Location per user ([MVP.md Section 7](docs/MVP_Phase-1/MVP.md)) → attach to the user's single Location via the same `location.findFirst({ orderBy: createdAt asc })` pattern used in onboarding + settings-profile routes
- **Defensive inline create**: if a Location is somehow missing (shouldn't happen post the PR #103 onboarding gate), create a `"Default Location"` in the same transaction rather than inserting a null-`locationId` review — keeps data clean, self-heals the row

Only one `review.create` call site exists in the codebase (verified — no seed/edit path creates reviews), so this single fix is complete.

## Tests

`tests/unit/api/reviews/reviews-crud.test.ts`:
- Added `location` to the Prisma mock
- Two create-success tests now stub `location.findFirst` + assert the review attaches to the existing location (no fresh create)
- **New case**: defensive inline-create path (no Location → creates `Default Location`, attaches it)
- Replaced the now-false `$transaction not called` assertion with a precise `sentimentUsage.create not called` (the location+review create now uses a callback-style `$transaction`)

**748 unit tests passing** (was 747). `lint:strict` / `type-check` / `build` all clean.

## Rollout / verification plan

1. Merge → staging auto-deploys
2. **Clear staging's 13 existing null rows** (re-run `scripts/backfill-locations.ts` against staging, or one SQL `UPDATE`) — these are pre-existing, not created by this PR
3. On staging: add a review through the UI → confirm the new row has a `locationId`
4. Promote to prod, add a review, confirm `locationId` set
5. **Let it bake.** Then PR 3b (the `SET NOT NULL` migration) — only after re-confirming `null_location = 0` on **both** staging and prod

This is the expand→contract discipline the iteration-1 plan intended; the plan just didn't account for review creation never having been wired to set the FK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)