### PR TITLE
feat: brand voice redesign iter 2 - V2 schema + constants + normalize adapter

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1471,6 +1471,63 @@ Branch: `feat/brand-voice-redesign-iter-1`. Closes the live prompt-injection gap
 
 Verification: `npm run lint:strict` clean; `npm run type-check` clean; `npm run test:unit` 783 passed, 0 failed; integration tests will run in CI's PostgreSQL container.
 
+### Iteration 2 — Validation schema + constants + normalize adapter (no DB, no behavior change)
+
+Branch: `feat/brand-voice-redesign-iter-2`. Pure type/validation/constant changes. The new V2 contract is exported and unit-tested, but the API routes still validate via the legacy `brandVoiceSchema` — that cutover lands in iteration 6. The only externally visible behaviour change is the response cap raise (500 → 2000), which is intentional and tested.
+
+#### Decision 44: Tone storage uses lowercase keys + display map, not the spec's literal display-string enum
+
+- **Decision:** `BRAND_VOICE_TONES_V2` are stable lowercase keys (`warm_casual`, `friendly_professional`, `polished_formal`, `empathetic_attentive`). Display labels (`"Warm & casual"`, etc.) are looked up via `BRAND_VOICE_TONE_INFO_V2[key].label`. `brandVoiceSchemaV2.tone` validates against the key set.
+- **Why:** Coupling DB values to UI copy makes any future label tweak a data migration. Lowercase keys also let `ReviewResponse.toneUsed` and the regenerate tone-modifier share the same key set as the brand voice tone field (corrected spec §8.1).
+- **Spec deviation:** Spec §9.2 Zod literally uses display strings. We deviate to the lowercase keys; the user approved this in the plan-decision discussion.
+- **Risk:** Low ✅. `LEGACY_TONE_TO_V2` covers every pre-V2 value (`friendly`, `professional`, `casual`, `formal`, `empathetic`) plus the `"default"` sentinel that the initial-generation route stores on `ReviewResponse.toneUsed`.
+
+#### Decision 45: `RESPONSE_TEXT_MAX` raised 500 → 2000; new `RESPONSE_BODY_CHAR_MAX` = 1200 added
+
+- **Decision:** `VALIDATION_LIMITS.RESPONSE_TEXT_MAX` raised from 500 to 2000 (assembled/stored + manual-edit cap). New `RESPONSE_BODY_CHAR_MAX = 1200` added for the model-emitted body alone — consumed by route truncation in iter 4 and by the closing-block-aware truncation in `assembleResponse` (iter 5).
+- **Why:** A multi-paragraph hospitality response (typical 600–1200 chars) plus salutation (~30 chars) plus sign-off (~80 chars) plus optional reply-to email line (~40 chars) blows the old 500-char budget. The spec's "2–4 paragraph + sign-off" output is structurally incompatible with the existing cap. Naive shipping with the old cap would chop the sign-off off every response.
+- **Storage impact:** `ReviewResponse.responseText` is `@db.Text` (no DB cap), so the raise is a pure validation/UI concern — no migration needed.
+- **Test fallout fixed in-iteration:** Two tests asserting `RESPONSE_TEXT_MAX === 500` and two ResponseEditor tests hard-coding `501` / `510` were updated. The ResponseEditor tests now import `VALIDATION_LIMITS.RESPONSE_TEXT_MAX` and assert *behaviour* rather than the number, so future cap changes won't break them.
+- **Risk:** Low ✅. Tested across validations, route, and component layers.
+
+#### Decision 46: `normalizeBrandVoice` lives in its own pure module, not in `claude.ts`
+
+- **Decision:** New file `src/lib/ai/brand-voice-normalize.ts` exports `normalizeBrandVoice(raw)` and `NormalizedBrandVoice`. The plan said "Add pure `normalizeBrandVoice` in `claude.ts`"; this decision splits it into its own module.
+- **Why:** Keeps `claude.ts` (which already grew in iter 1) lean. Lets the adapter be unit-tested independently of prompt construction. The function is genuinely pure (no Anthropic / no prisma), so the separation is honest. Iter 4 will import it back into `claude.ts:generateReviewResponse`.
+- **Risk:** Low ✅. Pure refactor of the plan's organisation.
+
+#### Decision 47: `BrandVoiceConfig` extended with V2 fields as optional (additive, dormant)
+
+- **Decision:** All V2 fields (`styleGuidelines`, `sampleResponsesV2`, `acknowledgeNamedStaff`, `acknowledgeOccasions`, `salutationPattern`, `signoffLines`, `negativeReviewEmailEnabled`, `negativeReviewFraming`, `negativeReviewFramingCustom`, `replyToEmail`) added as `?:` optional on the existing `BrandVoiceConfig` interface. The legacy `tone`/`formality`/`styleNotes`/`sampleResponses:string[]` fields remain required this iteration.
+- **Why:** Lets `BrandVoiceConfig` evolve in iter 4 without disturbing the three existing inline call sites in `generate`/`regenerate`/`brand-voice/test` routes — they still typecheck without modification. Iter 4 will swap the call sites to consume normalized V2 objects; this iteration just makes the contract expressible.
+- **Risk:** Low ✅. Pure type extension; `tsc` proves the 3 call sites still match.
+
+#### Decision 48: V2 Zod schema enforces a `styleGuidelines` per-item AND joined-total cap (200 / 2000)
+
+- **Decision:** `styleGuidelines` is validated as `string[]` with per-item max 200 chars, max 10 items, AND a `.refine` checking `arr.join("\n").length <= 2000` for the total-cap requirement (spec §4.2).
+- **Why:** Spec §4.2 specifies both a per-item and a total cap; relying only on the per-item × max-items product (200 × 10 = 2000 chars) wouldn't catch the edge where 10 short items + newlines exceed 2000.
+- **Note for UI iter 6:** The form will warn at ~90% of the total cap; this back-end check is the floor.
+- **Risk:** Low ✅.
+
+#### Decision 49: `replyToEmail` rejects literal `\n` and `\r` (header-injection guard)
+
+- **Decision:** `brandVoiceSchemaV2.replyToEmail` chains `.refine(v => !v.includes("\n") && !v.includes("\r"), ...)` on top of the standard email format check.
+- **Why:** Spec §7.5 calls this out explicitly. The reply-to email is interpolated into post-processed response text (iter 5); a stored email containing CR/LF would let a malicious user inject lines into every generated response — and if responses are ever published to a platform, into the platform's display.
+- **Risk:** Low ✅. The address column on `BrandVoice` is `varchar(254)`, so even without this check the blast radius is bounded; the check is defense-in-depth.
+
+#### Test coverage delta — Iteration 2
+
+| Type | Before iter 2 (suite total) | After iter 2 (suite total) | New from this iteration |
+|---|---|---|---|
+| Unit tests | 783 | 871 | **+88** |
+| New unit test files | — | — | 1 (`brand-voice-normalize.test.ts`) |
+| Modified unit test files | — | — | 3 (`validations.test.ts`, `constants.test.ts`, `response-editor.test.tsx`) |
+| Test files fixed for the cap raise | — | — | 2 (`response-edit.test.ts`, `response-editor.test.tsx`) |
+| Integration tests | — | — | 0 |
+| E2E specs | — | — | 0 |
+
+Verification: `npm run lint:strict` clean; `npm run type-check` clean; `npm run test:unit` 871 passed, 0 failed.
+
 ---
 
 ## Decision Log
@@ -1522,6 +1579,12 @@ Verification: `npm run lint:strict` clean; `npm run type-check` clean; `npm run 
 | 41 | Audit persistence stays in routes via helper; `sanitize.ts` is pure | Brand Voice Redesign / It. 1 | May 20 | Low ✅ | ✅ Implemented |
 | 42 | `INSTRUCTION_REINFORCEMENT` ships with security lines only in iter 1; structural lines added iter 4 | Brand Voice Redesign / It. 1 | May 20 | Low ✅ | ✅ Implemented |
 | 43 | `customRegenerateInstructions` param plumbed but dormant in iter 1; UI lands iter 6 | Brand Voice Redesign / It. 1 | May 20 | Low ✅ | ✅ Implemented |
+| 44 | Tone storage uses lowercase keys + display map, not spec's literal display-string Zod enum | Brand Voice Redesign / It. 2 | May 20 | Low ✅ | ✅ Implemented |
+| 45 | `RESPONSE_TEXT_MAX` raised 500→2000; new `RESPONSE_BODY_CHAR_MAX` = 1200 | Brand Voice Redesign / It. 2 | May 20 | Low ✅ | ✅ Implemented |
+| 46 | `normalizeBrandVoice` lives in its own pure module `src/lib/ai/brand-voice-normalize.ts`, not in `claude.ts` | Brand Voice Redesign / It. 2 | May 20 | Low ✅ | ✅ Implemented |
+| 47 | `BrandVoiceConfig` extended with V2 fields as optional (additive, dormant); call sites unchanged | Brand Voice Redesign / It. 2 | May 20 | Low ✅ | ✅ Implemented |
+| 48 | V2 schema enforces both per-item (200) AND joined-total (2000) caps on `styleGuidelines` | Brand Voice Redesign / It. 2 | May 20 | Low ✅ | ✅ Implemented |
+| 49 | `replyToEmail` rejects literal `\n` / `\r` (header-injection guard) on top of RFC email check | Brand Voice Redesign / It. 2 | May 20 | Low ✅ | ✅ Implemented |
 
 *Table will grow as decisions are made*
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1105,8 +1105,8 @@ A four-section restructure of the brand voice settings screen (Voice / Examples 
 
 | Iter. | Scope | Status |
 |---|---|---|
-| 1 | Sanitize helper + review-text retrofit + SecurityLog | ✅ Done (May 20) |
-| 2 | Validation schema + constants + normalize adapter | ⏳ Not started |
+| 1 | Sanitize helper + review-text retrofit + SecurityLog | ✅ Done (May 20, merged via PR #120) |
+| 2 | Validation schema + constants + normalize adapter | ✅ Done (May 20) |
 | 3 | Clean-reset schema migration + minimal route field-name cutover | ⏳ Not started |
 | 4 | Prompt-building rewrite (bug fix, wrap fields, structure, fragments) | ⏳ Not started |
 | 5 | Post-processing module + route wiring | ⏳ Not started |
@@ -1146,7 +1146,42 @@ A four-section restructure of the brand voice settings screen (Voice / Examples 
 
 **Decisions** (cross-reference DECISIONS.md "Brand Voice Page Redesign / Iteration 1" subsection): #39 security retrofit ships first; #40 new SecurityLog table (not Sentry-only); #41 audit persistence in routes, `sanitize.ts` stays pure; #42 reinforcement tail has security lines only this iteration; #43 `customRegenerateInstructions` plumbed but dormant.
 
+### ✅ Iteration 2 — Validation schema + constants + normalize adapter
+
+**Branch:** `feat/brand-voice-redesign-iter-2`
+**Status:** Locally verified (lint:strict / type-check / 871 unit tests passing). PR pending.
+
+Pure type/validation/constant changes — zero DB changes, zero runtime behaviour change for clean inputs. Makes the new V2 contract explicit and unit-tested before the schema reset (iter 3) so iter 3 becomes "DB only". The one externally visible behaviour change is the response cap raise (500→2000), which is intentional, tested across validations + route + component layers, and documented in DECISION #45.
+
+**What shipped:**
+
+- **`src/lib/constants.ts`** — new exports: `BRAND_VOICE_TONES_V2` (4 lowercase keys), `BRAND_VOICE_TONE_INFO_V2` (display labels + descriptors per spec §4.1), `DEFAULT_BRAND_VOICE_TONE_V2`, `LEGACY_TONE_TO_V2` (maps every legacy key + the `"default"` sentinel from `ReviewResponse.toneUsed`), `NEGATIVE_REVIEW_FRAMINGS` + `DEFAULT_NEGATIVE_REVIEW_FRAMING`, `BRAND_VOICE_LIMITS_V2` (per-field caps from spec §4.2/§4.3/§5.1/§7.x), `RESPONSE_BODY_CHAR_MAX = 1200`. Legacy `BRAND_VOICE_TONES` / `BRAND_VOICE_TONE_INFO` / `BRAND_VOICE_LIMITS` / `FORMALITY_*` retained until iter 6 cuts the form payload over. `VALIDATION_LIMITS.RESPONSE_TEXT_MAX` raised 500 → 2000.
+- **`src/lib/validations.ts`** — new `brandVoiceSchemaV2` per spec §9.2 with the lowercase-key tone enum (DECISION #44), V2 sample-response object shape (`{ratingContext: 1-5|'any', responseText}`), per-item + joined-total caps on styleGuidelines (DECISION #48), header-injection guard on `replyToEmail` (DECISION #49). Old `brandVoiceSchema` retained until iter 6 cutover. `updateResponseSchema` automatically picks up the new 2000 cap via `VALIDATION_LIMITS.RESPONSE_TEXT_MAX`.
+- **`src/lib/ai/brand-voice-normalize.ts` (NEW, pure module)** — `normalizeBrandVoice(raw)` accepts any plausible payload (legacy DB row, V2 row, partial object, untrusted JSON, even `null`) and returns the canonical `NormalizedBrandVoice` shape. Legacy `styleNotes` (JSON-stringified array OR newline-separated string) → `string[]`. Legacy `sampleResponses: string[]` → `[{ratingContext: 'any', ...}]`. Legacy tones mapped via `LEGACY_TONE_TO_V2`. Unknown / malformed values fall back to defaults. Unit-tested now (DECISION #46); wired into `generateReviewResponse` in iter 4.
+- **`src/lib/ai/claude.ts`** — `BrandVoiceConfig` extended with all V2 fields as optional (DECISION #47). The three inline call sites in `generate`/`regenerate`/`brand-voice/test` continue to typecheck without modification. No runtime change — the new fields are not yet read by `buildSystemPrompt` (that lands in iter 4).
+- **Test fallout fixed in-iteration:** `tests/unit/lib/constants.test.ts` "RESPONSE_TEXT_MAX is 500" → 2000; `tests/unit/lib/validations.test.ts` updateResponseSchema 500-cap tests → 2000; `tests/unit/api/reviews/response-edit.test.ts` "exceeding 500 characters" → "exceeding the max length"; `tests/unit/components/reviews/response-editor.test.tsx` hard-coded `501`/`510` replaced with `VALIDATION_LIMITS.RESPONSE_TEXT_MAX + 1` / `+ 10` so future cap changes don't break the tests.
+
+**Test coverage delta:**
+
+| Type | Before iter 2 (suite total) | After iter 2 (suite total) | New from this iteration |
+|---|---|---|---|
+| Unit tests | 783 | 871 | **+88** |
+| New unit test files | — | — | 1 (`tests/unit/lib/ai/brand-voice-normalize.test.ts`) |
+| Modified unit test files | — | — | 3 (`validations.test.ts`, `constants.test.ts`, `response-editor.test.tsx`) |
+| Test files fixed for the cap raise | — | — | 2 (`response-edit.test.ts`, `response-editor.test.tsx`) |
+| Integration tests | — | — | 0 |
+| E2E specs | — | — | 0 |
+
+**Verification status:**
+
+- ✅ `npm run lint:strict` clean
+- ✅ `npm run type-check` clean
+- ✅ `npm run test:unit` 871 passed, 0 failed (61 test files)
+- No DB migration this iteration; nothing for `prisma migrate deploy` to run.
+
+**Decisions** (cross-reference DECISIONS.md "Brand Voice Page Redesign / Iteration 2" subsection): #44 tone storage = lowercase keys + display map; #45 RESPONSE_TEXT_MAX 500→2000 + new RESPONSE_BODY_CHAR_MAX=1200; #46 normalizeBrandVoice in its own pure module; #47 BrandVoiceConfig extended with optional V2 fields; #48 styleGuidelines per-item AND joined-total caps; #49 replyToEmail rejects `\n`/`\r` (header-injection guard).
+
 ---
 
 **Last Updated:** May 20, 2026
-**Status:** Brand voice redesign iteration 1 complete on branch (PR pending). MVP Phase 1 (Closed Beta) remains the most recent production deploy.
+**Status:** Brand voice redesign iteration 2 complete on branch (PR pending). Iteration 1 merged via PR #120. MVP Phase 1 (Closed Beta) remains the most recent production deploy.

--- a/src/lib/ai/brand-voice-normalize.ts
+++ b/src/lib/ai/brand-voice-normalize.ts
@@ -1,0 +1,211 @@
+/**
+ * Brand voice normalization adapter (iter 2).
+ *
+ * Read-time adapter that converts a brand-voice record — in either the legacy
+ * shape (`styleNotes`, `sampleResponses: string[]`, old tone keys, `formality`)
+ * or the V2 shape (`styleGuidelines`, object-array sample responses, V2 tone
+ * keys, no formality) — into the canonical V2 shape that the iter-4 prompt
+ * builder will consume.
+ *
+ * Wired into `generateReviewResponse` in iteration 4. Unit-tested now so the
+ * contract is locked before the schema reset (iter 3) flips the underlying
+ * column shapes.
+ *
+ * Pure: no prisma, no Anthropic SDK, no I/O. Safe to call on any plain
+ * object including untrusted JSON parsed from a DB JSONB column.
+ *
+ * Spec: docs/MVP_Phase-1/BRAND_VOICE_REDESIGN.md §4.1 (tone mapping), §4.2
+ * (styleNotes → styleGuidelines), §5.1 (sample responses object shape).
+ */
+
+import {
+  BRAND_VOICE_TONES_V2,
+  DEFAULT_BRAND_VOICE_TONE_V2,
+  DEFAULT_NEGATIVE_REVIEW_FRAMING,
+  LEGACY_TONE_TO_V2,
+  type BrandVoiceToneV2,
+  type NegativeReviewFraming,
+  NEGATIVE_REVIEW_FRAMINGS,
+} from "@/lib/constants";
+
+/** Sample-response item, normalized shape. */
+export interface NormalizedSampleResponse {
+  ratingContext: 1 | 2 | 3 | 4 | 5 | "any";
+  responseText: string;
+}
+
+/**
+ * Canonical V2 shape produced by `normalizeBrandVoice`. All fields are
+ * non-optional with sane defaults; downstream code can rely on this.
+ */
+export interface NormalizedBrandVoice {
+  tone: BrandVoiceToneV2;
+  styleGuidelines: string[];
+  keyPhrases: string[];
+  sampleResponses: NormalizedSampleResponse[];
+  acknowledgeNamedStaff: boolean;
+  acknowledgeOccasions: boolean;
+  salutationPattern: string;
+  signoffLines: string;
+  negativeReviewEmailEnabled: boolean;
+  negativeReviewFraming: NegativeReviewFraming;
+  negativeReviewFramingCustom: string | null;
+  replyToEmail: string | null;
+}
+
+const DEFAULTS: NormalizedBrandVoice = {
+  tone: DEFAULT_BRAND_VOICE_TONE_V2,
+  styleGuidelines: [],
+  keyPhrases: [],
+  sampleResponses: [],
+  acknowledgeNamedStaff: true,
+  acknowledgeOccasions: true,
+  salutationPattern: "Dear {firstName},",
+  signoffLines: "Warmest regards,\nThe Team",
+  negativeReviewEmailEnabled: false,
+  negativeReviewFraming: DEFAULT_NEGATIVE_REVIEW_FRAMING,
+  negativeReviewFramingCustom: null,
+  replyToEmail: null,
+};
+
+const V2_TONE_SET = new Set<string>(BRAND_VOICE_TONES_V2);
+const FRAMING_SET = new Set<string>(NEGATIVE_REVIEW_FRAMINGS);
+
+/**
+ * Map any tone string we might see in stored data to a V2 key.
+ *
+ * - V2 key passed through                  → unchanged
+ * - Legacy key in LEGACY_TONE_TO_V2        → mapped
+ * - "default" (used on first-generation ReviewResponse.toneUsed) → default V2
+ * - Anything else                          → default V2 (defensive)
+ */
+function normalizeTone(raw: unknown): BrandVoiceToneV2 {
+  if (typeof raw !== "string") return DEFAULTS.tone;
+  if (V2_TONE_SET.has(raw)) return raw as BrandVoiceToneV2;
+  const mapped = LEGACY_TONE_TO_V2[raw];
+  return mapped ?? DEFAULTS.tone;
+}
+
+/**
+ * Parse legacy `styleNotes` into a `string[]`.
+ *
+ * Legacy storage was `JSON.stringify(string[])` in a text column (the iter-1
+ * BRAND_VOICE_REDESIGN.md headline bug). On read we try `JSON.parse` first;
+ * fall back to newline-split for any rows that pre-date the JSON serialization
+ * (the form once stored newline-separated strings). Anything that fails to
+ * yield a string array becomes `[]`.
+ */
+function normalizeStyleGuidelinesFromLegacy(raw: unknown): string[] {
+  if (raw == null) return [];
+  if (Array.isArray(raw)) {
+    // Already a JSONB array from the V2 column.
+    return raw.filter((s): s is string => typeof s === "string" && s.trim().length > 0).map((s) => s.trim());
+  }
+  if (typeof raw !== "string") return [];
+  // Try JSON-array form first.
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return parsed.filter((s): s is string => typeof s === "string" && s.trim().length > 0).map((s) => s.trim());
+    }
+  } catch {
+    // Not JSON — fall through to the newline split.
+  }
+  // Pre-JSON legacy form: newline-separated lines.
+  return raw
+    .split("\n")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/**
+ * Normalize sample responses to the V2 object shape.
+ *
+ * - `string[]` (legacy)                         → `[{ratingContext:'any', responseText:s}, ...]`
+ * - Array of `{ratingContext, responseText}`    → passed through, ratingContext coerced
+ * - Anything else                               → `[]`
+ */
+function normalizeSampleResponses(raw: unknown): NormalizedSampleResponse[] {
+  if (!Array.isArray(raw)) return [];
+  const out: NormalizedSampleResponse[] = [];
+  for (const item of raw) {
+    if (typeof item === "string") {
+      const trimmed = item.trim();
+      if (trimmed.length > 0) {
+        out.push({ ratingContext: "any", responseText: trimmed });
+      }
+      continue;
+    }
+    if (item && typeof item === "object") {
+      const rec = item as Record<string, unknown>;
+      const text = typeof rec.responseText === "string" ? rec.responseText.trim() : "";
+      if (text.length === 0) continue;
+      const rating = rec.ratingContext;
+      let ratingContext: NormalizedSampleResponse["ratingContext"] = "any";
+      if (rating === "any") {
+        ratingContext = "any";
+      } else if (typeof rating === "number" && Number.isInteger(rating) && rating >= 1 && rating <= 5) {
+        ratingContext = rating as 1 | 2 | 3 | 4 | 5;
+      }
+      out.push({ ratingContext, responseText: text });
+    }
+  }
+  return out;
+}
+
+function normalizeKeyPhrases(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.filter((s): s is string => typeof s === "string" && s.trim().length > 0).map((s) => s.trim());
+}
+
+function asBoolean(raw: unknown, fallback: boolean): boolean {
+  return typeof raw === "boolean" ? raw : fallback;
+}
+
+function asString(raw: unknown, fallback: string): string {
+  return typeof raw === "string" && raw.length > 0 ? raw : fallback;
+}
+
+function asNullableString(raw: unknown): string | null {
+  if (typeof raw !== "string") return null;
+  const trimmed = raw.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeFraming(raw: unknown): NegativeReviewFraming {
+  if (typeof raw === "string" && FRAMING_SET.has(raw)) return raw as NegativeReviewFraming;
+  return DEFAULTS.negativeReviewFraming;
+}
+
+/**
+ * Normalize any plausible brand-voice payload (legacy DB row, V2 DB row,
+ * partial object, untrusted JSON) into the canonical {@link NormalizedBrandVoice}
+ * shape. Missing fields fall back to spec defaults. Unknown fields are ignored.
+ *
+ * Safe to call on `null` / `undefined` — returns a full defaults object.
+ */
+export function normalizeBrandVoice(raw: unknown): NormalizedBrandVoice {
+  if (raw == null || typeof raw !== "object") {
+    return { ...DEFAULTS };
+  }
+  const r = raw as Record<string, unknown>;
+
+  // Style guidelines: prefer V2 column when present, fall back to legacy.
+  const styleSource = "styleGuidelines" in r ? r.styleGuidelines : r.styleNotes;
+  const styleGuidelines = normalizeStyleGuidelinesFromLegacy(styleSource);
+
+  return {
+    tone: normalizeTone(r.tone),
+    styleGuidelines,
+    keyPhrases: normalizeKeyPhrases(r.keyPhrases),
+    sampleResponses: normalizeSampleResponses(r.sampleResponses),
+    acknowledgeNamedStaff: asBoolean(r.acknowledgeNamedStaff, DEFAULTS.acknowledgeNamedStaff),
+    acknowledgeOccasions: asBoolean(r.acknowledgeOccasions, DEFAULTS.acknowledgeOccasions),
+    salutationPattern: asString(r.salutationPattern, DEFAULTS.salutationPattern),
+    signoffLines: asString(r.signoffLines, DEFAULTS.signoffLines),
+    negativeReviewEmailEnabled: asBoolean(r.negativeReviewEmailEnabled, DEFAULTS.negativeReviewEmailEnabled),
+    negativeReviewFraming: normalizeFraming(r.negativeReviewFraming),
+    negativeReviewFramingCustom: asNullableString(r.negativeReviewFramingCustom),
+    replyToEmail: asNullableString(r.replyToEmail),
+  };
+}

--- a/src/lib/ai/claude.ts
+++ b/src/lib/ai/claude.ts
@@ -10,12 +10,49 @@ import { INSTRUCTION_REINFORCEMENT, wrapUserContent } from "./sanitize";
 // Default model for response generation
 export const DEFAULT_MODEL = "claude-sonnet-4-20250514";
 
+/**
+ * Brand voice configuration consumed by `generateReviewResponse`.
+ *
+ * Shape note (brand voice redesign):
+ *   - Legacy fields (`formality`, `styleNotes`, `sampleResponses: string[]`)
+ *     remain required this iteration so the three existing inline call sites
+ *     in `generate`/`regenerate`/`brand-voice/test` routes keep type-checking
+ *     without changes. They become optional / are removed in iteration 4 once
+ *     the route caller objects are replaced with the V2 shape from
+ *     `getOrCreateBrandVoice` after the iter-3 schema reset.
+ *   - V2 fields are all optional this iteration — `normalizeBrandVoice` will
+ *     supply defaults for any that are missing. The prompt builder still
+ *     ignores them in iter 2; they're consumed starting iter 4.
+ *
+ * See `src/lib/ai/brand-voice-normalize.ts` for the canonical V2 shape
+ * (`NormalizedBrandVoice`).
+ */
 export interface BrandVoiceConfig {
   tone: string;
   formality: number;
   keyPhrases: string[];
   styleNotes: string | null;
   sampleResponses: string[];
+
+  // ─── V2 fields (iter 2: optional, dormant; iter 4: consumed by buildSystemPrompt) ───
+  styleGuidelines?: string[];
+  /**
+   * V2 sample responses: each entry is a typed object with a rating context
+   * (1–5 or "any") and the response text. Iter 4 will render these as labeled
+   * few-shot examples; iter 2 only locks the type.
+   */
+  sampleResponsesV2?: Array<{
+    ratingContext: 1 | 2 | 3 | 4 | 5 | "any";
+    responseText: string;
+  }>;
+  acknowledgeNamedStaff?: boolean;
+  acknowledgeOccasions?: boolean;
+  salutationPattern?: string;
+  signoffLines?: string;
+  negativeReviewEmailEnabled?: boolean;
+  negativeReviewFraming?: "management_contact" | "investigation" | "open_channel" | "custom";
+  negativeReviewFramingCustom?: string | null;
+  replyToEmail?: string | null;
 }
 
 export type ToneModifier = "professional" | "friendly" | "empathetic";

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -28,6 +28,9 @@ export const RESPONSE_TONES = ["professional", "friendly", "empathetic"] as cons
 export type ResponseTone = (typeof RESPONSE_TONES)[number];
 
 // Brand voice tones (for brand voice configuration)
+//
+// Legacy lowercase set retained until iteration 6 cuts the API over to V2.
+// New set lives in BRAND_VOICE_TONES_V2 below.
 export const BRAND_VOICE_TONES = ["professional", "friendly", "casual", "empathetic"] as const;
 export type BrandVoiceTone = (typeof BRAND_VOICE_TONES)[number];
 
@@ -54,6 +57,120 @@ export const BRAND_VOICE_TONE_INFO: Record<BrandVoiceTone, { label: string; desc
     icon: "heart",
   },
 };
+
+// ─── Brand voice redesign (iter 2) ──────────────────────────────────
+// Spec: docs/MVP_Phase-1/BRAND_VOICE_REDESIGN.md §4.1.
+//
+// V2 stores stable lowercase keys in the DB and renders the display label
+// via a map (DECISION #2 in the redesign plan). Avoids coupling DB values
+// to UI copy and lets the regenerate tone-modifier share the same key set
+// as the brand voice tone field (spec §8.1).
+
+export const BRAND_VOICE_TONES_V2 = [
+  "warm_casual",
+  "friendly_professional",
+  "polished_formal",
+  "empathetic_attentive",
+] as const;
+export type BrandVoiceToneV2 = (typeof BRAND_VOICE_TONES_V2)[number];
+
+export const DEFAULT_BRAND_VOICE_TONE_V2: BrandVoiceToneV2 = "friendly_professional";
+
+export const BRAND_VOICE_TONE_INFO_V2: Record<
+  BrandVoiceToneV2,
+  { label: string; description: string; icon: string }
+> = {
+  warm_casual: {
+    label: "Warm & casual",
+    description: "Relaxed, like greeting a returning guest at the door",
+    icon: "coffee",
+  },
+  friendly_professional: {
+    label: "Friendly & professional",
+    description: "Warm but composed — the default for most hospitality brands",
+    icon: "smile",
+  },
+  polished_formal: {
+    label: "Polished & formal",
+    description: "Refined and precise, for premium and luxury experiences",
+    icon: "briefcase",
+  },
+  empathetic_attentive: {
+    label: "Empathetic & attentive",
+    description: "For guests whose experience matters most — used heavily on complaints",
+    icon: "heart",
+  },
+};
+
+/**
+ * Legacy → V2 tone key mapping (spec §4.1 / §8.1).
+ *
+ * Used by `normalizeBrandVoice` in claude.ts so existing rows (and the
+ * regenerate tone-modifier values stored on `ReviewResponse.toneUsed`)
+ * stay valid until iteration 6 cuts the API over to V2 keys.
+ *
+ * Note: iteration 3 will TRUNCATE `brand_voices` (test data only), so this
+ * mapping primarily protects in-flight data — defaults, `toneUsed` strings
+ * already persisted on responses, and any code path that still passes the
+ * old key set.
+ */
+export const LEGACY_TONE_TO_V2: Record<string, BrandVoiceToneV2> = {
+  // BrandVoiceTone (legacy stored values)
+  friendly: "friendly_professional",
+  professional: "friendly_professional",
+  casual: "warm_casual",
+  formal: "polished_formal", // never persisted (only "formal" check was in a schema comment), but mapped defensively
+  empathetic: "empathetic_attentive",
+  // ResponseTone / ToneModifier values stored on ReviewResponse.toneUsed —
+  // these become the new key set on read so the regenerate selector aligns.
+  // "default" is also used in production (initial generation toneUsed) so it
+  // resolves to the default key — the model's tone modifier path is unaffected.
+  default: "friendly_professional",
+};
+
+// Spec §7.4 — negative-review email framing options.
+export const NEGATIVE_REVIEW_FRAMINGS = [
+  "management_contact",
+  "investigation",
+  "open_channel",
+  "custom",
+] as const;
+export type NegativeReviewFraming = (typeof NEGATIVE_REVIEW_FRAMINGS)[number];
+
+export const DEFAULT_NEGATIVE_REVIEW_FRAMING: NegativeReviewFraming = "investigation";
+
+/**
+ * Brand voice limits — V2 shape.
+ *
+ * Spec §4.2, §4.3, §5.1, §7.x.
+ *
+ * Per-item / total caps for the new V2 schema. The legacy `BRAND_VOICE_LIMITS`
+ * stays exported until iteration 6 cuts the form payload to V2.
+ */
+export const BRAND_VOICE_LIMITS_V2 = {
+  // Style guidelines
+  STYLE_GUIDELINE_ITEM_MAX: 200,
+  STYLE_GUIDELINES_MAX_ITEMS: 10,
+  STYLE_GUIDELINES_TOTAL_MAX: 2000,
+  // Key phrases
+  KEY_PHRASE_MAX: 100,
+  KEY_PHRASES_MAX_ITEMS: 10,
+  // Sample responses
+  SAMPLE_RESPONSE_MAX: 1000,
+  SAMPLE_RESPONSES_MAX_ITEMS: 5,
+  // Contact & sign-off
+  SALUTATION_MAX: 100,
+  SIGNOFF_MAX: 500,
+  FRAMING_CUSTOM_MAX: 500,
+  REPLY_TO_EMAIL_MAX: 254,
+} as const;
+
+// Spec / decision 3 — the model is told to generate a body of approximately
+// 200 words; this constant is the hard char cap on the model-emitted body
+// (before post-processing prepends salutation + appends sign-off + optional
+// email). VALIDATION_LIMITS.RESPONSE_TEXT_MAX (2000) is the assembled-and-
+// stored cap.
+export const RESPONSE_BODY_CHAR_MAX = 1200;
 
 // Formality level labels
 export const FORMALITY_LABELS = [
@@ -315,10 +432,19 @@ export const CREDIT_COSTS = {
 } as const;
 
 // Validation limits
+//
+// RESPONSE_TEXT_MAX raised from 500 to 2000 in the brand voice redesign
+// (iter 2): the new design assembles salutation + multi-paragraph body +
+// sign-off + optional reply-to email, none of which fit inside 500 chars.
+// The model-emitted body has its own narrower cap (RESPONSE_BODY_CHAR_MAX
+// above ≈ "approximately 200 words"); this constant is the assembled-and-
+// stored cap and also bounds manual edits in updateResponseSchema.
+// ReviewResponse.responseText is @db.Text (no DB cap) so the raise is a
+// pure validation/UI concern.
 export const VALIDATION_LIMITS = {
   REVIEW_TEXT_MIN: 1,
   REVIEW_TEXT_MAX: 2000,
-  RESPONSE_TEXT_MAX: 500,
+  RESPONSE_TEXT_MAX: 2000,
   PASSWORD_MIN: 8,
   PASSWORD_MAX: 100,
   NAME_MAX: 100,

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -11,6 +11,12 @@ import {
   SIGNUP_INTENTS,
   FOUNDER_INQUIRY_TYPES,
   FOUNDER_INQUIRY_SOURCES,
+  // Brand voice redesign V2
+  BRAND_VOICE_TONES_V2,
+  DEFAULT_BRAND_VOICE_TONE_V2,
+  NEGATIVE_REVIEW_FRAMINGS,
+  DEFAULT_NEGATIVE_REVIEW_FRAMING,
+  BRAND_VOICE_LIMITS_V2,
   type Industry,
 } from "./constants";
 
@@ -188,6 +194,145 @@ export const testBrandVoiceSchema = z.object({
   platform: z.enum(PLATFORMS).optional().default("Google"),
   rating: z.number().min(1).max(5).optional().nullable(),
 });
+
+// ─── Brand voice redesign V2 (iter 2) ──────────────────────────────
+// Spec: docs/MVP_Phase-1/BRAND_VOICE_REDESIGN.md §9.2.
+//
+// V2 is unit-tested and exported now, but NOT yet wired into the API
+// routes — the brand-voice GET/PUT continue to validate via the legacy
+// `brandVoiceSchema` until iteration 6 swaps them over. This lets us
+// land the schema contract independently of the schema reset (iter 3),
+// the prompt rewrite (iter 4), and the form rewrite (iter 6).
+//
+// Key deviation from spec §9.2: `tone` uses the stable lowercase key set
+// from BRAND_VOICE_TONES_V2 instead of the display strings the spec
+// literally shows. Display labels are looked up via BRAND_VOICE_TONE_INFO_V2.
+// Rationale: DECISIONS row #39+ in DECISIONS.md, plan decision 2.
+
+const sampleResponseV2Schema = z.object({
+  ratingContext: z.union([
+    z.number().int().min(1).max(5),
+    z.literal("any"),
+  ]),
+  responseText: z
+    .string()
+    .min(1, "Sample response cannot be empty")
+    .max(
+      BRAND_VOICE_LIMITS_V2.SAMPLE_RESPONSE_MAX,
+      `Sample response must be under ${BRAND_VOICE_LIMITS_V2.SAMPLE_RESPONSE_MAX} characters`,
+    )
+    .transform((s) => s.trim()),
+});
+
+export const brandVoiceSchemaV2 = z.object({
+  tone: z.enum(BRAND_VOICE_TONES_V2, {
+    message: "Please select a valid tone",
+  }),
+
+  styleGuidelines: z
+    .array(
+      z
+        .string()
+        .min(1, "Style guideline cannot be empty")
+        .max(
+          BRAND_VOICE_LIMITS_V2.STYLE_GUIDELINE_ITEM_MAX,
+          `Each style guideline must be under ${BRAND_VOICE_LIMITS_V2.STYLE_GUIDELINE_ITEM_MAX} characters`,
+        )
+        .transform((s) => s.trim()),
+    )
+    .max(
+      BRAND_VOICE_LIMITS_V2.STYLE_GUIDELINES_MAX_ITEMS,
+      `Maximum ${BRAND_VOICE_LIMITS_V2.STYLE_GUIDELINES_MAX_ITEMS} style guidelines`,
+    )
+    .default([])
+    .refine(
+      (arr) => arr.join("\n").length <= BRAND_VOICE_LIMITS_V2.STYLE_GUIDELINES_TOTAL_MAX,
+      `Style guidelines total must be under ${BRAND_VOICE_LIMITS_V2.STYLE_GUIDELINES_TOTAL_MAX} characters`,
+    ),
+
+  keyPhrases: z
+    .array(
+      z
+        .string()
+        .min(1, "Key phrase cannot be empty")
+        .max(
+          BRAND_VOICE_LIMITS_V2.KEY_PHRASE_MAX,
+          `Each key phrase must be under ${BRAND_VOICE_LIMITS_V2.KEY_PHRASE_MAX} characters`,
+        )
+        .transform((s) => s.trim()),
+    )
+    .max(
+      BRAND_VOICE_LIMITS_V2.KEY_PHRASES_MAX_ITEMS,
+      `Maximum ${BRAND_VOICE_LIMITS_V2.KEY_PHRASES_MAX_ITEMS} key phrases`,
+    )
+    .default([]),
+
+  sampleResponses: z
+    .array(sampleResponseV2Schema)
+    .max(
+      BRAND_VOICE_LIMITS_V2.SAMPLE_RESPONSES_MAX_ITEMS,
+      `Maximum ${BRAND_VOICE_LIMITS_V2.SAMPLE_RESPONSES_MAX_ITEMS} sample responses`,
+    )
+    .default([]),
+
+  acknowledgeNamedStaff: z.boolean().default(true),
+  acknowledgeOccasions: z.boolean().default(true),
+
+  salutationPattern: z
+    .string()
+    .max(
+      BRAND_VOICE_LIMITS_V2.SALUTATION_MAX,
+      `Salutation must be under ${BRAND_VOICE_LIMITS_V2.SALUTATION_MAX} characters`,
+    )
+    .transform((s) => s.trim())
+    .default("Dear {firstName},"),
+
+  signoffLines: z
+    .string()
+    .max(
+      BRAND_VOICE_LIMITS_V2.SIGNOFF_MAX,
+      `Sign-off must be under ${BRAND_VOICE_LIMITS_V2.SIGNOFF_MAX} characters`,
+    )
+    .transform((s) => s.trim())
+    .default("Warmest regards,\nThe Team"),
+
+  negativeReviewEmailEnabled: z.boolean().default(false),
+
+  negativeReviewFraming: z
+    .enum(NEGATIVE_REVIEW_FRAMINGS)
+    .default(DEFAULT_NEGATIVE_REVIEW_FRAMING),
+
+  negativeReviewFramingCustom: z
+    .string()
+    .max(
+      BRAND_VOICE_LIMITS_V2.FRAMING_CUSTOM_MAX,
+      `Custom framing must be under ${BRAND_VOICE_LIMITS_V2.FRAMING_CUSTOM_MAX} characters`,
+    )
+    .transform((s) => s.trim())
+    .optional()
+    .nullable(),
+
+  // RFC-compliant + explicit reject of CR/LF (header-injection hardening
+  // per spec §7.5) + per-RFC max length of 254 chars.
+  replyToEmail: z
+    .string()
+    .email("Please enter a valid email address")
+    .max(
+      BRAND_VOICE_LIMITS_V2.REPLY_TO_EMAIL_MAX,
+      `Email must be under ${BRAND_VOICE_LIMITS_V2.REPLY_TO_EMAIL_MAX} characters`,
+    )
+    .refine((v) => !v.includes("\n") && !v.includes("\r"), {
+      message: "Email cannot contain line breaks",
+    })
+    .optional()
+    .nullable(),
+});
+
+export type BrandVoiceInputV2 = z.infer<typeof brandVoiceSchemaV2>;
+
+// Re-export the default tone key so the schema and downstream consumers
+// agree without a second source of truth.
+export { DEFAULT_BRAND_VOICE_TONE_V2 };
 
 // User profile schemas
 // MVP Phase 1 onboarding wizard: collects org/industry/country/location info

--- a/tests/unit/api/reviews/response-edit.test.ts
+++ b/tests/unit/api/reviews/response-edit.test.ts
@@ -146,8 +146,10 @@ describe('PUT /api/reviews/[id]/response', () => {
     expect(json.error.code).toBe('VALIDATION_ERROR');
   });
 
-  it('returns 400 for responseText exceeding 500 characters', async () => {
-    const longText = 'A'.repeat(501);
+  it('returns 400 for responseText exceeding the max length', async () => {
+    // Brand voice redesign iter 2: cap raised from 500 → 2000 so multi-paragraph
+    // assembled responses (salutation + body + sign-off + optional email) fit.
+    const longText = 'A'.repeat(2001);
     const req = createRequest('/api/reviews/review-1/response', {
       method: 'PUT',
       body: { responseText: longText },

--- a/tests/unit/components/reviews/response-editor.test.tsx
+++ b/tests/unit/components/reviews/response-editor.test.tsx
@@ -1,6 +1,11 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import { ResponseEditor } from "@/components/reviews/ResponseEditor";
+import { VALIDATION_LIMITS } from "@/lib/constants";
+
+// Importing the live constant keeps these tests immune to future cap changes
+// (e.g. the iter 2 raise from 500 → 2000) — they assert behaviour, not numbers.
+const MAX = VALIDATION_LIMITS.RESPONSE_TEXT_MAX;
 
 describe("ResponseEditor", () => {
   const defaultProps = {
@@ -16,11 +21,11 @@ describe("ResponseEditor", () => {
     expect(textarea).toHaveValue("Hello world");
   });
 
-  it("shows character count", () => {
+  it("shows character count using the current max limit", () => {
     render(<ResponseEditor {...defaultProps} />);
 
     expect(screen.getByText(/11/)).toBeInTheDocument();
-    expect(screen.getByText(/500 characters/)).toBeInTheDocument();
+    expect(screen.getByText(new RegExp(`${MAX} characters`))).toBeInTheDocument();
   });
 
   it("disables Save button when text is unchanged", () => {
@@ -44,7 +49,7 @@ describe("ResponseEditor", () => {
     render(<ResponseEditor {...defaultProps} />);
 
     const textarea = screen.getByPlaceholderText("Edit your response...");
-    fireEvent.change(textarea, { target: { value: "A".repeat(501) } });
+    fireEvent.change(textarea, { target: { value: "A".repeat(MAX + 1) } });
 
     const saveBtn = screen.getByRole("button", { name: /save changes/i });
     expect(saveBtn).toBeDisabled();
@@ -71,7 +76,7 @@ describe("ResponseEditor", () => {
     render(<ResponseEditor {...defaultProps} />);
 
     const textarea = screen.getByPlaceholderText("Edit your response...");
-    fireEvent.change(textarea, { target: { value: "A".repeat(510) } });
+    fireEvent.change(textarea, { target: { value: "A".repeat(MAX + 10) } });
 
     expect(screen.getByText(/10 over limit/)).toBeInTheDocument();
   });

--- a/tests/unit/lib/ai/brand-voice-normalize.test.ts
+++ b/tests/unit/lib/ai/brand-voice-normalize.test.ts
@@ -1,0 +1,265 @@
+import { describe, it, expect } from "vitest";
+
+import { normalizeBrandVoice } from "@/lib/ai/brand-voice-normalize";
+
+describe("normalizeBrandVoice", () => {
+  describe("tone mapping (spec §4.1)", () => {
+    it("maps legacy 'friendly' → 'friendly_professional'", () => {
+      expect(normalizeBrandVoice({ tone: "friendly" }).tone).toBe("friendly_professional");
+    });
+
+    it("maps legacy 'professional' → 'friendly_professional'", () => {
+      expect(normalizeBrandVoice({ tone: "professional" }).tone).toBe("friendly_professional");
+    });
+
+    it("maps legacy 'casual' → 'warm_casual'", () => {
+      expect(normalizeBrandVoice({ tone: "casual" }).tone).toBe("warm_casual");
+    });
+
+    it("maps legacy 'formal' → 'polished_formal'", () => {
+      expect(normalizeBrandVoice({ tone: "formal" }).tone).toBe("polished_formal");
+    });
+
+    it("maps legacy 'empathetic' → 'empathetic_attentive'", () => {
+      expect(normalizeBrandVoice({ tone: "empathetic" }).tone).toBe("empathetic_attentive");
+    });
+
+    it("maps the 'default' sentinel (used on first-generation ReviewResponse.toneUsed) → default", () => {
+      expect(normalizeBrandVoice({ tone: "default" }).tone).toBe("friendly_professional");
+    });
+
+    it("passes V2 keys through unchanged", () => {
+      for (const tone of ["warm_casual", "friendly_professional", "polished_formal", "empathetic_attentive"]) {
+        expect(normalizeBrandVoice({ tone }).tone).toBe(tone);
+      }
+    });
+
+    it("falls back to default on unknown tone strings", () => {
+      expect(normalizeBrandVoice({ tone: "aggressive" }).tone).toBe("friendly_professional");
+    });
+
+    it("falls back to default on non-string tone (e.g. null)", () => {
+      expect(normalizeBrandVoice({ tone: null }).tone).toBe("friendly_professional");
+    });
+  });
+
+  describe("styleGuidelines (spec §4.2 — the headline JSON bug fix)", () => {
+    it("parses legacy JSON-stringified array from styleNotes", () => {
+      const out = normalizeBrandVoice({
+        styleNotes: JSON.stringify(["Rule one", "Rule two"]),
+      });
+      expect(out.styleGuidelines).toEqual(["Rule one", "Rule two"]);
+    });
+
+    it("parses legacy newline-separated styleNotes (pre-JSON era)", () => {
+      const out = normalizeBrandVoice({
+        styleNotes: "Rule one\nRule two\nRule three",
+      });
+      expect(out.styleGuidelines).toEqual(["Rule one", "Rule two", "Rule three"]);
+    });
+
+    it("trims whitespace and drops empty entries", () => {
+      const out = normalizeBrandVoice({
+        styleNotes: JSON.stringify(["  trim me  ", "", "  "]),
+      });
+      expect(out.styleGuidelines).toEqual(["trim me"]);
+    });
+
+    it("falls back to empty array on malformed JSON-looking input", () => {
+      const out = normalizeBrandVoice({
+        styleNotes: '["unterminated',
+      });
+      // Falls through to newline-split — entire string is one line, so we get it back.
+      // Either behavior is acceptable defensively; the contract is "never throw".
+      expect(Array.isArray(out.styleGuidelines)).toBe(true);
+    });
+
+    it("returns empty array when styleNotes is null/undefined", () => {
+      expect(normalizeBrandVoice({ styleNotes: null }).styleGuidelines).toEqual([]);
+      expect(normalizeBrandVoice({}).styleGuidelines).toEqual([]);
+    });
+
+    it("passes V2 styleGuidelines column (real JSONB array) through unchanged", () => {
+      const out = normalizeBrandVoice({
+        styleGuidelines: ["Already structured", "No JSON.stringify here"],
+      });
+      expect(out.styleGuidelines).toEqual(["Already structured", "No JSON.stringify here"]);
+    });
+
+    it("prefers styleGuidelines (V2 column) over styleNotes (legacy column) when both present", () => {
+      const out = normalizeBrandVoice({
+        styleGuidelines: ["from V2"],
+        styleNotes: JSON.stringify(["from legacy"]),
+      });
+      expect(out.styleGuidelines).toEqual(["from V2"]);
+    });
+  });
+
+  describe("sampleResponses (spec §5.1)", () => {
+    it("wraps legacy string[] as ratingContext='any' objects", () => {
+      const out = normalizeBrandVoice({
+        sampleResponses: ["Thanks!", "We appreciate it."],
+      });
+      expect(out.sampleResponses).toEqual([
+        { ratingContext: "any", responseText: "Thanks!" },
+        { ratingContext: "any", responseText: "We appreciate it." },
+      ]);
+    });
+
+    it("passes V2 object-shape entries through with ratingContext preserved", () => {
+      const out = normalizeBrandVoice({
+        sampleResponses: [
+          { ratingContext: 5, responseText: "Wonderful!" },
+          { ratingContext: "any", responseText: "Generic" },
+        ],
+      });
+      expect(out.sampleResponses).toEqual([
+        { ratingContext: 5, responseText: "Wonderful!" },
+        { ratingContext: "any", responseText: "Generic" },
+      ]);
+    });
+
+    it("coerces invalid ratingContext to 'any' (defensive)", () => {
+      const out = normalizeBrandVoice({
+        sampleResponses: [
+          { ratingContext: 99, responseText: "Out of range" },
+          { ratingContext: "nope", responseText: "Bad string" },
+          { ratingContext: null, responseText: "Null" },
+        ],
+      });
+      expect(out.sampleResponses.every((s) => s.ratingContext === "any")).toBe(true);
+    });
+
+    it("drops entries with empty/whitespace responseText", () => {
+      const out = normalizeBrandVoice({
+        sampleResponses: [
+          { ratingContext: 5, responseText: "" },
+          { ratingContext: 5, responseText: "   " },
+          { ratingContext: 5, responseText: "Real" },
+        ],
+      });
+      expect(out.sampleResponses).toEqual([{ ratingContext: 5, responseText: "Real" }]);
+    });
+
+    it("returns empty array on non-array input", () => {
+      expect(normalizeBrandVoice({ sampleResponses: "not an array" }).sampleResponses).toEqual([]);
+      expect(normalizeBrandVoice({}).sampleResponses).toEqual([]);
+    });
+  });
+
+  describe("keyPhrases", () => {
+    it("passes string[] through trimmed and de-emptied", () => {
+      const out = normalizeBrandVoice({
+        keyPhrases: ["  Thank you  ", "", "  ", "We appreciate"],
+      });
+      expect(out.keyPhrases).toEqual(["Thank you", "We appreciate"]);
+    });
+
+    it("returns empty array on non-array input", () => {
+      expect(normalizeBrandVoice({ keyPhrases: null }).keyPhrases).toEqual([]);
+      expect(normalizeBrandVoice({}).keyPhrases).toEqual([]);
+    });
+  });
+
+  describe("toggles & contact/sign-off defaults", () => {
+    it("acknowledgeNamedStaff defaults to true", () => {
+      expect(normalizeBrandVoice({}).acknowledgeNamedStaff).toBe(true);
+    });
+
+    it("acknowledgeOccasions defaults to true", () => {
+      expect(normalizeBrandVoice({}).acknowledgeOccasions).toBe(true);
+    });
+
+    it("preserves explicit false toggles", () => {
+      const out = normalizeBrandVoice({
+        acknowledgeNamedStaff: false,
+        acknowledgeOccasions: false,
+      });
+      expect(out.acknowledgeNamedStaff).toBe(false);
+      expect(out.acknowledgeOccasions).toBe(false);
+    });
+
+    it("salutationPattern defaults to 'Dear {firstName},'", () => {
+      expect(normalizeBrandVoice({}).salutationPattern).toBe("Dear {firstName},");
+    });
+
+    it("signoffLines default to 'Warmest regards,\\nThe Team'", () => {
+      expect(normalizeBrandVoice({}).signoffLines).toBe("Warmest regards,\nThe Team");
+    });
+
+    it("negativeReviewEmailEnabled defaults to false (opt-in)", () => {
+      expect(normalizeBrandVoice({}).negativeReviewEmailEnabled).toBe(false);
+    });
+
+    it("negativeReviewFraming defaults to 'investigation'", () => {
+      expect(normalizeBrandVoice({}).negativeReviewFraming).toBe("investigation");
+    });
+
+    it("falls back to default framing on unknown values", () => {
+      expect(normalizeBrandVoice({ negativeReviewFraming: "apologetic" }).negativeReviewFraming).toBe(
+        "investigation",
+      );
+    });
+
+    it("passes all four framing values through unchanged", () => {
+      for (const f of ["management_contact", "investigation", "open_channel", "custom"]) {
+        expect(normalizeBrandVoice({ negativeReviewFraming: f }).negativeReviewFraming).toBe(f);
+      }
+    });
+
+    it("normalizes empty/whitespace strings on negativeReviewFramingCustom + replyToEmail to null", () => {
+      const out = normalizeBrandVoice({
+        negativeReviewFramingCustom: "   ",
+        replyToEmail: "",
+      });
+      expect(out.negativeReviewFramingCustom).toBeNull();
+      expect(out.replyToEmail).toBeNull();
+    });
+
+    it("trims whitespace on negativeReviewFramingCustom + replyToEmail when non-empty", () => {
+      const out = normalizeBrandVoice({
+        negativeReviewFramingCustom: "  Custom rule  ",
+        replyToEmail: "  hello@example.com  ",
+      });
+      expect(out.negativeReviewFramingCustom).toBe("Custom rule");
+      expect(out.replyToEmail).toBe("hello@example.com");
+    });
+  });
+
+  describe("safety", () => {
+    it("returns defaults for null input", () => {
+      const out = normalizeBrandVoice(null);
+      expect(out.tone).toBe("friendly_professional");
+      expect(out.styleGuidelines).toEqual([]);
+      expect(out.sampleResponses).toEqual([]);
+    });
+
+    it("returns defaults for undefined input", () => {
+      const out = normalizeBrandVoice(undefined);
+      expect(out.tone).toBe("friendly_professional");
+    });
+
+    it("returns defaults for non-object primitive input", () => {
+      expect(normalizeBrandVoice("string").tone).toBe("friendly_professional");
+      expect(normalizeBrandVoice(42).tone).toBe("friendly_professional");
+      expect(normalizeBrandVoice(true).tone).toBe("friendly_professional");
+    });
+
+    it("ignores unknown fields without throwing", () => {
+      expect(() =>
+        normalizeBrandVoice({
+          tone: "friendly_professional",
+          aRandomField: { nested: "stuff" },
+          formality: 7, // legacy field that V2 drops — must be ignored, not used
+        }),
+      ).not.toThrow();
+    });
+
+    it("never returns undefined fields (the canonical shape is total)", () => {
+      const out = normalizeBrandVoice({});
+      for (const v of Object.values(out)) {
+        expect(v).not.toBeUndefined();
+      }
+    });
+  });
+});

--- a/tests/unit/lib/constants.test.ts
+++ b/tests/unit/lib/constants.test.ts
@@ -16,6 +16,15 @@ import {
   SESSION_CONFIG,
   EMAIL_CONFIG,
   SUBSCRIPTION_TIERS,
+  // Brand voice redesign V2 (iter 2)
+  BRAND_VOICE_TONES_V2,
+  BRAND_VOICE_TONE_INFO_V2,
+  DEFAULT_BRAND_VOICE_TONE_V2,
+  LEGACY_TONE_TO_V2,
+  NEGATIVE_REVIEW_FRAMINGS,
+  DEFAULT_NEGATIVE_REVIEW_FRAMING,
+  BRAND_VOICE_LIMITS_V2,
+  RESPONSE_BODY_CHAR_MAX,
 } from '@/lib/constants';
 
 describe('TIER_LIMITS', () => {
@@ -129,8 +138,10 @@ describe('VALIDATION_LIMITS', () => {
     expect(VALIDATION_LIMITS.REVIEW_TEXT_MAX).toBe(2000);
   });
 
-  it('RESPONSE_TEXT_MAX is 500', () => {
-    expect(VALIDATION_LIMITS.RESPONSE_TEXT_MAX).toBe(500);
+  it('RESPONSE_TEXT_MAX is 2000', () => {
+    // Brand voice redesign iter 2: raised from 500 → 2000 so multi-paragraph
+    // assembled responses (salutation + body + sign-off + optional email) fit.
+    expect(VALIDATION_LIMITS.RESPONSE_TEXT_MAX).toBe(2000);
   });
 
   it('PASSWORD_MIN is 8', () => {
@@ -218,5 +229,102 @@ describe('EMAIL_CONFIG', () => {
 
   it('PASSWORD_RESET_EXPIRY_HOURS is 1', () => {
     expect(EMAIL_CONFIG.PASSWORD_RESET_EXPIRY_HOURS).toBe(1);
+  });
+});
+
+// ─── Brand voice redesign V2 (iter 2) ────────────────────────────────
+
+describe('BRAND_VOICE_TONES_V2', () => {
+  it('exposes the four V2 keys in the right order', () => {
+    expect(BRAND_VOICE_TONES_V2).toEqual([
+      'warm_casual',
+      'friendly_professional',
+      'polished_formal',
+      'empathetic_attentive',
+    ]);
+  });
+
+  it('default key is "friendly_professional"', () => {
+    expect(DEFAULT_BRAND_VOICE_TONE_V2).toBe('friendly_professional');
+  });
+});
+
+describe('BRAND_VOICE_TONE_INFO_V2', () => {
+  it('has a label, description, and icon for every V2 key', () => {
+    for (const key of BRAND_VOICE_TONES_V2) {
+      const info = BRAND_VOICE_TONE_INFO_V2[key];
+      expect(info).toBeDefined();
+      expect(typeof info.label).toBe('string');
+      expect(info.label.length).toBeGreaterThan(0);
+      expect(typeof info.description).toBe('string');
+      expect(info.description.length).toBeGreaterThan(0);
+      expect(typeof info.icon).toBe('string');
+    }
+  });
+
+  it('uses the spec §4.1 display labels with ampersand', () => {
+    expect(BRAND_VOICE_TONE_INFO_V2.warm_casual.label).toBe('Warm & casual');
+    expect(BRAND_VOICE_TONE_INFO_V2.friendly_professional.label).toBe('Friendly & professional');
+    expect(BRAND_VOICE_TONE_INFO_V2.polished_formal.label).toBe('Polished & formal');
+    expect(BRAND_VOICE_TONE_INFO_V2.empathetic_attentive.label).toBe('Empathetic & attentive');
+  });
+});
+
+describe('LEGACY_TONE_TO_V2', () => {
+  it('maps every legacy lowercase tone key to a V2 key per spec §4.1', () => {
+    expect(LEGACY_TONE_TO_V2.friendly).toBe('friendly_professional');
+    expect(LEGACY_TONE_TO_V2.professional).toBe('friendly_professional');
+    expect(LEGACY_TONE_TO_V2.casual).toBe('warm_casual');
+    expect(LEGACY_TONE_TO_V2.formal).toBe('polished_formal');
+    expect(LEGACY_TONE_TO_V2.empathetic).toBe('empathetic_attentive');
+  });
+
+  it('maps the "default" sentinel (initial-generation ReviewResponse.toneUsed) to the default V2 key', () => {
+    expect(LEGACY_TONE_TO_V2.default).toBe(DEFAULT_BRAND_VOICE_TONE_V2);
+  });
+});
+
+describe('NEGATIVE_REVIEW_FRAMINGS', () => {
+  it('exposes the four spec §7.4 framing keys', () => {
+    expect(NEGATIVE_REVIEW_FRAMINGS).toEqual([
+      'management_contact',
+      'investigation',
+      'open_channel',
+      'custom',
+    ]);
+  });
+
+  it('default framing is "investigation" (marked Recommended in spec §7.4)', () => {
+    expect(DEFAULT_NEGATIVE_REVIEW_FRAMING).toBe('investigation');
+  });
+});
+
+describe('BRAND_VOICE_LIMITS_V2', () => {
+  it('matches the per-field caps in spec §4.2/§4.3/§5.1/§7.x', () => {
+    expect(BRAND_VOICE_LIMITS_V2.STYLE_GUIDELINE_ITEM_MAX).toBe(200);
+    expect(BRAND_VOICE_LIMITS_V2.STYLE_GUIDELINES_MAX_ITEMS).toBe(10);
+    expect(BRAND_VOICE_LIMITS_V2.STYLE_GUIDELINES_TOTAL_MAX).toBe(2000);
+    expect(BRAND_VOICE_LIMITS_V2.KEY_PHRASE_MAX).toBe(100);
+    expect(BRAND_VOICE_LIMITS_V2.KEY_PHRASES_MAX_ITEMS).toBe(10);
+    expect(BRAND_VOICE_LIMITS_V2.SAMPLE_RESPONSE_MAX).toBe(1000);
+    expect(BRAND_VOICE_LIMITS_V2.SAMPLE_RESPONSES_MAX_ITEMS).toBe(5);
+    expect(BRAND_VOICE_LIMITS_V2.SALUTATION_MAX).toBe(100);
+    expect(BRAND_VOICE_LIMITS_V2.SIGNOFF_MAX).toBe(500);
+    expect(BRAND_VOICE_LIMITS_V2.FRAMING_CUSTOM_MAX).toBe(500);
+    expect(BRAND_VOICE_LIMITS_V2.REPLY_TO_EMAIL_MAX).toBe(254);
+  });
+});
+
+describe('RESPONSE_BODY_CHAR_MAX', () => {
+  it('is 1200 — roughly the "approximately 200 words" guidance', () => {
+    // The model is told to target ~200 words for the body. 1200 chars is the
+    // hard char cap on the model-emitted body (post-processing prepends
+    // salutation and appends sign-off + optional email, which together
+    // bring assembled length within RESPONSE_TEXT_MAX = 2000).
+    expect(RESPONSE_BODY_CHAR_MAX).toBe(1200);
+  });
+
+  it('is strictly smaller than the assembled cap (so salutation+sign-off fit)', () => {
+    expect(RESPONSE_BODY_CHAR_MAX).toBeLessThan(VALIDATION_LIMITS.RESPONSE_TEXT_MAX);
   });
 });

--- a/tests/unit/lib/validations.test.ts
+++ b/tests/unit/lib/validations.test.ts
@@ -10,6 +10,7 @@ import {
   regenerateResponseSchema,
   updateResponseSchema,
   brandVoiceSchema,
+  brandVoiceSchemaV2,
   testBrandVoiceSchema,
   updateProfileSchema,
   paginationSchema,
@@ -461,16 +462,27 @@ describe('updateResponseSchema', () => {
     expect(result.success).toBe(false);
   });
 
-  it('rejects text > 500 chars', () => {
+  it('rejects text > 2000 chars', () => {
+    // Brand voice redesign iter 2: cap raised from 500 → 2000 so multi-paragraph
+    // assembled responses (salutation + body + sign-off + optional email) fit.
     const result = updateResponseSchema.safeParse({
-      responseText: 'a'.repeat(501),
+      responseText: 'a'.repeat(2001),
     });
     expect(result.success).toBe(false);
   });
 
-  it('accepts text at 500 chars', () => {
+  it('accepts text at 2000 chars', () => {
     const result = updateResponseSchema.safeParse({
-      responseText: 'a'.repeat(500),
+      responseText: 'a'.repeat(2000),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts text well above the old 500-char limit', () => {
+    // Sanity guard: multi-paragraph responses (typical 800–1500 chars) must
+    // round-trip through manual-edit validation.
+    const result = updateResponseSchema.safeParse({
+      responseText: 'a'.repeat(1500),
     });
     expect(result.success).toBe(true);
   });
@@ -635,6 +647,340 @@ describe('testBrandVoiceSchema', () => {
       reviewText: 'a'.repeat(2001),
     });
     expect(result.success).toBe(false);
+  });
+});
+
+// ─── Brand voice redesign V2 (iter 2) ────────────────────────────────
+// Spec: docs/MVP_Phase-1/BRAND_VOICE_REDESIGN.md §9.2
+
+describe('brandVoiceSchemaV2', () => {
+  const validFull = {
+    tone: 'friendly_professional',
+    styleGuidelines: ['Avoid corporate language', 'Mirror specific details from the review'],
+    keyPhrases: ['Thank you for taking the time'],
+    sampleResponses: [
+      { ratingContext: 5 as const, responseText: 'Thanks so much for the kind words!' },
+      { ratingContext: 'any' as const, responseText: 'We appreciate the feedback.' },
+    ],
+    acknowledgeNamedStaff: true,
+    acknowledgeOccasions: false,
+    salutationPattern: 'Dear {firstName},',
+    signoffLines: 'Warmest regards,\nThe Team',
+    negativeReviewEmailEnabled: true,
+    negativeReviewFraming: 'investigation' as const,
+    negativeReviewFramingCustom: null,
+    replyToEmail: 'hello@example.com',
+  };
+
+  describe('tone', () => {
+    it('accepts every V2 tone key', () => {
+      const tones = ['warm_casual', 'friendly_professional', 'polished_formal', 'empathetic_attentive'];
+      for (const tone of tones) {
+        const result = brandVoiceSchemaV2.safeParse({ ...validFull, tone });
+        expect(result.success).toBe(true);
+      }
+    });
+
+    it('rejects legacy tone keys (require the V2 set)', () => {
+      const result = brandVoiceSchemaV2.safeParse({ ...validFull, tone: 'professional' });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects display-string tones (we store keys, not labels)', () => {
+      const result = brandVoiceSchemaV2.safeParse({ ...validFull, tone: 'Friendly & professional' });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('styleGuidelines', () => {
+    it('defaults to empty array when omitted', () => {
+      const { styleGuidelines: _omit, ...rest } = validFull;
+      const result = brandVoiceSchemaV2.safeParse(rest);
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.styleGuidelines).toEqual([]);
+    });
+
+    it('rejects > 10 items', () => {
+      const result = brandVoiceSchemaV2.safeParse({
+        ...validFull,
+        styleGuidelines: Array.from({ length: 11 }, (_, i) => `Rule ${i}`),
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('accepts exactly 10 items', () => {
+      const result = brandVoiceSchemaV2.safeParse({
+        ...validFull,
+        styleGuidelines: Array.from({ length: 10 }, (_, i) => `Rule ${i}`),
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects per-item text > 200 chars', () => {
+      const result = brandVoiceSchemaV2.safeParse({
+        ...validFull,
+        styleGuidelines: ['a'.repeat(201)],
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects when joined total exceeds 2000 chars', () => {
+      // 10 items × ~205 chars when joined with \n = ~2059 chars total.
+      // Each item must individually pass the 200-char per-item check, so
+      // we pad with 199-char strings (10 × 200 incl. newlines ≈ 2009 > 2000).
+      const result = brandVoiceSchemaV2.safeParse({
+        ...validFull,
+        styleGuidelines: Array.from({ length: 10 }, () => 'a'.repeat(200)),
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('trims surrounding whitespace on accepted items', () => {
+      const result = brandVoiceSchemaV2.safeParse({
+        ...validFull,
+        styleGuidelines: ['  trim me  '],
+      });
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.styleGuidelines[0]).toBe('trim me');
+    });
+  });
+
+  describe('keyPhrases', () => {
+    it('defaults to empty array when omitted', () => {
+      const { keyPhrases: _omit, ...rest } = validFull;
+      const result = brandVoiceSchemaV2.safeParse(rest);
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.keyPhrases).toEqual([]);
+    });
+
+    it('rejects > 10 items (V2 lowered from legacy 20)', () => {
+      const result = brandVoiceSchemaV2.safeParse({
+        ...validFull,
+        keyPhrases: Array.from({ length: 11 }, (_, i) => `Phrase ${i}`),
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects per-item text > 100 chars', () => {
+      const result = brandVoiceSchemaV2.safeParse({
+        ...validFull,
+        keyPhrases: ['a'.repeat(101)],
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('sampleResponses', () => {
+    it('defaults to empty array when omitted', () => {
+      const { sampleResponses: _omit, ...rest } = validFull;
+      const result = brandVoiceSchemaV2.safeParse(rest);
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects > 5 items', () => {
+      const result = brandVoiceSchemaV2.safeParse({
+        ...validFull,
+        sampleResponses: Array.from({ length: 6 }, (_, i) => ({
+          ratingContext: 'any' as const,
+          responseText: `Sample ${i}`,
+        })),
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('accepts ratingContext = 1..5 and "any"', () => {
+      for (const rc of [1, 2, 3, 4, 5, 'any'] as const) {
+        const result = brandVoiceSchemaV2.safeParse({
+          ...validFull,
+          sampleResponses: [{ ratingContext: rc, responseText: 'ok' }],
+        });
+        expect(result.success).toBe(true);
+      }
+    });
+
+    it('rejects ratingContext outside 1..5', () => {
+      const result = brandVoiceSchemaV2.safeParse({
+        ...validFull,
+        sampleResponses: [{ ratingContext: 6, responseText: 'ok' }],
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects ratingContext other than "any" or 1..5', () => {
+      const result = brandVoiceSchemaV2.safeParse({
+        ...validFull,
+        sampleResponses: [{ ratingContext: 'all', responseText: 'ok' }],
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects empty responseText', () => {
+      const result = brandVoiceSchemaV2.safeParse({
+        ...validFull,
+        sampleResponses: [{ ratingContext: 'any', responseText: '' }],
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects responseText > 1000 chars', () => {
+      const result = brandVoiceSchemaV2.safeParse({
+        ...validFull,
+        sampleResponses: [{ ratingContext: 'any', responseText: 'a'.repeat(1001) }],
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('personalization toggles', () => {
+    it('default acknowledgeNamedStaff = true', () => {
+      const { acknowledgeNamedStaff: _omit, ...rest } = validFull;
+      const result = brandVoiceSchemaV2.safeParse(rest);
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.acknowledgeNamedStaff).toBe(true);
+    });
+
+    it('default acknowledgeOccasions = true', () => {
+      const { acknowledgeOccasions: _omit, ...rest } = validFull;
+      const result = brandVoiceSchemaV2.safeParse(rest);
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.acknowledgeOccasions).toBe(true);
+    });
+  });
+
+  describe('contact & sign-off', () => {
+    it('defaults salutationPattern to "Dear {firstName},"', () => {
+      const { salutationPattern: _omit, ...rest } = validFull;
+      const result = brandVoiceSchemaV2.safeParse(rest);
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.salutationPattern).toBe('Dear {firstName},');
+    });
+
+    it('rejects salutation > 100 chars', () => {
+      const result = brandVoiceSchemaV2.safeParse({
+        ...validFull,
+        salutationPattern: 'a'.repeat(101),
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('defaults signoffLines to "Warmest regards,\\nThe Team"', () => {
+      const { signoffLines: _omit, ...rest } = validFull;
+      const result = brandVoiceSchemaV2.safeParse(rest);
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.signoffLines).toBe('Warmest regards,\nThe Team');
+    });
+
+    it('rejects sign-off > 500 chars', () => {
+      const result = brandVoiceSchemaV2.safeParse({
+        ...validFull,
+        signoffLines: 'a'.repeat(501),
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('defaults negativeReviewEmailEnabled = false (opt-in per spec §7.3)', () => {
+      const { negativeReviewEmailEnabled: _omit, ...rest } = validFull;
+      const result = brandVoiceSchemaV2.safeParse(rest);
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.negativeReviewEmailEnabled).toBe(false);
+    });
+
+    it('accepts all four negativeReviewFraming values', () => {
+      for (const framing of ['management_contact', 'investigation', 'open_channel', 'custom'] as const) {
+        const result = brandVoiceSchemaV2.safeParse({ ...validFull, negativeReviewFraming: framing });
+        expect(result.success).toBe(true);
+      }
+    });
+
+    it('rejects unknown negativeReviewFraming', () => {
+      const result = brandVoiceSchemaV2.safeParse({
+        ...validFull,
+        negativeReviewFraming: 'apologetic',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('default negativeReviewFraming = "investigation"', () => {
+      const { negativeReviewFraming: _omit, ...rest } = validFull;
+      const result = brandVoiceSchemaV2.safeParse(rest);
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.negativeReviewFraming).toBe('investigation');
+    });
+
+    it('rejects negativeReviewFramingCustom > 500 chars', () => {
+      const result = brandVoiceSchemaV2.safeParse({
+        ...validFull,
+        negativeReviewFramingCustom: 'a'.repeat(501),
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('accepts a valid RFC-compliant replyToEmail', () => {
+      const result = brandVoiceSchemaV2.safeParse({
+        ...validFull,
+        replyToEmail: 'manager@brand.example.com',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects malformed replyToEmail', () => {
+      const result = brandVoiceSchemaV2.safeParse({
+        ...validFull,
+        replyToEmail: 'not-an-email',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects replyToEmail containing \\n (header-injection guard)', () => {
+      const result = brandVoiceSchemaV2.safeParse({
+        ...validFull,
+        replyToEmail: 'ok@example.com\nBcc: leak@evil.com',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects replyToEmail containing \\r (header-injection guard)', () => {
+      const result = brandVoiceSchemaV2.safeParse({
+        ...validFull,
+        replyToEmail: 'ok@example.com\rCc: leak@evil.com',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects replyToEmail > 254 chars', () => {
+      // Build a 255-char email: local part of 248 chars + "@a.com" (6) = 254 — make one over.
+      const local = 'a'.repeat(248);
+      const email = `${local}@a.com`; // 248 + 6 = 254
+      const tooLong = `a${email}`; // 255
+      // Sanity check the construction
+      expect(tooLong.length).toBe(255);
+      const result = brandVoiceSchemaV2.safeParse({ ...validFull, replyToEmail: tooLong });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('full payload', () => {
+    it('accepts a minimal valid payload (just tone) and defaults the rest', () => {
+      const result = brandVoiceSchemaV2.safeParse({ tone: 'friendly_professional' });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.tone).toBe('friendly_professional');
+        expect(result.data.styleGuidelines).toEqual([]);
+        expect(result.data.keyPhrases).toEqual([]);
+        expect(result.data.sampleResponses).toEqual([]);
+        expect(result.data.acknowledgeNamedStaff).toBe(true);
+        expect(result.data.acknowledgeOccasions).toBe(true);
+        expect(result.data.salutationPattern).toBe('Dear {firstName},');
+        expect(result.data.signoffLines).toBe('Warmest regards,\nThe Team');
+        expect(result.data.negativeReviewEmailEnabled).toBe(false);
+        expect(result.data.negativeReviewFraming).toBe('investigation');
+      }
+    });
+
+    it('accepts a fully populated payload', () => {
+      const result = brandVoiceSchemaV2.safeParse(validFull);
+      expect(result.success).toBe(true);
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

Second iteration of the brand voice page redesign — see [`docs/MVP_Phase-1/BRAND_VOICE_REDESIGN.md`](docs/MVP_Phase-1/BRAND_VOICE_REDESIGN.md) and the plan at `C:/Users/amith/.claude/plans/docs-mvp-phase-1-brand-voice-redesign-md-streamed-ripple.md`.

**Pure type/validation/constant changes — zero DB changes, zero runtime behaviour change for clean inputs.** Lands the V2 contract (tone keys + display map, new schema, normalize adapter, extended `BrandVoiceConfig`) so iter 3 becomes "DB only" and iter 4 becomes "prompt rewrite only".

The one externally observable behaviour change is the **response cap raise 500 → 2000** (DECISION #45) — necessary because the multi-paragraph + salutation + sign-off + optional email design literally cannot fit in 500 chars. Documented and tested across validations, route, and component layers.

## What changes

### New files

- `src/lib/ai/brand-voice-normalize.ts` — pure module exporting `normalizeBrandVoice(raw)` and the `NormalizedBrandVoice` type. Accepts any plausible payload (legacy DB row, V2 row, partial object, untrusted JSON, even `null`) and returns the canonical V2 shape with safe defaults. Legacy `styleNotes` (JSON-stringified array OR newline-separated string) → `string[]`. Legacy `sampleResponses: string[]` → `[{ratingContext: 'any', responseText}]`. Legacy tones mapped via `LEGACY_TONE_TO_V2`. Unknown / malformed values fall back to defaults rather than throwing. **Unit-tested now; wired into `generateReviewResponse` in iter 4.**
- `tests/unit/lib/ai/brand-voice-normalize.test.ts` (NEW, ~30 cases) — covers tone mapping (incl. the `"default"` sentinel + unknown → default), styleNotes JSON-parse + newline-split + malformed fallback, sample-response shape coercion, toggle/contact-signoff defaults, framing fallback, whitespace normalisation, null/undefined/non-object safety.

### Modified files

- `src/lib/constants.ts`:
  - New `BRAND_VOICE_TONES_V2` (4 lowercase keys: `warm_casual`, `friendly_professional`, `polished_formal`, `empathetic_attentive`) + `BRAND_VOICE_TONE_INFO_V2` (display labels + descriptors per spec §4.1) + `DEFAULT_BRAND_VOICE_TONE_V2`.
  - `LEGACY_TONE_TO_V2` maps every legacy lowercase tone key AND the `"default"` sentinel that initial-generation routes store on `ReviewResponse.toneUsed`.
  - `NEGATIVE_REVIEW_FRAMINGS` + `DEFAULT_NEGATIVE_REVIEW_FRAMING` (four spec §7.4 keys, default `investigation`).
  - `BRAND_VOICE_LIMITS_V2` — per-field caps from spec §4.2 / §4.3 / §5.1 / §7.x.
  - `RESPONSE_BODY_CHAR_MAX = 1200` — hard cap on the model-emitted body alone (closing-block-aware truncation lands in iter 5).
  - `VALIDATION_LIMITS.RESPONSE_TEXT_MAX` raised 500 → 2000.
  - Legacy exports retained until iter 6 cuts the form payload over.
- `src/lib/validations.ts`:
  - New `brandVoiceSchemaV2` per spec §9.2 — lowercase-key tone enum (DECISION #44), V2 sample-response object shape, per-item (200) AND joined-total (2000) caps on `styleGuidelines` (DECISION #48), header-injection guard on `replyToEmail` rejecting literal `\n` / `\r` on top of the RFC email check (DECISION #49).
  - Legacy `brandVoiceSchema` retained until iter 6 cutover.
  - `updateResponseSchema` automatically picks up the new 2000 cap via `VALIDATION_LIMITS.RESPONSE_TEXT_MAX`.
- `src/lib/ai/claude.ts` — `BrandVoiceConfig` extended with all V2 fields as optional (DECISION #47). The three inline call sites in generate / regenerate / brand-voice-test routes continue to typecheck without modification — the new fields are dormant until iter 4's prompt rewrite consumes them.

### Tests fixed for the cap raise

- `tests/unit/lib/constants.test.ts` — "RESPONSE_TEXT_MAX is 500" → 2000.
- `tests/unit/lib/validations.test.ts` — updateResponseSchema 500-cap tests → 2000; new `brandVoiceSchemaV2` describe block (~50 cases).
- `tests/unit/api/reviews/response-edit.test.ts` — "exceeding 500 characters" → "exceeding the max length" with 2001 chars.
- `tests/unit/components/reviews/response-editor.test.tsx` — hard-coded `501` / `510` replaced with `VALIDATION_LIMITS.RESPONSE_TEXT_MAX + 1` / `+ 10` so future cap changes don't break the tests.

### Decisions logged

Six new numbered decisions in `DECISIONS.md` (#44–49):

- **#44** Tone storage uses lowercase keys + display map, not the spec's literal display-string Zod enum.
- **#45** `RESPONSE_TEXT_MAX` raised 500 → 2000; new `RESPONSE_BODY_CHAR_MAX = 1200`.
- **#46** `normalizeBrandVoice` lives in its own pure module, not in `claude.ts`.
- **#47** `BrandVoiceConfig` extended with V2 fields as optional (additive, dormant); call sites unchanged.
- **#48** V2 schema enforces both per-item (200) AND joined-total (2000) caps on `styleGuidelines`.
- **#49** `replyToEmail` rejects literal `\n` / `\r` (header-injection guard) on top of the RFC email check.

## Verification

- `npm run lint:strict` clean
- `npm run type-check` clean
- `npm run test:unit` **871 passed, 0 failed** across 61 files (+88 new tests this iteration)
- No DB migration this iteration; nothing for `prisma migrate deploy` to run.

## What this PR is and is NOT

**Is:**
- Type/Zod/constants contract for the V2 brand voice shape, exported and unit-tested.
- The response-cap raise that unblocks iter 4/5.
- The normalize adapter ready to wire into `generateReviewResponse` in iter 4.

**Is NOT:**
- The schema reset (iter 3 — clean-reset truncate + new columns).
- The prompt-building rewrite (iter 4 — styleNotes bug fix, structure templates, conditional fragments).
- The post-processing assembly (iter 5).
- The UI restructure or API Zod cutover (iter 6 — the routes still validate via the legacy `brandVoiceSchema` until then).

## What changes externally when this merges

**Only one thing:** manual response edits can now be up to 2000 chars instead of 500. The `ResponseEditor` UI shows the new limit and accepts longer text; the `PUT /api/reviews/[id]/response` Zod schema accepts it; the DB column is `@db.Text` (no DB cap) so no migration needed.

Everything else (V2 tone keys, normalize adapter, extended `BrandVoiceConfig`, `RESPONSE_BODY_CHAR_MAX`) is exported but not yet consumed by any production code path.

## Out of 6 iterations

| Iter | Title | Status |
|---|---|---|
| 1 | Sanitize helper + review-text retrofit + SecurityLog | ✅ Merged (PR #120) |
| **2** | **Validation schema + constants + normalize adapter** | **This PR** |
| 3 | Clean-reset schema migration + minimal route field-name cutover | Pending |
| 4 | Prompt-building rewrite (bug fix, wrap fields, structure, fragments) | Pending |
| 5 | Post-processing module + route wiring | Pending |
| 6 | Frontend restructure + API Zod cutover + regenerate dialog | Pending |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
