### PR TITLE
fix(api): gate E2E mock canned response on env var AND request header

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1633,6 +1633,27 @@ The model now sees the user's style guidelines as a proper bulleted list instead
 
 Verification: `npm run lint:strict` clean; `npm run type-check` clean; `npm run test:unit` 963 passed, 0 failed across 63 files.
 
+### Follow-up fix: E2E mock header-gate (May 21, 2026)
+
+Branch: `fix/e2e-mock-header-gate`. Single small fix landing between iter 4 and iter 5. Discovered when manual response generation on staging returned the canned Playwright mock string instead of a real Claude response.
+
+#### Decision 61: Mock canned response gated on env var AND a per-request header (follow-up to decision 15)
+
+- **Decision:** `generateReviewResponse` in `src/lib/ai/claude.ts` now requires BOTH `process.env.E2E_MOCK_AI === "true"` AND a new `e2eMockOptIn` param to be true before returning the canned mock response. The three routes (`generate`, `regenerate`, `brand-voice/test`) read `request.headers.get("x-e2e-mock") === "1"` and forward it as `e2eMockOptIn`. `playwright.config.ts` adds `"x-e2e-mock": "1"` to its `extraHTTPHeaders` so every test request carries it.
+- **Why:** Decision 15 (April 17, 2026) added the env-var gate alone. The implicit assumption was that "Vercel Preview" and "staging-for-manual-testing" were distinct environments. They aren't on this project: pushes to `main` build a Vercel Preview that serves as the staging URL the founder tests manually. So `E2E_MOCK_AI=true` set on Preview (the documented intent) was correct for the E2E tests AND silently short-circuiting manual generates on staging. The single env-var check couldn't tell a Playwright request from a real user click — both ran in the same Next.js process. The header opt-in adds the missing identity: only Playwright carries it.
+- **What this does NOT change:** Production safety. The env var is still required — production never has it set, so even if a hostile header `x-e2e-mock: 1` were sent there, the mock won't fire. The env var is the "what environment can mock at all" gate; the header is the "is this caller asking to mock" gate. Both must agree.
+- **Risk:** Low ✅. Additive — Playwright tests get exactly the same canned response they always have (because the config now sends the header); manual users on Preview/staging get real Claude responses instead of the canned string. No production behavior change.
+
+**Test coverage:** 6 new unit tests in `tests/unit/lib/ai/claude.test.ts` covering the full truth table:
+- env=true + header=true → mock fires (Playwright happy path).
+- env=true + header=missing → Claude runs (the manual-user bug this fixes).
+- env=true + header=false explicitly → Claude runs.
+- env=false + header=true → Claude runs (production-poisoning-attempt protection).
+- env=false + header=missing → Claude runs (production/local default).
+- env=non-"true" value + header=true → Claude runs (only literal `"true"` enables).
+
+Verification: `npm run lint:strict` clean; `npm run type-check` clean; `npm run test:unit` 969 passed, 0 failed across 63 files (+6 from iter 4's 963).
+
 ---
 
 ## Decision Log
@@ -1701,6 +1722,7 @@ Verification: `npm run lint:strict` clean; `npm run type-check` clean; `npm run 
 | 58 | `max_tokens` bumped 500 → 1000 to give room for multi-paragraph + multi-language responses | Brand Voice Redesign / It. 4 | May 20 | Low ✅ | ✅ Implemented |
 | 59 | `ToneModifier` type retains the legacy 3-key set this iteration; iter 6 swaps to V2 4-key set | Brand Voice Redesign / It. 4 | May 20 | Low ✅ | ✅ Implemented |
 | 60 | V2 tone rendered in prompt as the human display label, not the snake_case key | Brand Voice Redesign / It. 4 | May 20 | Low ✅ | ✅ Implemented |
+| 61 | E2E mock canned response gated on env var AND `x-e2e-mock` header (follow-up to #15) so manual users on Preview/staging hit real Claude | Brand Voice Redesign / fix between It. 4 + It. 5 | May 21 | Low ✅ | ✅ Implemented |
 
 *Table will grow as decisions are made*
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1270,7 +1270,26 @@ After this iteration ships to staging you'll see the AI's output change: multi-p
 
 **Decisions** (cross-reference DECISIONS.md "Brand Voice Page Redesign / Iteration 4" subsection): #56 structure-template module separate from `claude.ts`; #57 JSONB fields typed as `unknown` with `normalizeBrandVoice` doing coercion; #58 `max_tokens` 500 → 1000; #59 `ToneModifier` type retains legacy 3-key set (iter 6 swaps to V2 4-key set); #60 V2 tone rendered as human display label.
 
+### 🔧 Follow-up fix between iter 4 and iter 5 — E2E mock header-gate
+
+**Branch:** `fix/e2e-mock-header-gate`
+**Status:** Locally verified (lint:strict / type-check / 969 unit tests passing). PR pending.
+
+Manual response generation on staging after iter 4 returned the canned Playwright mock string instead of a real Claude response. Root cause: the iter-1 `E2E_MOCK_AI` env-var gate (added April 17, 2026) is single-condition — when set on Vercel Preview, every call to `generateReviewResponse` short-circuits to the canned response regardless of caller. The original assumption that "Preview" and "staging-for-manual-testing" were distinct environments doesn't hold for this project; pushes to `main` build a Preview deployment that serves as the staging URL.
+
+**Fix:** Add a per-request header opt-in. The mock now requires BOTH `E2E_MOCK_AI=true` (env, scopes mocking to Preview) AND `x-e2e-mock: 1` (header, identifies the caller as Playwright). Routes read the header and forward it as a new `e2eMockOptIn` param on `generateReviewResponse`. `playwright.config.ts` adds the header to its `extraHTTPHeaders` so every test carries it. Manual users on the same Preview deployment hit real Claude.
+
+**Files:**
+- `src/lib/ai/claude.ts` — `GenerateResponseParams` gains `e2eMockOptIn?: boolean`; guard changes from `if (env === "true")` to `if (env === "true" && e2eMockOptIn)`.
+- `src/app/api/reviews/[id]/generate/route.ts` + `regenerate/route.ts` + `src/app/api/brand-voice/test/route.ts` — each reads `request.headers.get("x-e2e-mock") === "1"` and forwards as `e2eMockOptIn`.
+- `playwright.config.ts` — `extraHTTPHeaders` restructured so `x-e2e-mock: 1` is always sent and the existing Vercel bypass header remains conditional on the secret.
+- `tests/unit/lib/ai/claude.test.ts` — new "E2E mock double-gate" describe block with 6 truth-table cases.
+
+**Test delta:** 963 → 969 unit tests (+6). No integration or E2E changes (E2E already runs against staging with the header now configured).
+
+**Decisions** (cross-reference DECISIONS.md "Follow-up fix: E2E mock header-gate"): #61 mock requires env AND header (follow-up to #15).
+
 ---
 
-**Last Updated:** May 20, 2026
-**Status:** Brand voice redesign iteration 4 complete on branch (PR pending). Iterations 1 + 2 + 3 merged to main. MVP Phase 1 (Closed Beta) remains the most recent production deploy.
+**Last Updated:** May 21, 2026
+**Status:** Brand voice redesign iteration 4 merged via PR #123. E2E mock header-gate fix complete on branch (PR pending). Iter 5 (post-processing) next.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,12 +21,19 @@ export default defineConfig({
     baseURL: process.env.STAGING_URL || 'https://brandsiq-git-main-prajeens-projects-eb24da7b.vercel.app',
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
-    // Bypass Vercel Deployment Protection for automated testing
-    ...(process.env.VERCEL_AUTOMATION_BYPASS_SECRET && {
-      extraHTTPHeaders: {
+    extraHTTPHeaders: {
+      // x-e2e-mock opts this Playwright session into the canned AI mock
+      // response so tests don't burn Claude credits. The route handlers
+      // forward this to generateReviewResponse, which fires the mock ONLY
+      // when this header AND the E2E_MOCK_AI env var are both set. See
+      // DECISIONS.md #61 — without this gate, manual users on the same
+      // Preview deployment as the tests would also short-circuit Claude.
+      'x-e2e-mock': '1',
+      // Bypass Vercel Deployment Protection for automated testing.
+      ...(process.env.VERCEL_AUTOMATION_BYPASS_SECRET && {
         'x-vercel-protection-bypass': process.env.VERCEL_AUTOMATION_BYPASS_SECRET,
-      },
-    }),
+      }),
+    },
   },
 
   projects: [

--- a/src/app/api/brand-voice/test/route.ts
+++ b/src/app/api/brand-voice/test/route.ts
@@ -66,6 +66,9 @@ export async function POST(request: NextRequest) {
     // Detect language of the review
     const languageResult = detectLanguage(reviewText);
 
+    // E2E mock opt-in (header gate — see DECISIONS.md #61).
+    const e2eMockOptIn = request.headers.get("x-e2e-mock") === "1";
+
     // Iter 4: pass the V2 brand voice row directly. The iter-3 inline
     // V2→legacy projection is gone — `generateReviewResponse` now
     // `normalizeBrandVoice`s the input and `buildSystemPrompt` consumes
@@ -77,6 +80,7 @@ export async function POST(request: NextRequest) {
       detectedLanguage: languageResult.language,
       brandVoice,
       isTestMode: true,
+      e2eMockOptIn,
     });
 
     // The test panel UI still consumes the legacy brand-voice shape on

--- a/src/app/api/reviews/[id]/generate/route.ts
+++ b/src/app/api/reviews/[id]/generate/route.ts
@@ -144,6 +144,12 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     // labeled few-shot examples, Personalization toggles + negative-review
     // framing as conditional fragments). The iter-3 inline V2→legacy
     // projection is gone — that's spec §9.3 / DECISION 55.
+    // E2E mock opt-in: Playwright tests send `x-e2e-mock: 1` so the
+    // canned mock response fires only for tests, never for manual users
+    // hitting the same Preview deployment. The env-var alone is not
+    // enough — see DECISIONS.md #61.
+    const e2eMockOptIn = request.headers.get("x-e2e-mock") === "1";
+
     let generatedResponse;
     try {
       generatedResponse = await generateReviewResponse({
@@ -154,6 +160,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
         detectedLanguage: review.detectedLanguage,
         brandVoice,
         toneModifier: tone,
+        e2eMockOptIn,
       });
     } catch (error) {
       console.error("Claude API error:", error);

--- a/src/app/api/reviews/[id]/regenerate/route.ts
+++ b/src/app/api/reviews/[id]/regenerate/route.ts
@@ -152,6 +152,9 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     const brandVoice = await getOrCreateBrandVoice(session.user.id);
 
     // Generate new response with tone modifier
+    // E2E mock opt-in (header gate — see DECISIONS.md #61).
+    const e2eMockOptIn = request.headers.get("x-e2e-mock") === "1";
+
     // Iter 4: pass the V2 brand voice row directly; the iter-3 V2→legacy
     // projection is gone (DECISION 55). Sentiment is forwarded so the
     // rating-conditional structure router can pick the right template
@@ -166,6 +169,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
         detectedLanguage: review.detectedLanguage,
         brandVoice,
         toneModifier: tone as ToneModifier,
+        e2eMockOptIn,
       });
     } catch (error) {
       console.error("Claude API error:", error);

--- a/src/lib/ai/claude.ts
+++ b/src/lib/ai/claude.ts
@@ -96,6 +96,21 @@ export interface GenerateResponseParams {
    * generation only — it is never persisted.
    */
   customRegenerateInstructions?: string;
+  /**
+   * Set by the route handler when the inbound request carries the
+   * `x-e2e-mock: 1` header that Playwright tests send. Combined with the
+   * `E2E_MOCK_AI=true` env var (set on Vercel Preview), this opt-in causes
+   * the mock canned response to be returned instead of calling Claude.
+   *
+   * The env-var alone is not enough — both must be true. The env-var
+   * scopes mocking to Preview deployments (production never has it set);
+   * the header distinguishes a Playwright test from a real user clicking
+   * Generate inside that same Preview process. Without both gates, any
+   * manual click on staging would short-circuit Claude.
+   *
+   * See DECISIONS.md decision 61 (the follow-up to decision 15).
+   */
+  e2eMockOptIn?: boolean;
 }
 
 export interface GeneratedResponse {
@@ -158,11 +173,16 @@ export async function generateReviewResponse(
     isTestMode = false,
     toneModifier,
     customRegenerateInstructions,
+    e2eMockOptIn = false,
   } = params;
 
-  // E2E mock mode: return canned response without calling Claude API.
-  // Set E2E_MOCK_AI=true on the Vercel Preview environment to enable.
-  if (process.env.E2E_MOCK_AI === "true") {
+  // E2E mock mode — DOUBLE-GATED so manual users on Preview/staging never
+  // get the canned response.
+  //   1. `E2E_MOCK_AI=true` env var (set on Vercel Preview, unset on prod).
+  //   2. `e2eMockOptIn` — set by the route handler when the inbound request
+  //      carries the `x-e2e-mock: 1` header that Playwright tests send.
+  // Both must be true. See DECISIONS.md decision 61 (follow-up to #15).
+  if (process.env.E2E_MOCK_AI === "true" && e2eMockOptIn) {
     return {
       responseText:
         "Thank you for your feedback! We truly appreciate you taking the time to share your experience with us. Your input helps us continue to improve our service.",

--- a/tests/unit/lib/ai/claude.test.ts
+++ b/tests/unit/lib/ai/claude.test.ts
@@ -323,6 +323,88 @@ describe('claude.ts', () => {
     });
   });
 
+  // ─── Fix (post-iter-4): E2E mock double-gate ─────────────────────────
+  // The mock canned response must fire ONLY when BOTH the env var
+  // (`E2E_MOCK_AI=true`) is set on the runtime AND the inbound request
+  // carries the `x-e2e-mock: 1` header (forwarded by routes as
+  // `e2eMockOptIn`). The env var alone is not sufficient — manual users
+  // hitting a Preview deployment where the env var is set must still get
+  // a real Claude response. See DECISIONS.md #61.
+  describe('E2E mock double-gate', () => {
+    it('returns the canned mock when env=true AND e2eMockOptIn=true', async () => {
+      process.env.E2E_MOCK_AI = 'true';
+
+      const result = await generateReviewResponse({
+        ...defaultParams,
+        e2eMockOptIn: true,
+      });
+
+      expect(result.model).toBe('mock-e2e');
+      expect(result.responseText).toContain('Thank you for your feedback');
+      // The real Claude client must NOT have been invoked.
+      expect(mockCreate).not.toHaveBeenCalled();
+    });
+
+    it('calls Claude (no mock) when env=true but e2eMockOptIn is omitted (manual user case)', async () => {
+      process.env.E2E_MOCK_AI = 'true';
+
+      const result = await generateReviewResponse(defaultParams);
+
+      // Real path: Claude was hit and the canned mock did NOT fire.
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+      expect(result.model).toBe('claude-sonnet-4-20250514');
+      expect(result.responseText).not.toBe(
+        'Thank you for your feedback! We truly appreciate you taking the time to share your experience with us. Your input helps us continue to improve our service.',
+      );
+    });
+
+    it('calls Claude (no mock) when env=true but e2eMockOptIn=false explicitly', async () => {
+      process.env.E2E_MOCK_AI = 'true';
+
+      await generateReviewResponse({
+        ...defaultParams,
+        e2eMockOptIn: false,
+      });
+
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls Claude (no mock) when env=false but e2eMockOptIn=true (header without prod env)', async () => {
+      // E2E_MOCK_AI unset (or any non-"true" value) blocks the mock even
+      // if the header is present. This protects production, where the env
+      // var is never set, against any accidental or malicious header.
+      delete process.env.E2E_MOCK_AI;
+
+      await generateReviewResponse({
+        ...defaultParams,
+        e2eMockOptIn: true,
+      });
+
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls Claude (no mock) when env is unset AND e2eMockOptIn is omitted (production / local default)', async () => {
+      delete process.env.E2E_MOCK_AI;
+
+      await generateReviewResponse(defaultParams);
+
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+    });
+
+    it('treats a non-"true" env value as off, even with the header set', async () => {
+      // Belt-and-braces: only the literal string "true" enables. Any other
+      // truthy-looking value ("1", "yes", "TRUE") should not.
+      process.env.E2E_MOCK_AI = '1';
+
+      await generateReviewResponse({
+        ...defaultParams,
+        e2eMockOptIn: true,
+      });
+
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+    });
+  });
+
   // ─── Iteration 4: V2 prompt rewrite ─────────────────────────────────
   // Spec: docs/MVP_Phase-1/BRAND_VOICE_REDESIGN.md §4–§9.
   describe('V2 prompt rendering', () => {


### PR DESCRIPTION
## Summary

Small focused fix landing between iter 4 and iter 5 of the brand voice page redesign.

**Manual response generation on staging was returning the canned Playwright mock string instead of a real Claude response.** This blocks the founder from observing what iter 4 actually shipped. This PR double-gates the mock so manual users get real Claude on Preview/staging, while Playwright tests still get the canned mock for free CI runs.

## Root cause

The original `E2E_MOCK_AI` gate ([DECISION 15](DECISIONS.md), April 17 2026) is single-condition. When the env var is set on Vercel Preview (its documented placement), every call to `generateReviewResponse` short-circuits to the canned response regardless of caller. The implicit assumption that "Vercel Preview" and "staging-for-manual-testing" were distinct environments doesn't hold for this project: pushes to `main` build a Preview deployment that *is* the staging URL the founder tests manually. So `E2E_MOCK_AI=true` on Preview was correct for the E2E tests AND silently short-circuiting manual generates on staging — the env-var check couldn't distinguish a Playwright request from a real user click in the same Next.js process.

## Fix

Double-gate the mock. BOTH conditions must be true.

1. **`process.env.E2E_MOCK_AI === "true"`** — env var, set on Preview only. Keeps the mock impossible to fire on production no matter what headers an attacker sends.
2. **`e2eMockOptIn === true`** — forwarded by route handlers from the `x-e2e-mock: 1` header that Playwright sends. Identifies the caller as a test, not a real user click.

## Changes

### `src/lib/ai/claude.ts`

- `GenerateResponseParams.e2eMockOptIn?: boolean` added (defaults `false`).
- Mock guard changes from `if (env === "true")` to `if (env === "true" && e2eMockOptIn)`.

### Route handlers

- `src/app/api/reviews/[id]/generate/route.ts`
- `src/app/api/reviews/[id]/regenerate/route.ts`
- `src/app/api/brand-voice/test/route.ts`

Each reads `request.headers.get("x-e2e-mock") === "1"` and forwards as `e2eMockOptIn` to `generateReviewResponse`.

### `playwright.config.ts`

`extraHTTPHeaders` restructured so `x-e2e-mock: 1` is sent on every Playwright request (unconditional). The existing `x-vercel-protection-bypass` header stays conditional on the secret env var being present.

### Tests

`tests/unit/lib/ai/claude.test.ts` gains a new **"E2E mock double-gate"** describe block with 6 truth-table cases:

| env `E2E_MOCK_AI` | header → `e2eMockOptIn` | Outcome |
|---|---|---|
| `"true"` | `true` | Mock fires (Playwright happy path) |
| `"true"` | omitted | Claude runs (the bug this PR fixes — manual user) |
| `"true"` | `false` explicitly | Claude runs |
| unset | `true` | Claude runs (production-poisoning-header protection) |
| unset | omitted | Claude runs (production / local default) |
| `"1"` (non-`"true"`) | `true` | Claude runs (only literal `"true"` enables) |

## Verification

- `npm run lint:strict` clean
- `npm run type-check` clean
- `npm run test:unit` **969 passed, 0 failed** across 63 files (+6 from this fix; iter 4 baseline was 963)

## What this does NOT change

- **Production safety.** The env var is still required, and production never has it set. Even if a hostile `x-e2e-mock: 1` header is sent to production, the mock will not fire.
- **Playwright tests.** They continue to receive the canned mock response, because the config now sends the header on every request. No test changes required.

## What this DOES change

- **Manual users on Preview / staging:** receive a real Claude response. This is the user-visible bug fix.

## Smoke test after merge

1. Open dev tools → Network tab on staging.
2. Click **Generate** on a review.
3. Inspect the response from `POST /api/reviews/[id]/generate`.
4. `data.response.generationModel` should now be `"claude-sonnet-4-20250514"` (not `"mock-e2e"`).
5. `data.response.responseText` should be a real multi-paragraph response referencing specific details from the review — the V2 prompt rewrite from iter 4 finally observable.

If a Playwright E2E run is triggered (or you run `npm run test:e2e` against staging), Network responses for those test sessions should still show `"mock-e2e"`.

## Why this sits between iter 4 and iter 5

This is a follow-up architectural fix to a decision predating the redesign (DECISION 15, April 17 2026). Without it, the iter-4 work is invisible to manual testing on staging, which makes iter 5 (post-processing) and iter 6 (UI rewrite) harder to evaluate. Slotting it in as a small dedicated PR keeps it visible in the history and unblocks the rest of the redesign.

DECISIONS.md row 61 logs this as a follow-up to row 15.

## Related

- DECISION 15 (the original April-17 env-var gate this fix amends)
- DECISION 61 (this fix)
- PR #123 (iter 4, which surfaced the bug because it made the iter-1 mock behaviour newly visible against the V2 prompt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
