### PR TITLE
feat: brand voice redesign iter 5 - post-processing assembly (salutation + sign-off + reply-to email)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1654,6 +1654,66 @@ Branch: `fix/e2e-mock-header-gate`. Single small fix landing between iter 4 and 
 
 Verification: `npm run lint:strict` clean; `npm run type-check` clean; `npm run test:unit` 969 passed, 0 failed across 63 files (+6 from iter 4's 963).
 
+### Iteration 5 — Post-processing module + route wiring
+
+Branch: `feat/brand-voice-redesign-iter-5`. Deterministically assembles every AI response: prepends the configured salutation (with `{firstName}` substitution + no-name canonicalisation), appends the sign-off block, and on negative reviews substitutes the `[your email]` placeholder the model was instructed to emit with the brand's configured reply-to email. Wired identically into the three routes that call `generateReviewResponse` so preview (`/api/brand-voice/test`) matches prod (`generate`/`regenerate`).
+
+#### Decision 62: Email substitution is INLINE in the model body, not appended after sign-off
+
+- **Decision:** When `negativeReviewEmailEnabled && isNegativeReview && replyToEmail`, post-processing replaces the literal placeholder `[your email]` (case-insensitive, all occurrences) in the model-emitted body with the brand's configured email. The framing fragments in `structure-templates.ts` are updated to explicitly instruct the model to use this placeholder. The reply-to email does NOT appear as a separate line after the sign-off.
+- **Why:** Spec §7.4 example outputs literally show the email inline ("Please email [your email] with your booking details"). A bolted-on line after the sign-off would either duplicate the email (body says "email us" and then it appears again) or read awkwardly when the body already references it by name. The inline substitution matches what a careful human would write.
+- **Risk:** Low ✅. If the model fails to emit the placeholder, the email simply doesn't appear in that response — the structural prompt instruction is strong enough that this should be rare. If beta feedback shows it happening, the follow-up is to add an appended fallback line (open question in the spec).
+- **Required coordination:** The placeholder string is hardcoded in two places that must stay in sync — `structure-templates.ts` `FRAMING_FRAGMENTS` (where the model is told to emit it) and `post-process.ts` `EMAIL_PLACEHOLDER_PATTERN` (where it's substituted). Comments in both files call this out.
+
+#### Decision 63: `post-process.ts` is pure and accepts `unknown` for `brandVoice` (defensive normalisation)
+
+- **Decision:** `assembleResponse` accepts the brand voice as `unknown` and runs `normalizeBrandVoice` internally before reading any field. This mirrors iter 4's approach in `generateReviewResponse` — the route can pass the raw Prisma row, and the function tolerates legacy shapes, partial objects, or even `null`.
+- **Why:** Consistency with iter 4. Pushes coercion to a single well-tested module (`normalizeBrandVoice` already has 25 dedicated tests). Routes stay simple: same call shape as `generateReviewResponse`.
+- **Risk:** Low ✅. No new code paths in the normalize module; this is reuse.
+
+#### Decision 64: Canonicalisation table is an ordered `[regex, replacement][]` list, most-specific first
+
+- **Decision:** When `review.reviewerName` is null/empty, `{firstName}` is replaced with `""` first, then an ordered list of regex-replacement pairs runs over the salutation. The order matters: `Dear  ,` (double-space) is matched and rewritten BEFORE `Dear ,` (single-space) would have matched it. Spec §13.1.
+- **Why:** Concatenation of substitutions in the wrong order produces the wrong output. Most-specific-first ordering is the standard and easiest pattern to reason about. Each entry is commented inline.
+- **Risk:** Low ✅. Exhaustive unit tests cover every variant from the spec table (`Dear ,`, `Hi ,`, `Hello ,`, double-space variants, leading-comma edge case).
+
+#### Decision 65: Body truncation lives in `post-process.ts`, not in the routes
+
+- **Decision:** The route-side truncation (which used to live in `generate`/`regenerate` and was switched to `RESPONSE_BODY_CHAR_MAX` in iter 4) is now gone. Truncation happens inside `assembleResponse` and only affects the body region — salutation and sign-off are appended afterwards and are never truncated.
+- **Why:** Single source of truth. Routes used to duplicate ~8 lines of truncation logic each; that's now in one place with explicit tests proving the closing block survives. Spec §9.4 / §13.2.
+- **Side effect:** `RESPONSE_BODY_CHAR_MAX` is no longer imported by the routes — `assembleResponse` is.
+- **Risk:** Low ✅.
+
+#### Decision 66: Test panel runs the same post-processing as prod (preview == prod parity)
+
+- **Decision:** `POST /api/brand-voice/test` calls `assembleResponse` with `reviewerName: null`, `sentiment: null`, and the rating the panel provides. The test panel returns the assembled text so users see exactly what they'd see on a real review.
+- **Why:** Open Decision D7 (plan): "keep the test panel and have it match prod." Otherwise the panel teaches users a false expectation — "this is what my brand voice produces" — that diverges from the live behaviour.
+- **Risk:** Low ✅. New unit test (`brand-voice-test.test.ts:iter 5: returned responseText is the assembled form`) covers the parity.
+
+#### Decision 67: Sign-off line-break normalisation accepts both literal `\n` and real newlines
+
+- **Decision:** Sign-off text from the DB may contain literal `\n` (escape sequences) OR real newlines depending on how it was serialised. `normaliseSignoffLines` replaces literal `\n` with real newlines and collapses CR-LF/CR to LF for consistency. Spec §13.2.
+- **Why:** The DB column is `@db.Text` — Prisma doesn't enforce either form. Future form changes might switch between them; the post-processor accepting both is cheap and prevents regressions.
+- **Risk:** Low ✅.
+
+#### Decision 68: Framing fragments updated to explicitly tell the model to emit `[your email]`
+
+- **Decision:** All three preset framing fragments in `structure-templates.ts` now include "Use the literal placeholder `[your email]` for the email address." (`management_contact` / `investigation` / `open_channel`).
+- **Why:** Without this, the model invents its own placeholder — sometimes `<email>`, sometimes `[contact]`, sometimes just hard-coding a guessed address. The placeholder is the coordination point with `post-process.ts:substituteReplyToEmail`, so it must be stable. Comments in both files cross-reference the other.
+- **Risk:** Low ✅. The change is purely a clarifying instruction, no spec deviation.
+
+#### Test coverage delta — Iteration 5
+
+| Type | Before iter 5 (suite total) | After iter 5 (suite total) | New from this iteration |
+|---|---|---|---|
+| Unit tests | 969 | 1013 | **+44** |
+| New unit test files | — | — | 1 (`tests/unit/lib/ai/post-process.test.ts`, 41 cases) |
+| Modified unit test files | — | — | 3 (`generate.test.ts` +1, `regenerate.test.ts` +1, `brand-voice-test.test.ts` fixture + 1) |
+| Integration tests | — | — | 0 (route tests cover the persisted-shape assertion) |
+| E2E specs | — | — | 0 |
+
+Verification: `npm run lint:strict` clean; `npm run type-check` clean; `npm run test:unit` 1013 passed, 0 failed across 64 files.
+
 ---
 
 ## Decision Log
@@ -1723,6 +1783,13 @@ Verification: `npm run lint:strict` clean; `npm run type-check` clean; `npm run 
 | 59 | `ToneModifier` type retains the legacy 3-key set this iteration; iter 6 swaps to V2 4-key set | Brand Voice Redesign / It. 4 | May 20 | Low ✅ | ✅ Implemented |
 | 60 | V2 tone rendered in prompt as the human display label, not the snake_case key | Brand Voice Redesign / It. 4 | May 20 | Low ✅ | ✅ Implemented |
 | 61 | E2E mock canned response gated on env var AND `x-e2e-mock` header (follow-up to #15) so manual users on Preview/staging hit real Claude | Brand Voice Redesign / fix between It. 4 + It. 5 | May 21 | Low ✅ | ✅ Implemented |
+| 62 | Email substitution is INLINE in the model body (`[your email]` placeholder), not appended after sign-off | Brand Voice Redesign / It. 5 | May 21 | Low ✅ | ✅ Implemented |
+| 63 | `post-process.ts` accepts `unknown` for brandVoice and runs `normalizeBrandVoice` internally (matches iter 4 pattern) | Brand Voice Redesign / It. 5 | May 21 | Low ✅ | ✅ Implemented |
+| 64 | Canonicalisation table is an ordered `[regex, replacement][]` list, most-specific patterns first | Brand Voice Redesign / It. 5 | May 21 | Low ✅ | ✅ Implemented |
+| 65 | Body truncation lives in `post-process.ts` only — single source of truth; salutation/sign-off never truncated | Brand Voice Redesign / It. 5 | May 21 | Low ✅ | ✅ Implemented |
+| 66 | Test panel (`/api/brand-voice/test`) runs the same `assembleResponse` as prod (preview == prod parity) | Brand Voice Redesign / It. 5 | May 21 | Low ✅ | ✅ Implemented |
+| 67 | Sign-off line-break normalisation accepts both literal `\n` and real newlines from the DB column | Brand Voice Redesign / It. 5 | May 21 | Low ✅ | ✅ Implemented |
+| 68 | Framing fragments explicitly tell the model to emit `[your email]` placeholder (coordination with post-process) | Brand Voice Redesign / It. 5 | May 21 | Low ✅ | ✅ Implemented |
 
 *Table will grow as decisions are made*
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1108,8 +1108,8 @@ A four-section restructure of the brand voice settings screen (Voice / Examples 
 | 1 | Sanitize helper + review-text retrofit + SecurityLog | ✅ Done (May 20, merged via PR #120) |
 | 2 | Validation schema + constants + normalize adapter | ✅ Done (May 20, merged via PR #121) |
 | 3 | Clean-reset schema migration + route cutover + legacy form bridge | ✅ Done (May 20, merged via PR #122) |
-| 4 | Prompt-building rewrite (bug fix, wrap fields, structure, fragments) | ✅ Done (May 20) |
-| 5 | Post-processing module + route wiring | ⏳ Not started |
+| 4 | Prompt-building rewrite (bug fix, wrap fields, structure, fragments) | ✅ Done (May 20, merged via PR #123) |
+| 5 | Post-processing module + route wiring | ✅ Done (May 21) |
 | 6 | Frontend restructure + API Zod cutover + regenerate dialog | ⏳ Not started |
 
 ### ✅ Iteration 1 — Sanitize helper + review-text retrofit + SecurityLog table
@@ -1289,7 +1289,46 @@ Manual response generation on staging after iter 4 returned the canned Playwrigh
 
 **Decisions** (cross-reference DECISIONS.md "Follow-up fix: E2E mock header-gate"): #61 mock requires env AND header (follow-up to #15).
 
+### ✅ Iteration 5 — Post-processing module + route wiring
+
+**Branch:** `feat/brand-voice-redesign-iter-5`
+**Status:** Locally verified (lint:strict / type-check / 1013 unit tests passing). PR pending.
+
+Deterministically assembles every AI response. The model body coming back from Claude is just the prose paragraphs (iter 4's prompt explicitly tells the model NOT to generate a salutation or sign-off). Iter 5 prepends the configured salutation (with `{firstName}` substitution from `review.reviewerName` and canonicalisation when no name is available), appends the configured sign-off block, and on negative reviews substitutes the `[your email]` placeholder the model was instructed to emit with the brand's configured reply-to email. Wired identically into all three routes that call `generateReviewResponse`, so the test panel (`/api/brand-voice/test`) produces the same shape as prod (preview == prod parity).
+
+**What changes externally when this merges:** every generated response now reads like a complete email — salutation at the top, paragraphs in the middle, sign-off at the bottom, optional reply-to email inline for negative reviews. The model body itself is the same as iter 4; iter 5 is the wrapper around it.
+
+**What shipped:**
+
+- **`src/lib/ai/post-process.ts` (NEW, pure module — DECISION 63)** — `assembleResponse({ modelBody, brandVoice, review })` produces the final assembled string. Exports `extractFirstName`, `buildSalutation`, `substituteReplyToEmail` for unit testing. Body truncation lives inside this function (DECISION 65) — salutation and sign-off are appended afterwards and never truncated. Accepts `unknown` for `brandVoice` and runs `normalizeBrandVoice` internally (mirrors iter 4's defensive pattern).
+- **Canonicalisation table (DECISION 64)** — ordered `[regex, replacement][]` list inside `post-process.ts`. Most-specific patterns first so `Dear  ,` (double-space) is matched before `Dear ,` (single-space). Covers every variant from spec §13.1.
+- **`src/lib/ai/structure-templates.ts`** — framing fragments updated (DECISION 68) to explicitly instruct the model to emit the literal `[your email]` placeholder, with cross-reference comments to `post-process.ts:substituteReplyToEmail`.
+- **`src/app/api/reviews/[id]/generate/route.ts`** — replaces the iter-4 inline truncation with a single call to `assembleResponse`. Persists the assembled text.
+- **`src/app/api/reviews/[id]/regenerate/route.ts`** — same replacement; persists the assembled text into `ReviewResponse.responseText` via `update`.
+- **`src/app/api/brand-voice/test/route.ts`** — runs `assembleResponse` too (DECISION 66 / preview == prod). The test panel has no reviewer name or sentiment, so the salutation canonicalises to `Hello,` and the email substitution fires only when the panel passes a 1- or 2-star rating AND the brand voice has the toggle on with a reply-to email.
+
+**Test coverage delta:**
+
+| Type | Before iter 5 (suite total) | After iter 5 (suite total) | New from this iteration |
+|---|---|---|---|
+| Unit tests | 969 | 1013 | **+44** |
+| New unit test files | — | — | 1 (`tests/unit/lib/ai/post-process.test.ts`, 41 cases — the centrepiece) |
+| Modified unit test files | — | — | 3 (`generate.test.ts` +1 iter-5 case; `regenerate.test.ts` +1 iter-5 case; `brand-voice-test.test.ts` fixture rewritten + 1 iter-5 case) |
+| Integration tests | — | — | 0 (route assertions cover the persisted-shape check) |
+| E2E specs | — | — | 0 |
+
+The 41 post-process unit tests cover: `extractFirstName` (5 cases including null/whitespace), `buildSalutation` with name (4 cases) and without name (full canonicalisation table — 6 cases), `substituteReplyToEmail` (5 cases incl. case-insensitivity and multiple-occurrence), `assembleResponse` salutation+body+sign-off (6 cases incl. literal `\n` conversion), email substitution (8 cases covering every routing path — positive/negative/3-star/Kiran case/toggle off/email null), body truncation (4 cases incl. sentence-boundary preference and sign-off never truncated), defensive normalisation (3 cases incl. null brand voice), and full output order (1 case).
+
+**Verification status:**
+
+- ✅ `npm run lint:strict` clean
+- ✅ `npm run type-check` clean
+- ✅ `npm run test:unit` 1013 passed, 0 failed (64 test files)
+- ⏳ Manual smoke after merge: generate a response, confirm it now opens with the configured salutation and closes with the configured sign-off; on a 1-star review with the email toggle on + a reply-to email set, confirm the `[your email]` placeholder is substituted with the configured address.
+
+**Decisions** (cross-reference DECISIONS.md "Brand Voice Page Redesign / Iteration 5" subsection): #62 inline email substitution (not appended); #63 `unknown` brandVoice param + internal normalize; #64 ordered canonicalisation table; #65 body truncation centralised in post-process.ts; #66 test panel runs same assembly as prod; #67 sign-off accepts literal `\n` AND real newlines; #68 framing fragments tell the model to emit `[your email]`.
+
 ---
 
 **Last Updated:** May 21, 2026
-**Status:** Brand voice redesign iteration 4 merged via PR #123. E2E mock header-gate fix complete on branch (PR pending). Iter 5 (post-processing) next.
+**Status:** Brand voice redesign iteration 5 complete on branch (PR pending). Iterations 1 + 2 + 3 + 4 + E2E fix merged to main. Iter 6 (frontend rebuild + Zod cutover + regenerate dialog) next and last.

--- a/src/app/api/brand-voice/test/route.ts
+++ b/src/app/api/brand-voice/test/route.ts
@@ -3,6 +3,7 @@ import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { testBrandVoiceSchema } from "@/lib/validations";
 import { generateReviewResponse } from "@/lib/ai/claude";
+import { assembleResponse } from "@/lib/ai/post-process";
 import { detectLanguage } from "@/lib/language-detection";
 import { toLegacyShape } from "../_legacy-bridge";
 
@@ -83,6 +84,23 @@ export async function POST(request: NextRequest) {
       e2eMockOptIn,
     });
 
+    // Iter 5: run the same post-processing assembly as the real generate
+    // / regenerate routes so the test panel shows the user exactly what
+    // they would see on a real review (preview == prod). The test panel
+    // does not collect a reviewer name or sentiment, so the salutation
+    // falls back to "Hello," via canonicalisation and the email
+    // substitution fires only when the panel passes a 1- or 2-star
+    // rating AND the brand voice has the toggle on + a reply-to email.
+    const responseText = assembleResponse({
+      modelBody: generatedResponse.responseText,
+      brandVoice,
+      review: {
+        rating: rating ?? null,
+        sentiment: null,
+        reviewerName: null,
+      },
+    });
+
     // The test panel UI still consumes the legacy brand-voice shape on
     // the response (iter 6 rewrites the panel). Reuse the brand-voice
     // bridge's `toLegacyShape` so the projection has one source of
@@ -92,7 +110,7 @@ export async function POST(request: NextRequest) {
       success: true,
       data: {
         response: {
-          responseText: generatedResponse.responseText,
+          responseText,
           model: generatedResponse.model,
           isTestMode: true,
           creditsUsed: 0, // No credits deducted for test mode

--- a/src/app/api/reviews/[id]/generate/route.ts
+++ b/src/app/api/reviews/[id]/generate/route.ts
@@ -2,8 +2,9 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { generateReviewResponse, DEFAULT_MODEL, ToneModifier } from "@/lib/ai/claude";
+import { assembleResponse } from "@/lib/ai/post-process";
 import { deductCreditsAtomic, getOrCreateBrandVoice } from "@/lib/db-utils";
-import { CREDIT_COSTS, RESPONSE_BODY_CHAR_MAX } from "@/lib/constants";
+import { CREDIT_COSTS } from "@/lib/constants";
 import { logIfInjectionAttempt } from "@/lib/security-log";
 import { CreditActionValues } from "@/types/database";
 
@@ -177,20 +178,25 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       );
     }
 
-    // Iter 4: truncate the model body to RESPONSE_BODY_CHAR_MAX (≈ "200
-    // words"). The assembled response — salutation + body + sign-off +
-    // optional reply-to email — stays well within
-    // VALIDATION_LIMITS.RESPONSE_TEXT_MAX (= 2000). Iter 5's
-    // `assembleResponse` will replace this with closing-block-aware
-    // truncation so salutation/sign-off are never chopped.
-    let responseText = generatedResponse.responseText;
-    if (responseText.length > RESPONSE_BODY_CHAR_MAX) {
-      responseText = responseText.substring(0, RESPONSE_BODY_CHAR_MAX);
-      const lastPeriod = responseText.lastIndexOf(".");
-      if (lastPeriod > RESPONSE_BODY_CHAR_MAX - 100) {
-        responseText = responseText.substring(0, lastPeriod + 1);
-      }
-    }
+    // Iter 5: deterministically assemble the final response. `assembleResponse`
+    // prepends the configured salutation (with {firstName} substitution from
+    // review.reviewerName and canonicalisation when no name is available),
+    // appends the sign-off block (literal \n converted to real newlines),
+    // and for negative reviews with the email-invitation toggle on
+    // substitutes the [your email] placeholder in the model body with the
+    // brand's configured reply-to email. The model body is internally
+    // truncated to RESPONSE_BODY_CHAR_MAX (sentence-boundary aware);
+    // salutation and sign-off are appended afterwards and never truncated.
+    // Spec §7, §9.4, §13.1, §13.2.
+    const responseText = assembleResponse({
+      modelBody: generatedResponse.responseText,
+      brandVoice,
+      review: {
+        rating: review.rating,
+        sentiment: review.sentiment,
+        reviewerName: review.reviewerName,
+      },
+    });
 
     // Deduct credits atomically
     const creditResult = await deductCreditsAtomic(

--- a/src/app/api/reviews/[id]/regenerate/route.ts
+++ b/src/app/api/reviews/[id]/regenerate/route.ts
@@ -3,8 +3,9 @@ import { z } from "zod";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { generateReviewResponse, DEFAULT_MODEL, ToneModifier } from "@/lib/ai/claude";
+import { assembleResponse } from "@/lib/ai/post-process";
 import { deductCreditsAtomic, getOrCreateBrandVoice } from "@/lib/db-utils";
-import { CREDIT_COSTS, RESPONSE_BODY_CHAR_MAX } from "@/lib/constants";
+import { CREDIT_COSTS } from "@/lib/constants";
 import { logIfInjectionAttempt } from "@/lib/security-log";
 import { CreditActionValues } from "@/types/database";
 
@@ -186,17 +187,20 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       );
     }
 
-    // Iter 4: truncate the model body to RESPONSE_BODY_CHAR_MAX. Iter 5's
-    // `assembleResponse` will replace this with closing-block-aware
-    // truncation so salutation/sign-off are never chopped.
-    let responseText = generatedResponse.responseText;
-    if (responseText.length > RESPONSE_BODY_CHAR_MAX) {
-      responseText = responseText.substring(0, RESPONSE_BODY_CHAR_MAX);
-      const lastPeriod = responseText.lastIndexOf(".");
-      if (lastPeriod > RESPONSE_BODY_CHAR_MAX - 100) {
-        responseText = responseText.substring(0, lastPeriod + 1);
-      }
-    }
+    // Iter 5: assemble the final response (salutation + body + sign-off
+    // + conditional email substitution). Body is internally truncated to
+    // RESPONSE_BODY_CHAR_MAX; salutation and sign-off are appended after
+    // and never truncated. See post-process.ts and spec §7 / §9.4 /
+    // §13.1 / §13.2.
+    const responseText = assembleResponse({
+      modelBody: generatedResponse.responseText,
+      brandVoice,
+      review: {
+        rating: review.rating,
+        sentiment: review.sentiment,
+        reviewerName: review.reviewerName,
+      },
+    });
 
     // Deduct credits atomically
     const creditResult = await deductCreditsAtomic(

--- a/src/lib/ai/post-process.ts
+++ b/src/lib/ai/post-process.ts
@@ -1,0 +1,219 @@
+/**
+ * Post-processing assembler for AI-generated review responses (iter 5).
+ *
+ * The model in iter 4 is explicitly instructed NOT to generate a salutation
+ * or sign-off — those are deterministic and configurable per brand, so we
+ * add them outside the model where the wording is exact every time.
+ *
+ * Responsibilities:
+ *   1. Prepend the configured salutation (with `{firstName}` substitution
+ *      from `review.reviewerName`, plus canonicalisation when no name is
+ *      available so we don't end up with `Dear ,`).
+ *   2. Append the configured sign-off block, normalising the literal `\n`
+ *      stored form into real newlines.
+ *   3. For negative reviews with the email-invitation toggle on, replace
+ *      the `[your email]` placeholder the model was instructed to emit
+ *      (see `FRAMING_FRAGMENTS` in structure-templates.ts) with the
+ *      brand's configured `replyToEmail`.
+ *   4. Cap only the model body to `RESPONSE_BODY_CHAR_MAX` — salutation
+ *      and sign-off are appended after and are never truncated. Total
+ *      assembled length stays well within `RESPONSE_TEXT_MAX` (2000).
+ *
+ * Output order: `[salutation]\n\n[body]\n\n[sign-off block]`.
+ *
+ * Spec: docs/MVP_Phase-1/BRAND_VOICE_REDESIGN.md §7, §9.4, §13.1, §13.2.
+ *
+ * Pure: no prisma, no Anthropic SDK, no I/O. Safe to unit-test on plain
+ * objects. The route layer is the only caller.
+ */
+
+import { RESPONSE_BODY_CHAR_MAX } from "@/lib/constants";
+import {
+  type NormalizedBrandVoice,
+  normalizeBrandVoice,
+} from "./brand-voice-normalize";
+import { isNegativeReview } from "./structure-templates";
+
+/**
+ * Subset of a review the assembler reads. Mirrors the columns Prisma
+ * returns on `Review`, so callers can pass the row directly.
+ */
+export interface ReviewForAssembly {
+  rating: number | null;
+  sentiment: string | null;
+  reviewerName: string | null;
+}
+
+/**
+ * Input to {@link assembleResponse}. `brandVoice` accepts any shape — the
+ * function normalises it via `normalizeBrandVoice` before reading any field,
+ * so the route layer can pass the raw Prisma row.
+ */
+export interface AssembleResponseArgs {
+  modelBody: string;
+  brandVoice: unknown;
+  review: ReviewForAssembly;
+}
+
+/** The literal placeholder the model is told to emit; spec §7.4. */
+const EMAIL_PLACEHOLDER_PATTERN = /\[your email\]/gi;
+
+/**
+ * Salutation canonicalisation table (resolves spec §13.1).
+ *
+ * When `review.reviewerName` is empty, `{firstName}` is replaced with the
+ * empty string, leaving artifacts like `Dear ,` or `Hi ,`. The table below
+ * cleans those up into natural phrasing.
+ *
+ * Order matters — we apply most-specific patterns first (double-space
+ * variants before single-space variants) so that `Dear  ,` doesn't collapse
+ * to `Dear ,` only to be re-matched by a later rule.
+ *
+ * Adding a new variant: prefer a regex that's anchored to the start of the
+ * salutation (most patterns are at most a salutation prefix + comma) so
+ * accidental matches inside the body cannot occur.
+ */
+const NO_NAME_CANONICALISATIONS: ReadonlyArray<readonly [RegExp, string]> = [
+  // `Dear  ,` (double space before comma) → `Hello,`
+  [/^Dear\s{2,},/u, "Hello,"],
+  // `Hi  ,` / `Hello  ,` (double space) — keep prefix, drop the orphan
+  [/^Hi\s{2,},/u, "Hi,"],
+  [/^Hello\s{2,},/u, "Hello,"],
+  // `Dear ,` (single space before comma) → `Hello,` (Dear without a name is awkward)
+  [/^Dear\s,/u, "Hello,"],
+  // `Hi ,` / `Hello ,` → drop the orphan space
+  [/^Hi\s,/u, "Hi,"],
+  [/^Hello\s,/u, "Hello,"],
+  // Dangling comma at the very start (very defensive — covers patterns that
+  // start with `{firstName},`)
+  [/^,+\s*/u, "Hello,"],
+];
+
+/**
+ * Extract the first name from `review.reviewerName`. Splits on whitespace
+ * and returns the first non-empty token; returns `null` if the input is
+ * `null`, empty, or all-whitespace.
+ *
+ * Examples:
+ *   "Jane"             → "Jane"
+ *   "Jane Smith"       → "Jane"
+ *   "  Jane  Smith  "  → "Jane"
+ *   ""                 → null
+ *   null               → null
+ *   "   "              → null
+ */
+export function extractFirstName(raw: string | null | undefined): string | null {
+  if (raw == null) return null;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return null;
+  const firstToken = trimmed.split(/\s+/u)[0];
+  return firstToken && firstToken.length > 0 ? firstToken : null;
+}
+
+/**
+ * Substitute `{firstName}` in the salutation pattern and apply the no-name
+ * canonicalisation table when the name is unavailable.
+ *
+ * Exported for unit testing — the route layer should call
+ * {@link assembleResponse}, which wraps this.
+ */
+export function buildSalutation(
+  salutationPattern: string,
+  firstName: string | null,
+): string {
+  if (firstName) {
+    return salutationPattern.replace(/\{firstName\}/gu, firstName);
+  }
+
+  // Replace the variable with an empty string first; then run the table.
+  let s = salutationPattern.replace(/\{firstName\}/gu, "");
+  for (const [pattern, replacement] of NO_NAME_CANONICALISATIONS) {
+    s = s.replace(pattern, replacement);
+  }
+  return s.trim();
+}
+
+/**
+ * Convert the stored sign-off form into real line breaks.
+ *
+ * The DB column is `@db.Text` so the string may contain either real
+ * newlines or literal `\n` escape sequences (e.g. if the form serialises
+ * via `JSON.stringify` somewhere upstream). We accept both and normalise
+ * to real newlines. Resolves spec §13.2.
+ */
+function normaliseSignoffLines(raw: string): string {
+  // Replace literal backslash-n with a real newline. The regex matches
+  // a backslash followed by lowercase n; CR-LF / CR variants are also
+  // collapsed to LF for consistency.
+  return raw.replace(/\\n/gu, "\n").replace(/\r\n?/gu, "\n").trimEnd();
+}
+
+/**
+ * Substitute the `[your email]` placeholder (case-insensitive) with the
+ * brand's configured reply-to email. Returns the body unchanged if no
+ * placeholder is present, or if the email itself is empty.
+ *
+ * Exported for unit testing.
+ */
+export function substituteReplyToEmail(body: string, email: string | null): string {
+  if (!email || email.trim().length === 0) return body;
+  return body.replace(EMAIL_PLACEHOLDER_PATTERN, email);
+}
+
+/**
+ * Truncate the model-emitted body to `RESPONSE_BODY_CHAR_MAX`, preferring
+ * to end at a sentence boundary when one is available in the last 100
+ * characters.
+ *
+ * Salutation and sign-off are appended afterwards and are never affected.
+ */
+function truncateBody(body: string): string {
+  if (body.length <= RESPONSE_BODY_CHAR_MAX) return body;
+  const sliced = body.substring(0, RESPONSE_BODY_CHAR_MAX);
+  const lastPeriod = sliced.lastIndexOf(".");
+  if (lastPeriod > RESPONSE_BODY_CHAR_MAX - 100) {
+    return sliced.substring(0, lastPeriod + 1);
+  }
+  return sliced;
+}
+
+/**
+ * Assemble the final response from the model body and the brand voice
+ * configuration.
+ *
+ * Output order:
+ *   [salutation]
+ *
+ *   [body paragraphs (with [your email] substituted on negative reviews)]
+ *
+ *   [sign-off (with literal \n converted to real newlines)]
+ */
+export function assembleResponse(args: AssembleResponseArgs): string {
+  const { modelBody, brandVoice, review } = args;
+
+  const normalized: NormalizedBrandVoice = normalizeBrandVoice(brandVoice);
+
+  // 1. Salutation
+  const firstName = extractFirstName(review.reviewerName);
+  const salutation = buildSalutation(normalized.salutationPattern, firstName);
+
+  // 2. Body — first cap to RESPONSE_BODY_CHAR_MAX, then optionally
+  //    substitute the [your email] placeholder for negative reviews when
+  //    the toggle is on AND a reply-to email is configured.
+  let body = truncateBody(modelBody.trim());
+  const negative = isNegativeReview({
+    rating: review.rating,
+    sentiment: review.sentiment,
+  });
+  if (negative && normalized.negativeReviewEmailEnabled && normalized.replyToEmail) {
+    body = substituteReplyToEmail(body, normalized.replyToEmail);
+  }
+
+  // 3. Sign-off
+  const signoff = normaliseSignoffLines(normalized.signoffLines);
+
+  // 4. Assemble. Salutation → blank line → body → blank line → sign-off.
+  //    No trailing newline; the response is stored verbatim and rendered
+  //    by the UI's prose renderer which handles its own block spacing.
+  return `${salutation}\n\n${body}\n\n${signoff}`;
+}

--- a/src/lib/ai/structure-templates.ts
+++ b/src/lib/ai/structure-templates.ts
@@ -141,14 +141,21 @@ export type NegativeReviewFraming =
  * Spec §7.4 framing strings. The `custom` option is handled separately by
  * the caller (it wraps the user-supplied `negativeReviewFramingCustom` via
  * the sanitize helper).
+ *
+ * Each framing instructs the model to include the literal placeholder
+ * `[your email]` wherever the customer is invited to make contact. Iter
+ * 5's post-processing layer substitutes that placeholder with the
+ * brand voice's configured `replyToEmail`. The placeholder is the
+ * coordination point between this prompt and `post-process.ts:
+ * substituteReplyToEmail` — change it in both places together.
  */
 const FRAMING_FRAGMENTS: Record<Exclude<NegativeReviewFraming, "custom">, string> = {
   management_contact:
-    "Include a clear promise that a member of management will reach out via the contact email, and request the customer's booking details so the team can follow up properly.",
+    "Include a clear promise that a member of management will reach out via the contact email. Use the literal placeholder `[your email]` for the email address. Request the customer's booking details so the team can follow up properly.",
   investigation:
-    "Invite the customer to email their concerns and booking details, framing it as something the team would like to look into.",
+    "Invite the customer to email their concerns and booking details, framing it as something the team would like to look into. Use the literal placeholder `[your email]` for the email address.",
   open_channel:
-    "Offer the email as a channel for further conversation, without promising specific follow-up actions.",
+    "Offer the email as a channel for further conversation, without promising specific follow-up actions. Use the literal placeholder `[your email]` for the email address.",
 };
 
 /** Get the preset framing fragment. Returns null for the `custom` option. */

--- a/tests/unit/api/brand-voice/brand-voice-test.test.ts
+++ b/tests/unit/api/brand-voice/brand-voice-test.test.ts
@@ -60,14 +60,24 @@ function createRequest(
   });
 }
 
+// V2 brand voice fixture (iter 3 column shape, iter 5 post-processing
+// fields). The test panel uses this to drive the assembled-output assertion
+// below.
 const defaultBrandVoice = {
   id: 'bv1',
   userId: 'clu1234567890abcdef',
-  tone: 'professional',
-  formality: 3,
+  tone: 'friendly_professional',
   keyPhrases: ['Thank you', 'We appreciate your feedback'],
-  styleNotes: 'Be genuine and empathetic',
+  styleGuidelines: ['Be genuine and empathetic'],
   sampleResponses: [],
+  acknowledgeNamedStaff: true,
+  acknowledgeOccasions: true,
+  salutationPattern: 'Dear {firstName},',
+  signoffLines: 'Warmest regards,\nThe Team',
+  negativeReviewEmailEnabled: false,
+  negativeReviewFraming: 'investigation',
+  negativeReviewFramingCustom: null,
+  replyToEmail: null,
   createdAt: new Date(),
   updatedAt: new Date(),
 };
@@ -133,6 +143,28 @@ describe('POST /api/brand-voice/test', () => {
     expect(json.data.response.isTestMode).toBe(true);
     expect(json.data.response.creditsUsed).toBe(0);
     expect(json.data.response.responseText).toBeDefined();
+  });
+
+  // Iter 5: post-processing assembly runs in the test panel too, so the
+  // preview matches what a real generate would produce (preview == prod).
+  it('iter 5: returned responseText is the assembled form (salutation + body + sign-off)', async () => {
+    mockPrisma.brandVoice.findUnique.mockResolvedValue(defaultBrandVoice);
+
+    const req = createRequest('/api/brand-voice/test', {
+      method: 'POST',
+      body: { reviewText: 'Amazing service! Will come back again.' },
+    });
+    const res = await POST(req);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    // The test panel doesn't pass a reviewer name, so the salutation
+    // canonicalises to "Hello,".
+    expect(json.data.response.responseText.startsWith('Hello,\n\n')).toBe(true);
+    // The configured sign-off appears at the end, on its own block.
+    expect(json.data.response.responseText.endsWith('Warmest regards,\nThe Team')).toBe(true);
+    // The model body sits between the two.
+    expect(json.data.response.responseText).toContain('Thank you for your wonderful feedback');
   });
 
   it('creates default brand voice if none exists', async () => {

--- a/tests/unit/api/reviews/generate.test.ts
+++ b/tests/unit/api/reviews/generate.test.ts
@@ -325,6 +325,31 @@ describe('POST /api/reviews/[id]/generate', () => {
     expect(mockPrisma.reviewResponse.create).not.toHaveBeenCalled();
   });
 
+  // ─── Iteration 5: post-processing assembly ─────────────────────────
+  it('iter 5: persists the assembled response (salutation + body + sign-off)', async () => {
+    // The route runs `assembleResponse` on the model body before persisting.
+    // The reviewer is "John" → salutation becomes "Dear John,". The default
+    // brand voice sign-off is "Warmest regards,\nThe Team". Model body is
+    // "Thank you for your feedback!" from the mock.
+    mockPrisma.user.findUnique.mockResolvedValueOnce(baseUser);
+    mockPrisma.review.findFirst.mockResolvedValueOnce(reviewWithoutResponse);
+    mockPrisma.reviewResponse.create.mockResolvedValueOnce(createdResponse);
+    mockPrisma.creditUsage.updateMany.mockResolvedValueOnce({ count: 1 });
+
+    const req = createRequest('/api/reviews/review-1/generate', { method: 'POST', body: {} });
+    await POST(req, routeParams({ id: 'review-1' }));
+
+    expect(mockPrisma.reviewResponse.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          responseText: expect.stringMatching(
+            /^Dear John,\n\nThank you for your feedback!\n\nWarmest regards,\nThe Team$/,
+          ),
+        }),
+      }),
+    );
+  });
+
   // ─── Iteration 1: prompt-injection audit logging (spec §10.6) ────
   describe('prompt-injection audit logging', () => {
     it('calls logIfInjectionAttempt with the review text on every successful generation', async () => {

--- a/tests/unit/api/reviews/regenerate.test.ts
+++ b/tests/unit/api/reviews/regenerate.test.ts
@@ -409,4 +409,36 @@ describe('POST /api/reviews/[id]/regenerate', () => {
       expect(mockLogIfInjectionAttempt).not.toHaveBeenCalled();
     });
   });
+
+  // ─── Iteration 5: post-processing assembly ─────────────────────────
+  describe('post-processing assembly', () => {
+    it('persists the assembled response (salutation + body + sign-off)', async () => {
+      // reviewer "John" + mock body "We appreciate your feedback!" + default
+      // V2 brand voice salutation + sign-off → expected assembled form.
+      mockPrisma.user.findUnique.mockResolvedValueOnce(baseUser);
+      mockPrisma.review.findFirst.mockResolvedValueOnce(reviewWithResponse);
+      mockPrisma.reviewResponse.update.mockResolvedValueOnce({
+        ...existingResponse,
+        responseText: 'Dear John,\n\nWe appreciate your feedback!\n\nWarmest regards,\nThe Team',
+      });
+      mockPrisma.responseVersion.create.mockResolvedValueOnce({ id: 'ver-1' });
+      mockPrisma.creditUsage.updateMany.mockResolvedValueOnce({ count: 1 });
+
+      const req = createRequest('/api/reviews/review-1/regenerate', {
+        method: 'POST',
+        body: { tone: 'friendly' },
+      });
+      await POST(req, routeParams({ id: 'review-1' }));
+
+      expect(mockPrisma.reviewResponse.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            responseText: expect.stringMatching(
+              /^Dear John,\n\nWe appreciate your feedback!\n\nWarmest regards,\nThe Team$/,
+            ),
+          }),
+        }),
+      );
+    });
+  });
 });

--- a/tests/unit/lib/ai/post-process.test.ts
+++ b/tests/unit/lib/ai/post-process.test.ts
@@ -1,0 +1,435 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  assembleResponse,
+  buildSalutation,
+  extractFirstName,
+  substituteReplyToEmail,
+} from "@/lib/ai/post-process";
+
+// Default V2 brand voice — fields we override per-test, defaults from
+// `normalizeBrandVoice` fill in the rest at runtime.
+const baseBrandVoice = {
+  tone: "friendly_professional",
+  keyPhrases: [],
+  styleGuidelines: [],
+  sampleResponses: [],
+  acknowledgeNamedStaff: true,
+  acknowledgeOccasions: true,
+  salutationPattern: "Dear {firstName},",
+  signoffLines: "Warmest regards,\nThe Team",
+  negativeReviewEmailEnabled: false,
+  negativeReviewFraming: "investigation" as const,
+  negativeReviewFramingCustom: null,
+  replyToEmail: null,
+};
+
+const baseReview = {
+  rating: 5 as number | null,
+  sentiment: null as string | null,
+  reviewerName: "Jane" as string | null,
+};
+
+describe("extractFirstName", () => {
+  it("returns the single token unchanged", () => {
+    expect(extractFirstName("Jane")).toBe("Jane");
+  });
+
+  it("returns the first whitespace-delimited token for a multi-word name", () => {
+    expect(extractFirstName("Jane Smith")).toBe("Jane");
+    expect(extractFirstName("Jane Anne Smith")).toBe("Jane");
+  });
+
+  it("trims surrounding whitespace before extracting", () => {
+    expect(extractFirstName("  Jane Smith  ")).toBe("Jane");
+    expect(extractFirstName("\tJane")).toBe("Jane");
+  });
+
+  it("collapses internal multi-whitespace and still returns the first token", () => {
+    expect(extractFirstName("Jane    Smith")).toBe("Jane");
+  });
+
+  it("returns null for null / undefined / empty / whitespace-only input", () => {
+    expect(extractFirstName(null)).toBeNull();
+    expect(extractFirstName(undefined)).toBeNull();
+    expect(extractFirstName("")).toBeNull();
+    expect(extractFirstName("   ")).toBeNull();
+  });
+});
+
+describe("buildSalutation — with name", () => {
+  it("substitutes {firstName} with the provided name", () => {
+    expect(buildSalutation("Dear {firstName},", "Jane")).toBe("Dear Jane,");
+  });
+
+  it("substitutes in 'Hi {firstName},' too", () => {
+    expect(buildSalutation("Hi {firstName},", "Jane")).toBe("Hi Jane,");
+  });
+
+  it("substitutes multiple occurrences (defensive — unlikely but supported)", () => {
+    expect(buildSalutation("Hi {firstName}, {firstName}!", "Jane")).toBe("Hi Jane, Jane!");
+  });
+
+  it("returns the pattern unchanged when it has no {firstName} placeholder", () => {
+    expect(buildSalutation("Hello,", "Jane")).toBe("Hello,");
+  });
+});
+
+describe("buildSalutation — without name (canonicalisation, spec §13.1)", () => {
+  it("'Dear {firstName},' with no name → 'Hello,'", () => {
+    expect(buildSalutation("Dear {firstName},", null)).toBe("Hello,");
+  });
+
+  it("'Hi {firstName},' with no name → 'Hi,'", () => {
+    expect(buildSalutation("Hi {firstName},", null)).toBe("Hi,");
+  });
+
+  it("'Hello {firstName},' with no name → 'Hello,'", () => {
+    expect(buildSalutation("Hello {firstName},", null)).toBe("Hello,");
+  });
+
+  it("collapses double-space artifacts: 'Dear  {firstName},' with no name → 'Hello,'", () => {
+    // Pattern with a trailing space after Dear before {firstName} produces
+    // "Dear  ," when the variable is dropped — the canonicalisation should
+    // still recover "Hello,".
+    expect(buildSalutation("Dear {firstName} ,", null)).toBe("Hello,");
+  });
+
+  it("returns 'Hello,' as the safe fallback for a salutation that starts with just {firstName},", () => {
+    // Edge case: salutation pattern is just "{firstName}," — drop variable
+    // leaves a dangling leading comma.
+    expect(buildSalutation("{firstName},", null)).toBe("Hello,");
+  });
+
+  it("returns the pattern unchanged when it doesn't reference {firstName}", () => {
+    expect(buildSalutation("Hello,", null)).toBe("Hello,");
+  });
+});
+
+describe("substituteReplyToEmail", () => {
+  it("replaces [your email] with the configured address", () => {
+    expect(
+      substituteReplyToEmail(
+        "Please email [your email] with your booking details.",
+        "hello@brand.example",
+      ),
+    ).toBe("Please email hello@brand.example with your booking details.");
+  });
+
+  it("is case-insensitive (defensive — the model could vary the casing)", () => {
+    expect(substituteReplyToEmail("Email [Your Email] please.", "hello@brand.example"))
+      .toBe("Email hello@brand.example please.");
+    expect(substituteReplyToEmail("Email [YOUR EMAIL] please.", "hello@brand.example"))
+      .toBe("Email hello@brand.example please.");
+  });
+
+  it("replaces all occurrences if the model emits the placeholder twice", () => {
+    expect(
+      substituteReplyToEmail(
+        "Please email [your email] or write to [your email].",
+        "hello@brand.example",
+      ),
+    ).toBe("Please email hello@brand.example or write to hello@brand.example.");
+  });
+
+  it("returns the body unchanged when no placeholder is present", () => {
+    const body = "Thanks for your feedback.";
+    expect(substituteReplyToEmail(body, "hello@brand.example")).toBe(body);
+  });
+
+  it("returns the body unchanged when the email is null/empty", () => {
+    const body = "Please email [your email].";
+    expect(substituteReplyToEmail(body, null)).toBe(body);
+    expect(substituteReplyToEmail(body, "")).toBe(body);
+    expect(substituteReplyToEmail(body, "   ")).toBe(body);
+  });
+});
+
+describe("assembleResponse — salutation + body + sign-off", () => {
+  it("prepends the salutation, body, then sign-off in the right order", () => {
+    const out = assembleResponse({
+      modelBody: "Thanks so much for sharing this.",
+      brandVoice: baseBrandVoice,
+      review: baseReview,
+    });
+
+    expect(out).toBe("Dear Jane,\n\nThanks so much for sharing this.\n\nWarmest regards,\nThe Team");
+  });
+
+  it("falls back to 'Hello,' when reviewerName is null", () => {
+    const out = assembleResponse({
+      modelBody: "Body.",
+      brandVoice: baseBrandVoice,
+      review: { ...baseReview, reviewerName: null },
+    });
+
+    expect(out.startsWith("Hello,\n\n")).toBe(true);
+  });
+
+  it("uses only the first whitespace-delimited token of a multi-word name", () => {
+    const out = assembleResponse({
+      modelBody: "Body.",
+      brandVoice: baseBrandVoice,
+      review: { ...baseReview, reviewerName: "Jane Smith" },
+    });
+
+    expect(out.startsWith("Dear Jane,")).toBe(true);
+    expect(out).not.toContain("Smith");
+  });
+
+  it("converts literal \\n in signoffLines to real newlines", () => {
+    const out = assembleResponse({
+      modelBody: "Body.",
+      brandVoice: { ...baseBrandVoice, signoffLines: "Kind regards,\\nManager Name" },
+      review: baseReview,
+    });
+
+    // The literal `\n` becomes a real newline so the sign-off renders on two lines.
+    expect(out.endsWith("Kind regards,\nManager Name")).toBe(true);
+  });
+
+  it("strips trailing whitespace from the sign-off (no dangling newlines on the assembled output)", () => {
+    const out = assembleResponse({
+      modelBody: "Body.",
+      brandVoice: { ...baseBrandVoice, signoffLines: "Regards,\nThe Team\n\n\n" },
+      review: baseReview,
+    });
+
+    expect(out.endsWith("Regards,\nThe Team")).toBe(true);
+  });
+
+  it("uses a custom salutation pattern verbatim when {firstName} is present", () => {
+    const out = assembleResponse({
+      modelBody: "Body.",
+      brandVoice: { ...baseBrandVoice, salutationPattern: "Hello {firstName}," },
+      review: baseReview,
+    });
+
+    expect(out.startsWith("Hello Jane,")).toBe(true);
+  });
+});
+
+describe("assembleResponse — email substitution (spec §7.5)", () => {
+  it("substitutes [your email] when negative review + toggle ON + replyToEmail set", () => {
+    const out = assembleResponse({
+      modelBody:
+        "We apologise for the experience. Please email [your email] with booking details.",
+      brandVoice: {
+        ...baseBrandVoice,
+        negativeReviewEmailEnabled: true,
+        replyToEmail: "hello@brand.example",
+      },
+      review: { ...baseReview, rating: 1 },
+    });
+
+    expect(out).toContain("hello@brand.example");
+    expect(out).not.toContain("[your email]");
+  });
+
+  it("does NOT substitute on a positive review even when toggle is ON (spec §7.5: positives never get the email in body)", () => {
+    const out = assembleResponse({
+      modelBody: "Thanks! Please email [your email] if you have questions.",
+      brandVoice: {
+        ...baseBrandVoice,
+        negativeReviewEmailEnabled: true,
+        replyToEmail: "hello@brand.example",
+      },
+      review: { ...baseReview, rating: 5 },
+    });
+
+    // Placeholder remains because the routing predicate returned positive.
+    expect(out).toContain("[your email]");
+    expect(out).not.toContain("hello@brand.example");
+  });
+
+  it("does NOT substitute when the toggle is OFF, even on a negative review", () => {
+    const out = assembleResponse({
+      modelBody: "Please email [your email].",
+      brandVoice: {
+        ...baseBrandVoice,
+        negativeReviewEmailEnabled: false,
+        replyToEmail: "hello@brand.example",
+      },
+      review: { ...baseReview, rating: 1 },
+    });
+
+    expect(out).toContain("[your email]");
+    expect(out).not.toContain("hello@brand.example");
+  });
+
+  it("does NOT substitute when replyToEmail is null, even with toggle on + negative review", () => {
+    const out = assembleResponse({
+      modelBody: "Please email [your email].",
+      brandVoice: {
+        ...baseBrandVoice,
+        negativeReviewEmailEnabled: true,
+        replyToEmail: null,
+      },
+      review: { ...baseReview, rating: 1 },
+    });
+
+    expect(out).toContain("[your email]");
+  });
+
+  it("fires substitution on the Kiran case (4-star with negative sentiment)", () => {
+    const out = assembleResponse({
+      modelBody: "Please email [your email] with details.",
+      brandVoice: {
+        ...baseBrandVoice,
+        negativeReviewEmailEnabled: true,
+        replyToEmail: "hello@brand.example",
+      },
+      review: { ...baseReview, rating: 4, sentiment: "negative" },
+    });
+
+    expect(out).toContain("hello@brand.example");
+    expect(out).not.toContain("[your email]");
+  });
+
+  it("fires on a 2-star review regardless of sentiment", () => {
+    const out = assembleResponse({
+      modelBody: "Please email [your email].",
+      brandVoice: {
+        ...baseBrandVoice,
+        negativeReviewEmailEnabled: true,
+        replyToEmail: "hello@brand.example",
+      },
+      review: { ...baseReview, rating: 2 },
+    });
+
+    expect(out).toContain("hello@brand.example");
+  });
+
+  it("does NOT fire on a 3-star review (mixed routing, not negative)", () => {
+    const out = assembleResponse({
+      modelBody: "Please email [your email].",
+      brandVoice: {
+        ...baseBrandVoice,
+        negativeReviewEmailEnabled: true,
+        replyToEmail: "hello@brand.example",
+      },
+      review: { ...baseReview, rating: 3 },
+    });
+
+    expect(out).toContain("[your email]");
+  });
+});
+
+describe("assembleResponse — body truncation", () => {
+  it("does not truncate when body length is within RESPONSE_BODY_CHAR_MAX", () => {
+    const body = "a".repeat(500);
+    const out = assembleResponse({
+      modelBody: body,
+      brandVoice: baseBrandVoice,
+      review: baseReview,
+    });
+
+    // Body appears in full between the salutation and sign-off.
+    expect(out).toContain(body);
+  });
+
+  it("truncates the body to RESPONSE_BODY_CHAR_MAX when it exceeds the cap", () => {
+    const body = "a".repeat(2000);
+    const out = assembleResponse({
+      modelBody: body,
+      brandVoice: baseBrandVoice,
+      review: baseReview,
+    });
+
+    // The full 2000-char body must not appear unchanged.
+    expect(out).not.toContain(body);
+    // The sign-off still appears intact at the end — it was NOT truncated.
+    expect(out.endsWith("Warmest regards,\nThe Team")).toBe(true);
+  });
+
+  it("prefers a sentence boundary when one is available in the last 100 chars of the cap", () => {
+    // Build a body that ends with a sentence close just inside the cap, then
+    // long filler that pushes past it.
+    const head = "a".repeat(1150) + ". ";
+    const tail = "b".repeat(500);
+    const body = head + tail;
+    const out = assembleResponse({
+      modelBody: body,
+      brandVoice: baseBrandVoice,
+      review: baseReview,
+    });
+
+    // The body inside the assembled output should end at "." (the closest
+    // sentence boundary within the last 100 chars before the cap).
+    const salutation = "Dear Jane,\n\n";
+    const signoffStart = "\n\nWarmest regards,";
+    const startIdx = out.indexOf(salutation) + salutation.length;
+    const endIdx = out.lastIndexOf(signoffStart);
+    const assembledBody = out.slice(startIdx, endIdx);
+    expect(assembledBody.endsWith(".")).toBe(true);
+    // None of the 'b' filler should make it in.
+    expect(assembledBody).not.toContain("b");
+  });
+
+  it("never truncates the sign-off, even with an aggressively long body", () => {
+    const out = assembleResponse({
+      modelBody: "x".repeat(5000),
+      brandVoice: baseBrandVoice,
+      review: baseReview,
+    });
+
+    expect(out.endsWith("Warmest regards,\nThe Team")).toBe(true);
+  });
+});
+
+describe("assembleResponse — defensive normalisation", () => {
+  it("handles a brand voice missing optional fields (normalize fills defaults)", () => {
+    const out = assembleResponse({
+      modelBody: "Body.",
+      brandVoice: { tone: "friendly_professional", keyPhrases: [] },
+      review: baseReview,
+    });
+
+    // The DEFAULTS in normalizeBrandVoice supply "Dear {firstName},"
+    // and "Warmest regards,\nThe Team".
+    expect(out.startsWith("Dear Jane,\n\n")).toBe(true);
+    expect(out.endsWith("Warmest regards,\nThe Team")).toBe(true);
+  });
+
+  it("handles a null brand voice (entirely defaults)", () => {
+    const out = assembleResponse({
+      modelBody: "Body.",
+      brandVoice: null,
+      review: baseReview,
+    });
+
+    expect(out.startsWith("Dear Jane,\n\n")).toBe(true);
+  });
+
+  it("trims surrounding whitespace from the model body before assembly", () => {
+    const out = assembleResponse({
+      modelBody: "   \n\nBody.\n\n  ",
+      brandVoice: baseBrandVoice,
+      review: baseReview,
+    });
+
+    // The body region between the salutation block and the sign-off block
+    // should be just "Body." — no extra leading/trailing whitespace.
+    expect(out).toBe("Dear Jane,\n\nBody.\n\nWarmest regards,\nThe Team");
+  });
+});
+
+describe("assembleResponse — full output order (spec §9.5)", () => {
+  it("produces salutation → blank line → body → blank line → sign-off, in that order", () => {
+    const out = assembleResponse({
+      modelBody: "First paragraph.\n\nSecond paragraph.",
+      brandVoice: baseBrandVoice,
+      review: baseReview,
+    });
+
+    const lines = out.split("\n");
+    expect(lines[0]).toBe("Dear Jane,");
+    expect(lines[1]).toBe("");
+    expect(lines[2]).toBe("First paragraph.");
+    expect(lines[3]).toBe("");
+    expect(lines[4]).toBe("Second paragraph.");
+    expect(lines[5]).toBe("");
+    expect(lines[6]).toBe("Warmest regards,");
+    expect(lines[7]).toBe("The Team");
+  });
+});


### PR DESCRIPTION
## Summary

Fifth iteration of the brand voice page redesign — see [`docs/MVP_Phase-1/BRAND_VOICE_REDESIGN.md`](docs/MVP_Phase-1/BRAND_VOICE_REDESIGN.md) and the plan at `C:/Users/amith/.claude/plans/docs-mvp-phase-1-brand-voice-redesign-md-streamed-ripple.md`.

**Wraps every AI response in a complete email shape — salutation at the top, sign-off at the bottom, optional reply-to email inline for negatives.** The model body itself is unchanged from iter 4; iter 5 is the deterministic wrapper around it.

The model in iter 4 is explicitly instructed NOT to generate a salutation or sign-off (those need to be exact every time per brand, so they don't belong in the model). Iter 5 adds them deterministically in post-processing.

## What changes externally when this merges

🟩 **Every response now reads like a complete email.** Salutation at the top (`Dear Jane,` / `Hi Jane,` / `Hello,` as canonicalised when no name is available), body in the middle, sign-off block at the bottom (`Warmest regards,` / `The Team` on its own line).

🟩 **Negative-review responses get the reply-to email inline.** When the brand voice has the toggle on, has a configured reply-to email, AND the review is negative (rating ≤ 2 OR sentiment === 'negative' — the iter-4 routing predicate), the model's `[your email]` placeholder gets substituted with the actual address inline in the prose. Example: *"Please email hello@brand.example with your booking details."*

🟩 **Preview matches prod.** The brand voice test panel runs the same `assembleResponse` so users see exactly what they'll see on real reviews.

🟨 **The brand voice form is still the legacy 4-field one.** Iter 6 finally rewrites it to the V2 four-section layout with the new Personalization toggles UI, Contact & sign-off section, V2 tone presets, and starter templates.

## New files

- `src/lib/ai/post-process.ts` — pure module, the heart of iter 5:
  - `assembleResponse({ modelBody, brandVoice, review })` produces the final assembled string.
  - Output order: `[salutation]\n\n[body]\n\n[sign-off]`.
  - Accepts `unknown` for `brandVoice` and runs `normalizeBrandVoice` internally (DECISION 63 — same defensive pattern as iter 4's `generateReviewResponse`).
  - Exports `extractFirstName`, `buildSalutation`, `substituteReplyToEmail` for unit testing.
- `tests/unit/lib/ai/post-process.test.ts` — 41-case unit test suite, the centrepiece.

## Modified files

### `src/lib/ai/structure-templates.ts` (DECISION 68)

All three preset framing fragments (`management_contact` / `investigation` / `open_channel`) now explicitly instruct the model: *"Use the literal placeholder `[your email]` for the email address."* The placeholder is the coordination point between this prompt and `post-process.ts:substituteReplyToEmail` — comments in both files cross-reference each other.

### Routes (3 callers, identical pattern)

- `src/app/api/reviews/[id]/generate/route.ts`
- `src/app/api/reviews/[id]/regenerate/route.ts`
- `src/app/api/brand-voice/test/route.ts`

Each calls `assembleResponse` after `generateReviewResponse` and persists/returns the assembled text. The iter-4 inline body-truncation block in `generate`/`regenerate` is gone — truncation is centralised in `post-process.ts` (DECISION 65). The test route runs the same assembly (DECISION 66 — preview == prod).

## Decisions logged (DECISIONS.md #62–68)

- **#62** Email substitution is INLINE in the model body (`[your email]` placeholder), not appended after the sign-off. Reads like natural prose; matches spec §7.4 example outputs literally.
- **#63** `post-process.ts` accepts `unknown` for `brandVoice` and runs `normalizeBrandVoice` internally. Mirrors iter 4's defensive pattern — the route layer can pass the Prisma row directly.
- **#64** Canonicalisation table is an ordered `[regex, replacement][]` list, most-specific patterns first. Covers every variant from spec §13.1.
- **#65** Body truncation lives in `post-process.ts` only — single source of truth. Salutation and sign-off are appended afterwards and are never truncated.
- **#66** Test panel (`/api/brand-voice/test`) runs the same `assembleResponse` as prod (preview == prod parity).
- **#67** Sign-off line-break normalisation accepts both literal `\n` (escape sequence) AND real newlines from the DB column.
- **#68** Framing fragments explicitly instruct the model to emit `[your email]` placeholder. The placeholder is the coordination point with `post-process.ts:substituteReplyToEmail`.

## Detail: the canonicalisation table (spec §13.1)

When `review.reviewerName` is null/empty, `{firstName}` is replaced with `""` first, leaving artifacts like `Dear ,` or `Hi ,`. The table below cleans them up. Order matters — most-specific patterns first.

| Pattern | Replacement | Notes |
|---|---|---|
| `^Dear\s{2,},` | `Hello,` | Double-space before comma (when salutation has trailing space before `{firstName}`) |
| `^Hi\s{2,},` | `Hi,` | Keep "Hi" prefix |
| `^Hello\s{2,},` | `Hello,` | Keep "Hello" prefix |
| `^Dear\s,` | `Hello,` | Single-space — "Dear" without a name is awkward, downgrade to "Hello" |
| `^Hi\s,` | `Hi,` | Drop the orphan space |
| `^Hello\s,` | `Hello,` | Drop the orphan space |
| `^,+\s*` | `Hello,` | Defensive: salutation patterns that start with `{firstName},` |

## Verification

- `npm run lint:strict` clean
- `npm run type-check` clean
- `npm run test:unit` **1013 passed, 0 failed** across 64 files (+44 new this iteration; iter 4 baseline was 969)

The 41 post-process unit tests cover: `extractFirstName` (5), `buildSalutation` with name (4) + without name (6 — the full canonicalisation table), `substituteReplyToEmail` (5), `assembleResponse` salutation+body+sign-off (6), email-substitution truth table (8 — every routing path including the Kiran case), body truncation (4), defensive normalisation (3), full output order (1).

## Smoke test after merge

1. **Generate a response on any 5-star review with a reviewer name set.** Expected output structure:
   ```
   Dear [Name],

   [Multi-paragraph body...]

   Warmest regards,
   The Team
   ```

2. **Generate on a 1-star review** *without* the email toggle on (default). Expected: same structure as above, no email anywhere.

3. **(Manual config required:** set `negative_review_email_enabled = true` + `reply_to_email = 'test@example.com'` via Prisma Studio on staging since the V2 form lands in iter 6.**) Generate on a 1-star review.** Expected: the body contains the email inline — *"Please email test@example.com with..."* — substituted from `[your email]`.

## What this PR is and is NOT

**Is:**
- Salutation prepended, sign-off appended, every response.
- `[your email]` substituted with the actual address inline for negative reviews when configured.
- Test panel produces the same assembled shape as prod.
- Body truncation moved to `post-process.ts` (single source of truth).

**Is NOT:**
- New UI for configuring the salutation/sign-off/email (iter 6).
- Any change to the prompt sent to the model (modulo the small framing-fragment updates instructing the model to emit `[your email]`).
- Schema change (`ReviewResponse.responseText` is `@db.Text` — no DB cap).

## Out of 6 iterations

| Iter | Title | Status |
|---|---|---|
| 1 | Sanitize helper + review-text retrofit + SecurityLog | ✅ Merged (PR #120) |
| 2 | Validation schema + constants + normalize adapter | ✅ Merged (PR #121) |
| 3 | Clean-reset schema migration + V2 column cutover + legacy form bridge | ✅ Merged (PR #122) |
| 4 | Prompt-building rewrite (headline bug fix + V2 prompt + structure templates) | ✅ Merged (PR #123) |
| — | Fix: E2E mock header-gate | ✅ Merged (PR #124) |
| **5** | **Post-processing module + route wiring** | **This PR** |
| 6 | Frontend restructure + API Zod cutover + regenerate dialog | Pending |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
