### PR TITLE
fix(ui): regenerate dialog viewport overflow + tone options 2x2 grid

### DIFF
--- a/src/components/reviews/ToneModifier.tsx
+++ b/src/components/reviews/ToneModifier.tsx
@@ -98,7 +98,19 @@ export function ToneModifier({
           {isLoading ? "Regenerating..." : "Regenerate"}
         </Button>
       </DialogTrigger>
-      <DialogContent className="sm:max-w-lg">
+      {/*
+        Dialog sizing:
+          - `sm:max-w-2xl` widens the dialog at tablet+ so the 2-col tone
+            grid has room to breathe without forcing the descriptions to
+            wrap aggressively.
+          - `max-h-[90vh]` caps the overall height to 90% of the viewport
+            so the dialog never overflows on short screens. Combined with
+            `flex flex-col` on the content and `flex-1 overflow-y-auto`
+            on the body region, the header + footer stay anchored while
+            the tone grid + additional-instructions block scroll internally
+            when needed.
+      */}
+      <DialogContent className="flex max-h-[90vh] flex-col sm:max-w-2xl">
         <DialogHeader>
           <DialogTitle>Regenerate response</DialogTitle>
           <DialogDescription>
@@ -112,8 +124,10 @@ export function ToneModifier({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-5 py-4">
-          {/* Tone modifier — V2 4-key set */}
+        {/* Scrollable body: header + footer stay fixed; this region scrolls
+            internally when content exceeds the viewport-capped dialog height. */}
+        <div className="flex-1 space-y-5 overflow-y-auto py-4 pr-1">
+          {/* Tone modifier — V2 4-key set, rendered as a 2-col grid at sm+ */}
           <div className="space-y-2">
             <Label className="text-sm font-medium">Change the tone for this response (optional)</Label>
             <p className="text-xs text-muted-foreground">
@@ -122,7 +136,7 @@ export function ToneModifier({
             <RadioGroup
               value={selectedTone}
               onValueChange={(value) => setSelectedTone(value as BrandVoiceToneV2)}
-              className="space-y-2"
+              className="grid grid-cols-1 gap-2 sm:grid-cols-2"
             >
               {BRAND_VOICE_TONES_V2.map((tone) => {
                 const info = BRAND_VOICE_TONE_INFO_V2[tone];
@@ -177,7 +191,7 @@ export function ToneModifier({
           </div>
         </div>
 
-        <DialogFooter className="flex-col sm:flex-row gap-2">
+        <DialogFooter className="flex-col gap-2 sm:flex-row">
           <p className="text-xs text-muted-foreground mr-auto">
             This will use {creditsNeeded} credit{creditsNeeded !== 1 ? "s" : ""}
           </p>

--- a/tests/unit/components/reviews/tone-modifier.test.tsx
+++ b/tests/unit/components/reviews/tone-modifier.test.tsx
@@ -53,6 +53,45 @@ describe("ToneModifier", () => {
     expect(screen.queryByText(/apologetic/i)).not.toBeInTheDocument();
   });
 
+  it("renders the tone options as a 2-col grid at sm+ (1 col on mobile)", async () => {
+    render(<ToneModifier {...defaultProps} />);
+    fireEvent.click(screen.getByRole("button", { name: /regenerate/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Warm & casual")).toBeInTheDocument();
+    });
+
+    const radioGroup = screen.getByRole("radiogroup");
+    // Layout classes are applied to the RadioGroup wrapper. We assert the
+    // CSS classes are present rather than computed styles because jsdom
+    // doesn't run a real layout engine — class presence is the meaningful
+    // signal here.
+    expect(radioGroup.className).toContain("grid");
+    expect(radioGroup.className).toContain("grid-cols-1");
+    expect(radioGroup.className).toContain("sm:grid-cols-2");
+  });
+
+  it("constrains the dialog to 90vh and makes the body scrollable so header/footer stay visible", async () => {
+    render(<ToneModifier {...defaultProps} />);
+    fireEvent.click(screen.getByRole("button", { name: /regenerate/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    const dialog = screen.getByRole("dialog");
+    // The dialog itself is capped at 90vh and laid out as a flex column so
+    // the header + footer stay anchored while the body scrolls.
+    expect(dialog.className).toContain("max-h-[90vh]");
+    expect(dialog.className).toContain("flex");
+    expect(dialog.className).toContain("flex-col");
+
+    // The scrollable body region carries flex-1 + overflow-y-auto.
+    const scrollable = dialog.querySelector(".overflow-y-auto");
+    expect(scrollable).not.toBeNull();
+    expect(scrollable!.className).toContain("flex-1");
+  });
+
   it("renders the new Additional instructions textarea with the 500-char cap", async () => {
     render(<ToneModifier {...defaultProps} />);
     fireEvent.click(screen.getByRole("button", { name: /regenerate/i }));


### PR DESCRIPTION
## Summary

Two UX fixes to the iter-6 regenerate dialog after staging feedback. Small, focused change — one component file + its tests.

## The two fixes

### 1. Dialog viewport overflow

**Before:** On shorter screens, the dialog could extend past the top and bottom of the viewport — the title was clipped at the top, the action buttons (Cancel / Regenerate) were clipped at the bottom, and there was no way to scroll the whole dialog.

**After:**
- `DialogContent` gains `max-h-[90vh]` so the dialog is capped at 90% of the viewport regardless of content height.
- `DialogContent` switches from the default `grid` layout to `flex flex-col` (twMerge resolves the conflict correctly — `flex flex-col` wins over the base `grid`).
- The body region (tone radios + additional-instructions textarea) gets `flex-1 overflow-y-auto` so it scrolls internally while the `DialogHeader` and `DialogFooter` stay anchored. The user always sees the title and action buttons.
- Dialog max-width widened from `sm:max-w-lg` to `sm:max-w-2xl` so the new 2-col tone grid has room to breathe at tablet+.

### 2. Tone options as a 2x2 grid

**Before:** The four tone presets were stacked vertically — wasted vertical space (which compounded the overflow problem above) and didn't match the brand voice form's tone selector style.

**After:**
- `RadioGroup` className changed from `space-y-2` (vertical stack) to `grid grid-cols-1 gap-2 sm:grid-cols-2`.
- **Mobile (< 640px):** 1 column — each card has full width to display its descriptor without aggressive wrapping.
- **Tablet+ (≥ 640px):** 2 columns — compact grid that uses the wider dialog efficiently.

## Verification

- `npm run lint:strict` clean
- `npm run type-check` clean
- `npm run test:unit` **998 passed, 0 failed** across 63 files (+2 new tests this fix)

## Tests added

Two new layout assertions in `tests/unit/components/reviews/tone-modifier.test.tsx`:

- **`renders the tone options as a 2-col grid at sm+`** — asserts the `RadioGroup` wrapper carries `grid`, `grid-cols-1`, and `sm:grid-cols-2` classes.
- **`constrains the dialog to 90vh and makes the body scrollable`** — asserts the `DialogContent` carries `max-h-[90vh]`, `flex`, and `flex-col`, and that the body region (the `.overflow-y-auto` descendant) also carries `flex-1`.

Layout assertions are class-presence rather than computed-style because jsdom doesn't run a real layout engine — class presence is the meaningful signal we can verify reliably.

## Smoke test after merge

1. Open any review with an existing response on staging.
2. Click **Regenerate**.
3. Expected:
   - Dialog title ("Regenerate response") visible at the top.
   - Four tone cards laid out in a 2x2 grid.
   - Additional Instructions textarea below the grid.
   - Cancel / Regenerate buttons visible at the bottom without scrolling outside the dialog.
   - If the screen is short enough that all content can't fit at 90vh, the body region scrolls internally while header/footer stay fixed.
4. Resize the browser narrow (< 640px) — expected: tone cards drop to a single column, dialog still fits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
