### PR TITLE
fix(ui): regenerate dialog - hoist Additional instructions, trim header, autofocus

### DIFF
--- a/src/components/reviews/ResponsePanel.tsx
+++ b/src/components/reviews/ResponsePanel.tsx
@@ -478,7 +478,6 @@ export function ResponsePanel({
               <ToneModifier
                 onRegenerate={handleRegenerate}
                 isLoading={isLoading}
-                currentTone={localResponse.toneUsed}
                 creditsNeeded={CREDIT_COSTS.REGENERATE_RESPONSE}
               />
               {!localResponse.isPublished && (

--- a/src/components/reviews/ToneModifier.tsx
+++ b/src/components/reviews/ToneModifier.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -55,7 +55,6 @@ interface ToneModifierProps {
   }) => Promise<void>;
   isLoading?: boolean;
   disabled?: boolean;
-  currentTone?: string;
   creditsNeeded?: number;
 }
 
@@ -63,12 +62,12 @@ export function ToneModifier({
   onRegenerate,
   isLoading = false,
   disabled = false,
-  currentTone,
   creditsNeeded = 1.0,
 }: ToneModifierProps) {
   const [open, setOpen] = useState(false);
   const [selectedTone, setSelectedTone] = useState<BrandVoiceToneV2>("friendly_professional");
   const [additionalInstructions, setAdditionalInstructions] = useState("");
+  const instructionsRef = useRef<HTMLTextAreaElement>(null);
 
   const handleRegenerate = async () => {
     const trimmed = additionalInstructions.trim();
@@ -110,23 +109,61 @@ export function ToneModifier({
             the tone grid + additional-instructions block scroll internally
             when needed.
       */}
-      <DialogContent className="flex max-h-[90vh] flex-col sm:max-w-2xl">
+      {/*
+        Iter 6 follow-up — the description text was trimmed from a two-line
+        wordy summary to a single short scope note, the "Current tone" line
+        was removed (it was rarely useful and ate vertical space), and the
+        field order was swapped so the more-commonly-used Additional
+        instructions textarea sits above the tone grid and is autofocused
+        when the dialog opens. The tone grid now sits below the textarea
+        but most of it is still above the fold on a typical viewport.
+      */}
+      <DialogContent
+        className="flex max-h-[90vh] flex-col sm:max-w-2xl"
+        onOpenAutoFocus={(event) => {
+          // Default Radix behaviour focuses the first focusable element
+          // (which would be the Close × in the corner). Override to put
+          // the cursor in the Additional instructions textarea — the
+          // primary input for this dialog.
+          event.preventDefault();
+          instructionsRef.current?.focus();
+        }}
+      >
         <DialogHeader>
           <DialogTitle>Regenerate response</DialogTitle>
-          <DialogDescription>
-            Pick a different tone, add specific instructions, or both — they&apos;ll be applied just
-            for this regeneration.
-            {currentTone && currentTone !== "default" && (
-              <span className="block mt-1">
-                Current tone: <strong>{currentTone}</strong>
-              </span>
-            )}
-          </DialogDescription>
+          <DialogDescription>Apply just for this regeneration.</DialogDescription>
         </DialogHeader>
 
         {/* Scrollable body: header + footer stay fixed; this region scrolls
             internally when content exceeds the viewport-capped dialog height. */}
         <div className="flex-1 space-y-5 overflow-y-auto py-4 pr-1">
+          {/* Additional instructions — free text. Iter 6 follow-up: hoisted
+              above the tone grid because typing instructions is the more
+              common path; autofocused on dialog open via onOpenAutoFocus. */}
+          <div className="space-y-2">
+            <Label htmlFor="additional-instructions" className="text-sm font-medium">
+              Additional instructions (optional)
+            </Label>
+            <p className="text-xs text-muted-foreground">
+              Anything specific you want this response to mention or address.
+            </p>
+            <Textarea
+              id="additional-instructions"
+              ref={instructionsRef}
+              value={additionalInstructions}
+              onChange={(e) => setAdditionalInstructions(e.target.value)}
+              maxLength={ADDITIONAL_INSTRUCTIONS_MAX}
+              rows={3}
+              placeholder='e.g. "mention our loyalty program" or "address the dessert complaint specifically"'
+              className="resize-none"
+            />
+            <p
+              className={`text-xs ${isOverLimit ? "text-destructive" : "text-muted-foreground"}`}
+            >
+              {additionalInstructions.length} / {ADDITIONAL_INSTRUCTIONS_MAX} characters
+            </p>
+          </div>
+
           {/* Tone modifier — V2 4-key set, rendered as a 2-col grid at sm+ */}
           <div className="space-y-2">
             <Label className="text-sm font-medium">Change the tone for this response (optional)</Label>
@@ -164,30 +201,6 @@ export function ToneModifier({
                 );
               })}
             </RadioGroup>
-          </div>
-
-          {/* Additional instructions — free text */}
-          <div className="space-y-2">
-            <Label htmlFor="additional-instructions" className="text-sm font-medium">
-              Additional instructions (optional)
-            </Label>
-            <p className="text-xs text-muted-foreground">
-              Anything specific you want this response to mention or address.
-            </p>
-            <Textarea
-              id="additional-instructions"
-              value={additionalInstructions}
-              onChange={(e) => setAdditionalInstructions(e.target.value)}
-              maxLength={ADDITIONAL_INSTRUCTIONS_MAX}
-              rows={3}
-              placeholder='e.g. "mention our loyalty program" or "address the dessert complaint specifically"'
-              className="resize-none"
-            />
-            <p
-              className={`text-xs ${isOverLimit ? "text-destructive" : "text-muted-foreground"}`}
-            >
-              {additionalInstructions.length} / {ADDITIONAL_INSTRUCTIONS_MAX} characters
-            </p>
           </div>
         </div>
 

--- a/tests/unit/components/reviews/tone-modifier.test.tsx
+++ b/tests/unit/components/reviews/tone-modifier.test.tsx
@@ -9,7 +9,6 @@ describe("ToneModifier", () => {
   const defaultProps = {
     onRegenerate: vi.fn().mockResolvedValue(undefined),
     isLoading: false,
-    currentTone: "friendly_professional",
     creditsNeeded: 1,
   };
 
@@ -112,14 +111,64 @@ describe("ToneModifier", () => {
     });
   });
 
-  it("shows current tone in dialog description", async () => {
-    render(<ToneModifier {...defaultProps} currentTone="warm_casual" />);
+  it("does not render the 'Current tone' line (removed in iter-6 follow-up UX fix)", async () => {
+    render(<ToneModifier {...defaultProps} />);
     fireEvent.click(screen.getByRole("button", { name: /regenerate/i }));
 
     await waitFor(() => {
-      expect(screen.getByText(/current tone:/i)).toBeInTheDocument();
-      expect(screen.getByText("warm_casual")).toBeInTheDocument();
+      expect(screen.getByText("Regenerate response")).toBeInTheDocument();
     });
+
+    // The line was rarely useful, ate vertical space, and could mislead
+    // (it showed the *previous* regeneration's tone, not what the next
+    // regeneration would use). Iter-6 follow-up removed it.
+    expect(screen.queryByText(/current tone:/i)).not.toBeInTheDocument();
+  });
+
+  it("renders the trimmed one-line description", async () => {
+    render(<ToneModifier {...defaultProps} />);
+    fireEvent.click(screen.getByRole("button", { name: /regenerate/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/apply just for this regeneration\.?/i)).toBeInTheDocument();
+    });
+
+    // The pre-iter-6-follow-up wordy description is gone.
+    expect(screen.queryByText(/pick a different tone, add specific instructions/i)).not.toBeInTheDocument();
+  });
+
+  it("renders Additional instructions BEFORE the tone grid (iter-6 follow-up — primary input first)", async () => {
+    render(<ToneModifier {...defaultProps} />);
+    fireEvent.click(screen.getByRole("button", { name: /regenerate/i }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/additional instructions/i)).toBeInTheDocument();
+    });
+
+    // Both fields render inside the same scrollable body region. The
+    // textarea's label should appear earlier in the DOM than the radio
+    // group's heading, so the user sees instructions first.
+    const dialog = screen.getByRole("dialog");
+    const html = dialog.innerHTML;
+    const instructionsIdx = html.indexOf("Additional instructions");
+    const toneIdx = html.indexOf("Change the tone");
+    expect(instructionsIdx).toBeGreaterThan(-1);
+    expect(toneIdx).toBeGreaterThan(-1);
+    expect(instructionsIdx).toBeLessThan(toneIdx);
+  });
+
+  it("autofocuses the Additional instructions textarea when the dialog opens", async () => {
+    render(<ToneModifier {...defaultProps} />);
+    fireEvent.click(screen.getByRole("button", { name: /regenerate/i }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/additional instructions/i)).toBeInTheDocument();
+    });
+
+    // Radix's default focus would land on the first focusable element
+    // (Close ×). Iter-6 follow-up overrides onOpenAutoFocus to put focus
+    // in the textarea — the primary input.
+    expect(screen.getByLabelText(/additional instructions/i)).toHaveFocus();
   });
 
   it("calls onRegenerate with the selected V2 tone key in a payload object", async () => {


### PR DESCRIPTION
## Summary

Four small UX improvements to the iter-6 regenerate dialog after staging feedback. Same dialog file as PR #127, addressing the visibility-of-primary-input issue that surfaced once the overflow was contained.

**The observation:** even with the 90vh-capped dialog and the 2-col tone grid from #127, the Additional instructions field still required a scroll to see. Yet typing per-regeneration instructions is the *primary* action users open this dialog for — changing tone is the *occasional* refinement. The dialog was giving the prime real estate to the less-important control.

## The four edits

### 1. Description trimmed

**Before:** "Pick a different tone, add specific instructions, or both — they'll be applied just for this regeneration." (two lines)

**After:** "Apply just for this regeneration." (one line)

The form fields below already make the "what you can do" obvious. The only non-obvious thing the description needs to say is that these adjustments don't persist to the brand voice — five words says that.

### 2. "Current tone" line removed

The line ("Current tone: professional") only rendered for users who had previously regenerated with a tone modifier, described *history* rather than what would happen next, and didn't help users complete the action. Cut entirely. The `currentTone` prop is removed from `ToneModifierProps`; the caller in `ResponsePanel.tsx` stops passing it.

### 3. Field order swapped — Additional instructions above tone grid

The primary input now sits at the top of the body region. The tone grid sits below; at least the first row is still visible above the fold on the typical viewport, with the rest reachable by scroll.

### 4. Autofocus on the textarea

Radix's default focus on dialog open lands on the first focusable element — which is the Close × in the corner. Overriding `onOpenAutoFocus` to focus the textarea instead means the user can start typing instructions the instant the dialog opens, no extra click required.

## Before / After

```
BEFORE                              AFTER
┌─ Regenerate response ─────┐       ┌─ Regenerate response ────────┐
│ Pick a different tone,     │       │ Apply just for this           │
│ add specific instructions, │       │ regeneration.                 │
│ or both — they'll be       │       ├───────────────────────────────┤
│ applied just for this      │       │ Additional instructions       │
│ regeneration.              │       │ ┌──────────────────────────┐ │
│ Current tone: professional │       │ │ ▎ (cursor here on open)  │ │
├────────────────────────────┤       │ └──────────────────────────┘ │
│ Change the tone (optional) │       │ 0 / 500 characters            │
│ ┌───────┬──────────┐       │       │                               │
│ │ Warm  │ Friendly │       │       │ Change the tone (optional)    │
│ └───────┴──────────┘       │       │ ┌─────────┬────────────────┐  │
│ ┌───────┬──────────┐       │       │ │ Warm    │ Friendly       │  │
│ │ Polish│ Empathetic│      │       │ └─────────┴────────────────┘  │
│ └───────┴──────────┘       │       │ ┌─────────┬────────────────┐  │
│                            │       │ │ Polished│ Empathetic     │  │
│ Additional instructions    │       │ └─────────┴────────────────┘  │
│ ┌─────────┐  (must scroll  │       ├───────────────────────────────┤
│ │  ?      │   to see)      │       │ [Cancel]      [Regenerate]    │
│ └─────────┘                │       └───────────────────────────────┘
├────────────────────────────┤
│ [Cancel]   [Regenerate]    │
└────────────────────────────┘
```

## Verification

- `npm run lint:strict` clean
- `npm run type-check` clean
- `npm run test:unit` **1001 passed, 0 failed** across 63 files (+3 net this PR)

## Tests

Net +3 cases in `tests/unit/components/reviews/tone-modifier.test.tsx` (16 total, was 13):

- **REPLACED:** `shows current tone in dialog description` → `does not render the Current tone line (removed in iter-6 follow-up)`
- **NEW:** `renders the trimmed one-line description` — asserts the new copy is present and the old wordy copy is gone.
- **NEW:** `renders Additional instructions BEFORE the tone grid` — DOM ordering assertion (the textarea label appears earlier in the dialog HTML than the tone-radio heading).
- **NEW:** `autofocuses the Additional instructions textarea when the dialog opens` — asserts `document.activeElement` is the textarea right after the dialog appears, verifying the `onOpenAutoFocus` override worked.

## Smoke test after merge

1. Open any review with an existing response on staging.
2. Click **Regenerate**.
3. Expected:
   - Dialog title visible at top.
   - One-line description: "Apply just for this regeneration."
   - No "Current tone" line.
   - **Additional instructions textarea visible immediately, cursor blinking in it** (no click needed).
   - Tone grid below the textarea; at least the first row of tone cards visible without scrolling.
   - Cancel / Regenerate buttons anchored at the bottom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
