### PR TITLE
fix(ui): regenerate dialog padding - trim top gap + fix focus-ring clip

### DIFF
--- a/src/components/reviews/ToneModifier.tsx
+++ b/src/components/reviews/ToneModifier.tsx
@@ -135,8 +135,14 @@ export function ToneModifier({
         </DialogHeader>
 
         {/* Scrollable body: header + footer stay fixed; this region scrolls
-            internally when content exceeds the viewport-capped dialog height. */}
-        <div className="flex-1 space-y-5 overflow-y-auto py-4 pr-1">
+            internally when content exceeds the viewport-capped dialog height.
+            Padding notes:
+              - `pb-4` (no `pt-`) — the DialogContent's parent `gap-4` already
+                gives breathing room between the header and this region; an
+                extra `pt-4` here doubled the gap.
+              - `px-1` — small horizontal padding so the textarea/grid focus
+                rings don't get clipped by the dialog's outer p-6 edge. */}
+        <div className="flex-1 space-y-5 overflow-y-auto pb-4 px-1">
           {/* Additional instructions — free text. Iter 6 follow-up: hoisted
               above the tone grid because typing instructions is the more
               common path; autofocused on dialog open via onOpenAutoFocus. */}


### PR DESCRIPTION
## Summary

Two small CSS tweaks to the regenerate dialog's scrollable body region, addressing the third round of staging feedback. Same file as PRs #127 and #128.

## The two fixes

### 1. Textarea focus ring clipped on the left

The textarea (and tone radio cards) had their focus rings slightly clipped against the dialog's left edge. The scrollable body had `pr-1` (small right padding for the scrollbar) but no left padding, so focus rings sat flush against the dialog's outer `p-6` boundary.

**Fix:** `pr-1` → `px-1` so focus rings get symmetric small horizontal breathing room.

### 2. Extra dead space between description and first field

Visible gap between "Apply just for this regeneration." and "Additional instructions" was bigger than needed. Cause: shadcn's `DialogContent` uses `gap-4` (1rem) on its grid between direct children, AND the scrollable body had `py-4` (another 1rem top). Two stacked rems where one is enough.

**Fix:** `py-4` → `pb-4` — drop the redundant top padding. The parent's `gap-4` handles header-to-body spacing; `pb-4` keeps the body-to-footer breathing room.

## Change

```diff
- <div className="flex-1 space-y-5 overflow-y-auto py-4 pr-1">
+ <div className="flex-1 space-y-5 overflow-y-auto pb-4 px-1">
```

That's the whole functional change. A comment was added inline explaining the choices.

## What this does NOT touch

- **The Vercel INP warning (272ms) on the trigger button.** Flagged but skipped per discussion — marginal at 272ms (just over the 200ms threshold), and addressing it properly would be a separate optimization PR (likely lazy-render the dialog content, or profile first). If real-user metrics surface this as a problem later, it gets its own PR.

## Verification

- `npm run lint:strict` clean
- `npm run type-check` clean
- `npm run test:unit` — **16/16 ToneModifier tests passing** (the existing layout assertions from PR #127, asserting `flex-1` + `overflow-y-auto` on the body, still hold; the class swap doesn't break them)

## Smoke test after merge

1. Open any review with an existing response on staging.
2. Click **Regenerate**.
3. Expected:
   - Description ("Apply just for this regeneration.") sits comfortably below the title — no extra gap above the Additional instructions label.
   - Click into the textarea — the focus ring sits cleanly inside the dialog, not clipped on the left.
   - Click a tone card — same, focus ring contained within the dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
