### PR TITLE
feat(ui): brand-voice page hierarchy — numbered headers, plain h1, tinted cards

### DIFF
--- a/src/components/settings/BrandVoiceForm.tsx
+++ b/src/components/settings/BrandVoiceForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef, useCallback } from "react";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import { ToneSelector } from "./ToneSelector";
@@ -309,26 +309,24 @@ export function BrandVoiceForm() {
 
   return (
     <div className="space-y-6">
-      {/* Page header (spec §3) */}
-      <Card>
-        <CardHeader>
-          <div className="flex items-center justify-between gap-4">
-            <div>
-              <CardTitle>Brand voice</CardTitle>
-              <CardDescription>
-                Teach our AI how to write responses that sound like you.
-              </CardDescription>
-            </div>
-            <SaveStatusIndicator status={saveStatus} />
-          </div>
-        </CardHeader>
-      </Card>
+      {/* Page header (spec §3). Iter-7 hierarchy pass: demoted from a Card to a
+          plain heading block so it visually anchors the page rather than reading
+          as "one of the sections". The Card wrappers are reserved for the four
+          numbered sections below. */}
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Brand voice</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            Teach our AI how to write responses that sound like you.
+          </p>
+        </div>
+        <SaveStatusIndicator status={saveStatus} />
+      </div>
 
       {/* §1 Voice — Tone, Style guidelines, Key phrases */}
-      <Card>
+      <Card className="bg-muted/30">
         <CardHeader>
-          <CardTitle className="text-lg">Voice</CardTitle>
-          <CardDescription>How we sound.</CardDescription>
+          <SectionHeader number={1} title="Voice" descriptor="how we sound" />
         </CardHeader>
         <CardContent className="space-y-8">
           {/* §4.1 Tone */}
@@ -379,10 +377,9 @@ export function BrandVoiceForm() {
       </Card>
 
       {/* §2 Examples — Sample responses */}
-      <Card>
+      <Card className="bg-muted/30">
         <CardHeader>
-          <CardTitle className="text-lg">Examples</CardTitle>
-          <CardDescription>What good looks like for us.</CardDescription>
+          <SectionHeader number={2} title="Examples" descriptor="what good looks like for us" />
         </CardHeader>
         <CardContent>
           <div className="space-y-2">
@@ -400,10 +397,9 @@ export function BrandVoiceForm() {
       </Card>
 
       {/* §3 Personalization — Named-staff + Occasion toggles */}
-      <Card>
+      <Card className="bg-muted/30">
         <CardHeader>
-          <CardTitle className="text-lg">Personalization</CardTitle>
-          <CardDescription>What we acknowledge.</CardDescription>
+          <SectionHeader number={3} title="Personalization" descriptor="what we acknowledge" />
         </CardHeader>
         <CardContent>
           <PersonalizationSection
@@ -417,10 +413,9 @@ export function BrandVoiceForm() {
       </Card>
 
       {/* §4 Contact & sign-off — Salutation, sign-off, email invitation */}
-      <Card>
+      <Card className="bg-muted/30">
         <CardHeader>
-          <CardTitle className="text-lg">Contact &amp; sign-off</CardTitle>
-          <CardDescription>How we close.</CardDescription>
+          <SectionHeader number={4} title="Contact & sign-off" descriptor="how we close" />
         </CardHeader>
         <CardContent>
           <ContactSignoffSection
@@ -459,6 +454,47 @@ export function BrandVoiceForm() {
 
       {/* Test Panel */}
       <TestResponsePanel disabled={isSaving} />
+    </div>
+  );
+}
+
+/**
+ * Numbered section header used by all four V2 sections.
+ *
+ * Renders the title on one line with three visual layers:
+ *   - Large muted numeral on the left — gives the reader an at-a-glance
+ *     "section 2 of 4" cue without forcing them to read every title.
+ *   - Bold title in primary text colour.
+ *   - Em-dash + muted descriptor inline on the same line — replaces the
+ *     stacked CardTitle + CardDescription pair so the section header
+ *     reads as one rhythm instead of two paragraphs.
+ *
+ * Inspired by the reference design the user shared during the iter-7
+ * hierarchy pass.
+ */
+function SectionHeader({
+  number,
+  title,
+  descriptor,
+}: {
+  number: number;
+  title: string;
+  descriptor: string;
+}) {
+  return (
+    <div className="flex items-baseline gap-3">
+      <span
+        className="text-2xl font-semibold text-muted-foreground tabular-nums"
+        aria-hidden="true"
+      >
+        {number}
+      </span>
+      <h2 className="text-lg font-semibold tracking-tight">
+        {title}
+        <span className="ml-2 text-sm font-normal text-muted-foreground">
+          — {descriptor}
+        </span>
+      </h2>
     </div>
   );
 }

--- a/tests/unit/components/settings/brand-voice-form.test.tsx
+++ b/tests/unit/components/settings/brand-voice-form.test.tsx
@@ -68,8 +68,71 @@ describe("BrandVoiceForm (V2)", () => {
     expect(screen.getByText("Voice")).toBeInTheDocument();
     expect(screen.getByText("Examples")).toBeInTheDocument();
     expect(screen.getByText("Personalization")).toBeInTheDocument();
-    // CardTitle uses an HTML entity for the &amp; — match the visible glyph.
+    // SectionHeader renders the &-glyph directly (not the HTML entity).
     expect(screen.getByText(/Contact .* sign-off/i)).toBeInTheDocument();
+  });
+
+  // Iter-7 hierarchy pass: numbered + descriptor section headers.
+  it("renders numbered section headers (1, 2, 3, 4) for visual hierarchy", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ data: { brandVoice: mockBrandVoice } }),
+    });
+
+    render(<BrandVoiceForm />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Brand voice")).toBeInTheDocument();
+    });
+
+    // Each section is prefixed with a large numeral. The numerals are
+    // aria-hidden (they're decoration; the title carries the meaning)
+    // so we query the DOM directly rather than via getByText.
+    expect(screen.getByText("1")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+    expect(screen.getByText("4")).toBeInTheDocument();
+  });
+
+  it("renders the section descriptor inline on the same line as the title", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ data: { brandVoice: mockBrandVoice } }),
+    });
+
+    render(<BrandVoiceForm />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Brand voice")).toBeInTheDocument();
+    });
+
+    // The descriptor lives inside the same h2 as the title, prefixed
+    // with an em-dash. Querying by the descriptor text confirms the
+    // inline-descriptor rendering pattern is in place for all four
+    // sections.
+    expect(screen.getByText(/— how we sound/)).toBeInTheDocument();
+    expect(screen.getByText(/— what good looks like for us/)).toBeInTheDocument();
+    expect(screen.getByText(/— what we acknowledge/)).toBeInTheDocument();
+    expect(screen.getByText(/— how we close/)).toBeInTheDocument();
+  });
+
+  it("renders the page header as a plain heading (not a Card)", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ data: { brandVoice: mockBrandVoice } }),
+    });
+
+    render(<BrandVoiceForm />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Brand voice")).toBeInTheDocument();
+    });
+
+    // Iter-7 hierarchy pass: the page title now lives in an h1 directly
+    // on the page surface, not inside a Card. This separates the page-
+    // level header from the section-level cards visually.
+    const heading = screen.getByRole("heading", { level: 1, name: /brand voice/i });
+    expect(heading).toBeInTheDocument();
   });
 
   it("does NOT render a Formality slider (iter 6 dropped the field)", async () => {


### PR DESCRIPTION
## Summary

The brand-voice settings page after iter-6 was visually flat — page-header card on top of four section cards, all the same white surface, no signal about the page's structure or which numbered section you were in. This PR is the **top-three hierarchy improvements** from the visual-design review:

- **Numbered + inline-descriptor section headers** — each of the four section Cards now opens with a large muted numeral (1–4, `aria-hidden`) next to the section title, with the spec-mandated one-line descriptor inline on the same line after an em-dash (e.g. *"1 Voice — how we sound"*). Gives the page the same scannable rhythm as the reference design.
- **Plain `h1` page header** — the page title moves out of a Card and onto the page surface directly. The four section Cards now have visual prominence; the page-header is no longer competing for attention against them. `SaveStatusIndicator` lives inline next to the heading.
- **Subtle `bg-muted/30` card tint** — all four section Cards now read as a single rhythm against the surrounding white page surface. Subtle enough to keep the form feel; distinct enough that "the form" and "the page" are no longer the same flat white.

Three follow-up hierarchy passes (sub-section grouping in Contact & sign-off, typography polish, chip styling) are queued separately and not part of this PR.

## Test plan

- [x] `npm run lint:strict` clean
- [x] `npm run type-check` clean
- [x] `npm run test:unit` — 1004 passed, 30 skipped, 0 failed (63 files). Three new `BrandVoiceForm` assertions: numerals 1–4 render, descriptors render inline once per section, the page title is an `h1` heading not inside a Card.
- [ ] Visual check on staging Preview: confirm the four numbered section headers, the inline em-dash descriptors, the plain page header, and the subtle card tint match the reference design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
