### PR TITLE
feat(ui): brand-voice inner contrast — sub-block containers, framing reveal, card borders

### DIFF
--- a/src/components/settings/BrandVoiceForm.tsx
+++ b/src/components/settings/BrandVoiceForm.tsx
@@ -324,7 +324,7 @@ export function BrandVoiceForm() {
       </div>
 
       {/* §1 Voice — Tone, Style guidelines, Key phrases */}
-      <Card className="bg-card shadow-sm">
+      <Card className="bg-card border-slate-200 shadow-sm">
         <CardHeader>
           <SectionHeader number={1} title="Voice" descriptor="how we sound" />
         </CardHeader>
@@ -379,7 +379,7 @@ export function BrandVoiceForm() {
       </Card>
 
       {/* §2 Examples — Sample responses */}
-      <Card className="bg-card shadow-sm">
+      <Card className="bg-card border-slate-200 shadow-sm">
         <CardHeader>
           <SectionHeader number={2} title="Examples" descriptor="what good looks like for us" />
         </CardHeader>
@@ -399,7 +399,7 @@ export function BrandVoiceForm() {
       </Card>
 
       {/* §3 Personalization — Named-staff + Occasion toggles */}
-      <Card className="bg-card shadow-sm">
+      <Card className="bg-card border-slate-200 shadow-sm">
         <CardHeader>
           <SectionHeader number={3} title="Personalization" descriptor="what we acknowledge" />
         </CardHeader>
@@ -415,7 +415,7 @@ export function BrandVoiceForm() {
       </Card>
 
       {/* §4 Contact & sign-off — Salutation, sign-off, email invitation */}
-      <Card className="bg-card shadow-sm">
+      <Card className="bg-card border-slate-200 shadow-sm">
         <CardHeader>
           <SectionHeader number={4} title="Contact & sign-off" descriptor="how we close" />
         </CardHeader>

--- a/src/components/settings/ContactSignoffSection.tsx
+++ b/src/components/settings/ContactSignoffSection.tsx
@@ -103,190 +103,198 @@ export function ContactSignoffSection({
     negativeReviewEmailEnabled && (replyToEmail == null || replyToEmail.trim().length === 0);
 
   return (
-    <div className="space-y-8">
+    <div className="space-y-6">
       {/* Sub-block 1: Greeting & closing (§7.1 + §7.2)
-          Iter-7 hierarchy pass — the Contact & sign-off section has 5 controls
-          and was the longest one. Grouping into 2 visual sub-blocks with a
-          subtle uppercase eyebrow label + divider makes the structure
-          scannable instead of one flat list. */}
-      <div className="space-y-1">
-        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-          Greeting & closing
-        </p>
-        <p className="text-xs text-muted-foreground">
-          Applied to every response, regardless of rating.
-        </p>
-      </div>
+          Inner-contrast pass — each sub-block is now its own bordered
+          container with a faint slate tint. Gives the two halves of this
+          long section the same figure-on-ground read the section cards
+          themselves have on the page surface. */}
+      <div className="rounded-lg border border-slate-200 bg-slate-50/50 p-4 space-y-6">
+        <div className="space-y-1">
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Greeting & closing
+          </p>
+          <p className="text-xs text-muted-foreground">
+            Applied to every response, regardless of rating.
+          </p>
+        </div>
 
-      {/* §7.1 Salutation */}
-      <div className="space-y-2">
-        <Label htmlFor="salutation-pattern" className="text-sm font-medium">
-          Salutation
-        </Label>
-        <p className="text-xs text-muted-foreground">
-          How responses open. Use <code className="text-xs bg-muted px-1 py-0.5 rounded">{"{firstName}"}</code> to personalise.
-        </p>
-        <Input
-          id="salutation-pattern"
-          value={salutationPattern}
-          onChange={(e) => onSalutationPatternChange(e.target.value)}
-          maxLength={BRAND_VOICE_LIMITS_V2.SALUTATION_MAX}
-          placeholder="Dear {firstName},"
-          disabled={disabled}
-        />
-        <ExampleChips
-          label="Suggestions"
-          items={SALUTATION_CHIPS}
-          onPick={onSalutationPatternChange}
-          disabled={disabled}
-        />
-      </div>
+        {/* §7.1 Salutation */}
+        <div className="space-y-2">
+          <Label htmlFor="salutation-pattern" className="text-sm font-medium">
+            Salutation
+          </Label>
+          <p className="text-xs text-muted-foreground">
+            How responses open. Use <code className="text-xs bg-muted px-1 py-0.5 rounded">{"{firstName}"}</code> to personalise.
+          </p>
+          <Input
+            id="salutation-pattern"
+            value={salutationPattern}
+            onChange={(e) => onSalutationPatternChange(e.target.value)}
+            maxLength={BRAND_VOICE_LIMITS_V2.SALUTATION_MAX}
+            placeholder="Dear {firstName},"
+            disabled={disabled}
+            className="bg-card"
+          />
+          <ExampleChips
+            label="Suggestions"
+            items={SALUTATION_CHIPS}
+            onPick={onSalutationPatternChange}
+            disabled={disabled}
+          />
+        </div>
 
-      {/* §7.2 Sign-off */}
-      <div className="space-y-2">
-        <Label htmlFor="signoff-lines" className="text-sm font-medium">
-          Sign-off
-        </Label>
-        <p className="text-xs text-muted-foreground">
-          How responses close. Press enter for a new line.
-        </p>
-        <Textarea
-          id="signoff-lines"
-          value={signoffLines}
-          onChange={(e) => onSignoffLinesChange(e.target.value)}
-          maxLength={BRAND_VOICE_LIMITS_V2.SIGNOFF_MAX}
-          rows={3}
-          placeholder={"Warmest regards,\nThe Team"}
-          className="resize-none"
-          disabled={disabled}
-        />
-        <ExampleChips
-          label="Suggestions"
-          items={SIGNOFF_CHIPS}
-          onPick={onSignoffLinesChange}
-          disabled={disabled}
-          previewLines
-        />
+        {/* §7.2 Sign-off */}
+        <div className="space-y-2">
+          <Label htmlFor="signoff-lines" className="text-sm font-medium">
+            Sign-off
+          </Label>
+          <p className="text-xs text-muted-foreground">
+            How responses close. Press enter for a new line.
+          </p>
+          <Textarea
+            id="signoff-lines"
+            value={signoffLines}
+            onChange={(e) => onSignoffLinesChange(e.target.value)}
+            maxLength={BRAND_VOICE_LIMITS_V2.SIGNOFF_MAX}
+            rows={3}
+            placeholder={"Warmest regards,\nThe Team"}
+            className="resize-none bg-card"
+            disabled={disabled}
+          />
+          <ExampleChips
+            label="Suggestions"
+            items={SIGNOFF_CHIPS}
+            onPick={onSignoffLinesChange}
+            disabled={disabled}
+            previewLines
+          />
+        </div>
       </div>
 
       {/* Sub-block 2: Negative-review email (§7.3 + §7.4 + §7.5)
-          Visually separated from sub-block 1 by an extra space-y gap and the
-          eyebrow label below. The block is conceptually about one decision —
-          "should we invite negative reviewers to email us" — and three
-          dependent controls. */}
-      <div className="border-t pt-6 space-y-1">
-        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-          Negative-review email
-        </p>
-        <p className="text-xs text-muted-foreground">
-          Optional. Only applies when the review is 1–2 stars or has negative sentiment.
-        </p>
-      </div>
-
-      {/* §7.3 Negative-review email invitation toggle */}
-      <div className="flex items-start justify-between gap-4 rounded-md border bg-card p-4">
-        <div className="flex-1 space-y-1">
-          <Label htmlFor="neg-email-enabled" className="text-sm font-medium cursor-pointer">
-            Invite customers to contact you via email
-          </Label>
+          Own bordered container matching sub-block 1. The conditional
+          framing reveal stays nested inside this block (with its own
+          tighter border) so the user sees "toggle expanded into more
+          controls within the same conceptual area". */}
+      <div className="rounded-lg border border-slate-200 bg-slate-50/50 p-4 space-y-4">
+        <div className="space-y-1">
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Negative-review email
+          </p>
           <p className="text-xs text-muted-foreground">
-            When a customer leaves a negative review (1–2 stars or negative sentiment), our AI will
-            invite them to reach out via email so the conversation can continue privately.
+            Optional. Only applies when the review is 1–2 stars or has negative sentiment.
           </p>
         </div>
-        <Switch
-          id="neg-email-enabled"
-          checked={negativeReviewEmailEnabled}
-          onCheckedChange={onNegativeReviewEmailEnabledChange}
-          disabled={disabled}
-        />
-      </div>
 
-      {/* §7.4 Framing radio + §7.5 Reply-to email — only when toggle is ON */}
-      {negativeReviewEmailEnabled && (
-        <div className="space-y-6 rounded-md border border-dashed bg-muted/30 p-4">
-          <div className="space-y-3">
-            <Label className="text-sm font-medium">
-              How should our AI frame the invitation?
+        {/* §7.3 Negative-review email invitation toggle */}
+        <div className="flex items-start justify-between gap-4 rounded-md border border-slate-200 bg-card p-4">
+          <div className="flex-1 space-y-1">
+            <Label htmlFor="neg-email-enabled" className="text-sm font-medium cursor-pointer">
+              Invite customers to contact you via email
             </Label>
             <p className="text-xs text-muted-foreground">
-              Controls how the email is framed in negative review responses. Doesn&apos;t affect positive
-              reviews — there, the email simply doesn&apos;t appear in the body.
+              When a customer leaves a negative review (1–2 stars or negative sentiment), our AI will
+              invite them to reach out via email so the conversation can continue privately.
             </p>
-            <RadioGroup
-              value={negativeReviewFraming}
-              onValueChange={(v) => onNegativeReviewFramingChange(v as NegativeReviewFraming)}
-              disabled={disabled}
-              className="space-y-2"
-            >
-              {NEGATIVE_REVIEW_FRAMINGS.map((framing) => {
-                const info = FRAMING_LABELS[framing];
-                return (
-                  <div key={framing} className="flex items-start gap-3">
-                    <RadioGroupItem value={framing} id={`framing-${framing}`} className="mt-1" />
-                    <div className="flex-1 space-y-1">
-                      <Label htmlFor={`framing-${framing}`} className="text-sm font-medium cursor-pointer">
-                        {info.label}
-                      </Label>
-                      <p className="text-xs text-muted-foreground">{info.description}</p>
-                    </div>
-                  </div>
-                );
-              })}
-            </RadioGroup>
-
-            {/* Custom framing textarea — only when 'custom' is selected */}
-            {negativeReviewFraming === "custom" && (
-              <div className="space-y-2 pl-7">
-                <Label htmlFor="framing-custom" className="text-xs font-medium">
-                  Custom instructions
-                </Label>
-                <Textarea
-                  id="framing-custom"
-                  value={negativeReviewFramingCustom ?? ""}
-                  onChange={(e) => onNegativeReviewFramingCustomChange(e.target.value)}
-                  maxLength={BRAND_VOICE_LIMITS_V2.FRAMING_CUSTOM_MAX}
-                  rows={3}
-                  placeholder="For brands with specific phrasing or obligations…"
-                  disabled={disabled}
-                  className="resize-none"
-                />
-                <p className="text-xs text-muted-foreground">
-                  {(negativeReviewFramingCustom ?? "").length} / {BRAND_VOICE_LIMITS_V2.FRAMING_CUSTOM_MAX} characters
-                </p>
-              </div>
-            )}
           </div>
-
-          {/* §7.5 Reply-to email */}
-          <div className="space-y-2">
-            <Label htmlFor="reply-to-email" className="text-sm font-medium">
-              Reply-to email
-            </Label>
-            <p className="text-xs text-muted-foreground">
-              The email address that will appear in the responses above.
-            </p>
-            <Input
-              id="reply-to-email"
-              type="email"
-              value={replyToEmail ?? ""}
-              onChange={(e) => onReplyToEmailChange(e.target.value)}
-              maxLength={BRAND_VOICE_LIMITS_V2.REPLY_TO_EMAIL_MAX}
-              placeholder="hello@yourbrand.com"
-              disabled={disabled}
-            />
-            {showEmailMissingWarning && (
-              <Alert variant="default" className="border-yellow-500/50 bg-yellow-500/5">
-                <AlertCircle className="h-4 w-4 text-yellow-600" />
-                <AlertDescription className="text-xs">
-                  Add an email above or turn off the contact invitation. The toggle is on but no
-                  email is configured.
-                </AlertDescription>
-              </Alert>
-            )}
-          </div>
+          <Switch
+            id="neg-email-enabled"
+            checked={negativeReviewEmailEnabled}
+            onCheckedChange={onNegativeReviewEmailEnabledChange}
+            disabled={disabled}
+          />
         </div>
-      )}
+
+        {/* §7.4 Framing radio + §7.5 Reply-to email — only when toggle is ON.
+            Switched from `border-dashed bg-muted/30` (which read as nothing on
+            the new white cards) to a proper solid-bordered white surface
+            with a left accent so it visibly "emerged" from the toggle above. */}
+        {negativeReviewEmailEnabled && (
+          <div className="space-y-6 rounded-md border border-slate-200 border-l-2 border-l-primary/40 bg-card p-4">
+            <div className="space-y-3">
+              <Label className="text-sm font-medium">
+                How should our AI frame the invitation?
+              </Label>
+              <p className="text-xs text-muted-foreground">
+                Controls how the email is framed in negative review responses. Doesn&apos;t affect positive
+                reviews — there, the email simply doesn&apos;t appear in the body.
+              </p>
+              <RadioGroup
+                value={negativeReviewFraming}
+                onValueChange={(v) => onNegativeReviewFramingChange(v as NegativeReviewFraming)}
+                disabled={disabled}
+                className="space-y-2"
+              >
+                {NEGATIVE_REVIEW_FRAMINGS.map((framing) => {
+                  const info = FRAMING_LABELS[framing];
+                  return (
+                    <div key={framing} className="flex items-start gap-3">
+                      <RadioGroupItem value={framing} id={`framing-${framing}`} className="mt-1" />
+                      <div className="flex-1 space-y-1">
+                        <Label htmlFor={`framing-${framing}`} className="text-sm font-medium cursor-pointer">
+                          {info.label}
+                        </Label>
+                        <p className="text-xs text-muted-foreground">{info.description}</p>
+                      </div>
+                    </div>
+                  );
+                })}
+              </RadioGroup>
+
+              {/* Custom framing textarea — only when 'custom' is selected */}
+              {negativeReviewFraming === "custom" && (
+                <div className="space-y-2 pl-7">
+                  <Label htmlFor="framing-custom" className="text-xs font-medium">
+                    Custom instructions
+                  </Label>
+                  <Textarea
+                    id="framing-custom"
+                    value={negativeReviewFramingCustom ?? ""}
+                    onChange={(e) => onNegativeReviewFramingCustomChange(e.target.value)}
+                    maxLength={BRAND_VOICE_LIMITS_V2.FRAMING_CUSTOM_MAX}
+                    rows={3}
+                    placeholder="For brands with specific phrasing or obligations…"
+                    disabled={disabled}
+                    className="resize-none"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    {(negativeReviewFramingCustom ?? "").length} / {BRAND_VOICE_LIMITS_V2.FRAMING_CUSTOM_MAX} characters
+                  </p>
+                </div>
+              )}
+            </div>
+
+            {/* §7.5 Reply-to email */}
+            <div className="space-y-2">
+              <Label htmlFor="reply-to-email" className="text-sm font-medium">
+                Reply-to email
+              </Label>
+              <p className="text-xs text-muted-foreground">
+                The email address that will appear in the responses above.
+              </p>
+              <Input
+                id="reply-to-email"
+                type="email"
+                value={replyToEmail ?? ""}
+                onChange={(e) => onReplyToEmailChange(e.target.value)}
+                maxLength={BRAND_VOICE_LIMITS_V2.REPLY_TO_EMAIL_MAX}
+                placeholder="hello@yourbrand.com"
+                disabled={disabled}
+              />
+              {showEmailMissingWarning && (
+                <Alert variant="default" className="border-yellow-500/50 bg-yellow-500/5">
+                  <AlertCircle className="h-4 w-4 text-yellow-600" />
+                  <AlertDescription className="text-xs">
+                    Add an email above or turn off the contact invitation. The toggle is on but no
+                    email is configured.
+                  </AlertDescription>
+                </Alert>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/settings/PersonalizationSection.tsx
+++ b/src/components/settings/PersonalizationSection.tsx
@@ -66,7 +66,7 @@ interface ToggleRowProps {
 
 function ToggleRow({ id, label, description, checked, onCheckedChange, disabled }: ToggleRowProps) {
   return (
-    <div className="flex items-start justify-between gap-4 rounded-md border bg-card p-4">
+    <div className="flex items-start justify-between gap-4 rounded-md border border-slate-200 bg-slate-50/50 p-4">
       <div className="flex-1 space-y-1">
         <Label htmlFor={id} className="text-sm font-medium cursor-pointer">
           {label}


### PR DESCRIPTION
## Summary

Follow-up to #132 — you noted on Preview:
- The white section Cards have good page-level contrast, but **inside the cards everything is flat** — the long Contact & sign-off section reads as one wall of controls instead of two sub-blocks.
- The **conditional framing block** (when the email toggle is ON) had **nearly zero contrast** against the white card.
- Section card edges felt soft against the new tinted page surface.

Three coordinated fixes:

1. **Section card borders → `border-slate-200`** so the card edges crisp up against the `slate-50` page surface.
2. **Contact & sign-off sub-blocks → bordered containers with faint tint** (`border-slate-200 + bg-slate-50/50`). The two sub-blocks ("Greeting & closing" / "Negative-review email") now read as nested figures on the white section card — same figure-on-ground move the page surface does.
3. **Conditional framing reveal block → proper styled container** instead of `border-dashed + bg-muted/30`. Now: solid border + a **left-accent border** (`border-l-2 border-l-primary/40`) so the user reads it as "the toggle expanded into a controlled-detail block" rather than ambiguous floating content.
4. **Personalization toggle rows → match sub-block style** since the same `border + bg-card` pattern was invisible there too once the parent card lost its tint.

Form inputs inside tinted sub-blocks explicitly pick up `bg-card` so they stay crisp white — keeps the form controls focal against the slate-tinted container.

## Test plan

- [x] `npm run lint:strict` clean
- [x] `npm run type-check` clean
- [x] `npm run test:unit` — 1005 passed, 30 skipped, 0 failed; 1 flaky timeout on `tests/unit/api/beta-invites/validate.test.ts` that passes cleanly on re-run (unrelated to this PR — that test makes no UI assertions).
- [ ] Visual check on staging Preview:
  - confirm section card edges read more clearly against the tinted page
  - confirm the Contact & sign-off section has two visibly separate sub-blocks
  - toggle the negative-review email switch ON and confirm the framing reveal block stands out (border + left accent) rather than disappearing
  - confirm the two Personalization toggle rows have visible borders

🤖 Generated with [Claude Code](https://claude.com/claude-code)
