### PR TITLE
feat: bump REVIEW_TEXT_MAX to 4000 + fix character-counter colour thresholds

### DIFF
--- a/docs/phase-0/CORE_SPECS.md
+++ b/docs/phase-0/CORE_SPECS.md
@@ -165,7 +165,7 @@ model Review {
   user            User      @relation(fields: [userId], references: [id], onDelete: Cascade)
   
   platform        String                    // "google" | "amazon" | "shopify" | "trustpilot" | "other"
-  reviewText      String    @db.Text        // 1-2000 chars
+  reviewText      String    @db.Text        // 1-4000 chars (Zod cap)
   rating          Int?                      // 1-5 stars, nullable
   reviewerName    String?
   reviewDate      DateTime?
@@ -404,7 +404,7 @@ The signup route (`POST /auth/signup`) and NextAuth's `events.signIn` were modif
 // Request
 {
   "platform": "google",        // Required: "google" | "amazon" | "shopify" | "trustpilot" | "other"
-  "reviewText": string,        // Required, 1-2000 chars
+  "reviewText": string,        // Required, 1-4000 chars
   "rating"?: number,           // Optional, 1-5
   "reviewerName"?: string,
   "reviewDate"?: string,       // ISO 8601
@@ -525,7 +525,7 @@ The signup route (`POST /auth/signup`) and NextAuth's `events.signIn` were modif
 - Credits: 0-1000 (cannot go negative)
 
 ### Review
-- reviewText: 1-2000 chars
+- reviewText: 1-4000 chars
 - rating: 1-5 or null
 - platform: one of allowed values
 - detectedLanguage: auto-detected, user can override

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -212,7 +212,7 @@ model Review {
   location   Location @relation(fields: [locationId], references: [id], onDelete: Cascade)
 
   platform     String // "google" | "amazon" | "shopify" | "trustpilot" | "other"
-  reviewText   String    @db.Text // 1-2000 chars
+  reviewText   String    @db.Text // 1-4000 chars (Zod cap; @db.Text is unbounded)
   rating       Int? // 1-5 stars, nullable
   reviewerName String?
   reviewDate   DateTime?

--- a/src/components/reviews/ReviewForm.tsx
+++ b/src/components/reviews/ReviewForm.tsx
@@ -154,7 +154,13 @@ export function ReviewForm({ initialData, mode = "create" }: ReviewFormProps) {
   };
 
   const characterCount = reviewText?.length || 0;
-  const characterPercentage = (characterCount / VALIDATION_LIMITS.REVIEW_TEXT_MAX) * 100;
+  // Character-count colour uses absolute-chars-remaining rather than %-of-max
+  // so the warning zones stay invariant if `REVIEW_TEXT_MAX` ever changes
+  // again. Red when within 200 of the cap (or over), yellow when within 500.
+  const charactersRemaining = VALIDATION_LIMITS.REVIEW_TEXT_MAX - characterCount;
+  const isOverLimit = charactersRemaining < 0;
+  const isNearLimit = charactersRemaining >= 0 && charactersRemaining <= 200;
+  const isInWarningZone = charactersRemaining > 200 && charactersRemaining <= 500;
 
   return (
     <Card>
@@ -226,9 +232,9 @@ export function ReviewForm({ initialData, mode = "create" }: ReviewFormProps) {
               </div>
               <span
                 className={`${
-                  characterPercentage > 90
+                  isOverLimit || isNearLimit
                     ? "text-destructive"
-                    : characterPercentage > 75
+                    : isInWarningZone
                     ? "text-yellow-600"
                     : "text-muted-foreground"
                 }`}

--- a/src/components/reviews/ReviewForm.tsx
+++ b/src/components/reviews/ReviewForm.tsx
@@ -154,13 +154,16 @@ export function ReviewForm({ initialData, mode = "create" }: ReviewFormProps) {
   };
 
   const characterCount = reviewText?.length || 0;
-  // Character-count colour uses absolute-chars-remaining rather than %-of-max
-  // so the warning zones stay invariant if `REVIEW_TEXT_MAX` ever changes
-  // again. Red when within 200 of the cap (or over), yellow when within 500.
+  // Character-count colour: red ONLY means "over the limit, the form will
+  // reject this". Within the cap, yellow is the strongest signal we use
+  // (≤ 500 remaining). Showing red on valid input misled users into
+  // trimming text that would have submitted fine.
+  //
+  // Absolute-chars-remaining instead of %-of-max keeps the warning band
+  // invariant if `REVIEW_TEXT_MAX` ever changes again.
   const charactersRemaining = VALIDATION_LIMITS.REVIEW_TEXT_MAX - characterCount;
   const isOverLimit = charactersRemaining < 0;
-  const isNearLimit = charactersRemaining >= 0 && charactersRemaining <= 200;
-  const isInWarningZone = charactersRemaining > 200 && charactersRemaining <= 500;
+  const isInWarningZone = charactersRemaining >= 0 && charactersRemaining <= 500;
 
   return (
     <Card>
@@ -232,7 +235,7 @@ export function ReviewForm({ initialData, mode = "create" }: ReviewFormProps) {
               </div>
               <span
                 className={`${
-                  isOverLimit || isNearLimit
+                  isOverLimit
                     ? "text-destructive"
                     : isInWarningZone
                     ? "text-yellow-600"

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -443,7 +443,11 @@ export const CREDIT_COSTS = {
 // pure validation/UI concern.
 export const VALIDATION_LIMITS = {
   REVIEW_TEXT_MIN: 1,
-  REVIEW_TEXT_MAX: 2000,
+  // Bumped from 2000 → 4000 after seeing real customer reviews exceed 2000
+  // chars (~2900 in one observed hospitality complaint). Postgres column is
+  // `@db.Text` (unbounded) so this is purely a Zod + UI concern; no DB
+  // migration needed.
+  REVIEW_TEXT_MAX: 4000,
   RESPONSE_TEXT_MAX: 2000,
   PASSWORD_MIN: 8,
   PASSWORD_MAX: 100,

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -199,7 +199,10 @@ export const brandVoiceSchema = z.object({
 
 // Test brand voice schema (for testing with sample review)
 export const testBrandVoiceSchema = z.object({
-  reviewText: z.string().min(1, "Review text is required").max(2000, "Review text too long"),
+  reviewText: z
+    .string()
+    .min(VALIDATION_LIMITS.REVIEW_TEXT_MIN, "Review text is required")
+    .max(VALIDATION_LIMITS.REVIEW_TEXT_MAX, "Review text too long"),
   platform: z.enum(PLATFORMS).optional().default("Google"),
   rating: z.number().min(1).max(5).optional().nullable(),
 });

--- a/tests/unit/components/reviews/review-form.test.tsx
+++ b/tests/unit/components/reviews/review-form.test.tsx
@@ -104,7 +104,7 @@ describe("ReviewForm", () => {
     it("shows character count starting at 0", () => {
       render(<ReviewForm />);
 
-      expect(screen.getByText("0/2000")).toBeInTheDocument();
+      expect(screen.getByText("0/4000")).toBeInTheDocument();
     });
   });
 

--- a/tests/unit/lib/constants.test.ts
+++ b/tests/unit/lib/constants.test.ts
@@ -134,8 +134,10 @@ describe('CREDIT_COSTS', () => {
 });
 
 describe('VALIDATION_LIMITS', () => {
-  it('REVIEW_TEXT_MAX is 2000', () => {
-    expect(VALIDATION_LIMITS.REVIEW_TEXT_MAX).toBe(2000);
+  it('REVIEW_TEXT_MAX is 4000', () => {
+    // Bumped from 2000 → 4000 after real reviews exceeded the old cap
+    // (~2900 chars observed). DB column is @db.Text (unbounded).
+    expect(VALIDATION_LIMITS.REVIEW_TEXT_MAX).toBe(4000);
   });
 
   it('RESPONSE_TEXT_MAX is 2000', () => {

--- a/tests/unit/lib/validations.test.ts
+++ b/tests/unit/lib/validations.test.ts
@@ -16,6 +16,7 @@ import {
   paginationSchema,
   reviewFiltersSchema,
 } from '@/lib/validations';
+import { VALIDATION_LIMITS } from '@/lib/constants';
 
 // ─── Auth Schemas ─────────────────────────────────────────
 
@@ -229,10 +230,18 @@ describe('createReviewSchema', () => {
     expect(result.success).toBe(false);
   });
 
-  it('rejects too-long reviewText (> 2000)', () => {
+  it('accepts reviewText up to REVIEW_TEXT_MAX (4000) chars', () => {
     const result = createReviewSchema.safeParse({
       platform: 'Google',
-      reviewText: 'a'.repeat(2001),
+      reviewText: 'a'.repeat(VALIDATION_LIMITS.REVIEW_TEXT_MAX),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects reviewText exceeding REVIEW_TEXT_MAX (4000)', () => {
+    const result = createReviewSchema.safeParse({
+      platform: 'Google',
+      reviewText: 'a'.repeat(VALIDATION_LIMITS.REVIEW_TEXT_MAX + 1),
     });
     expect(result.success).toBe(false);
   });
@@ -642,9 +651,9 @@ describe('testBrandVoiceSchema', () => {
     }
   });
 
-  it('rejects reviewText > 2000 chars', () => {
+  it('rejects reviewText exceeding REVIEW_TEXT_MAX', () => {
     const result = testBrandVoiceSchema.safeParse({
-      reviewText: 'a'.repeat(2001),
+      reviewText: 'a'.repeat(VALIDATION_LIMITS.REVIEW_TEXT_MAX + 1),
     });
     expect(result.success).toBe(false);
   });


### PR DESCRIPTION
## Summary

Two bugs, one PR. Both surfaced when a real customer review came in at 2903 chars.

### Bug 1 — REVIEW_TEXT_MAX too low

`VALIDATION_LIMITS.REVIEW_TEXT_MAX` was 2000, but real hospitality complaints (especially negative ones with detailed grievances) routinely exceed that. The Zod schema rejected a 2903-char real-world review.

**Fix:** bump to **4000**. The Postgres column is `@db.Text` (unbounded), so this is a pure Zod + UI concern — **no DB migration**. The hardcoded `2000` in `testBrandVoiceSchema` is also swapped to use the shared constant so future bumps stay one-line changes.

### Bug 2 — Character counter colour bands re-scale with the cap

The counter colour used `% of REVIEW_TEXT_MAX`:
- `> 90%` → red
- `> 75%` → yellow

At the old cap that meant red kicked in at 1801 and never let go on the way down. Worse, with the cap bumped to 4000 those same thresholds would mean red starts at 3601 and yellow at 3000 — useless "warnings" that fire only when the user is already at the limit.

**Fix:** switch to absolute-chars-remaining, **and red ONLY means "over the limit, the form will reject this"**. Within the cap, yellow is the strongest signal. Showing red on valid input misled users into trimming text that would have submitted fine.
- `remaining < 0`   → red (over the limit)
- `remaining ≤ 500` → yellow (warning zone)
- otherwise         → muted

The warning band stays the same if `REVIEW_TEXT_MAX` changes again (cap-invariant).

### Why no DB migration

The `Review.reviewText` column is `@db.Text` in Postgres — unbounded by the type itself. The previous 2000 was enforced only in Zod + the UI counter. Comment in `schema.prisma` updated from "1-2000 chars" → "1-4000 chars (Zod cap; @db.Text is unbounded)".

## Test plan

- [x] `npm run lint:strict` clean
- [x] `npm run type-check` clean
- [x] `npm run test:unit` — 1007 passed, 30 skipped, 0 failed (63 files).
- [ ] Visual check on staging Preview:
  - paste a 3000-char review and confirm it is accepted (was rejected before)
  - paste a 4001-char review and confirm validation error + counter goes red
  - confirm counter goes yellow at 3500+ (≤ 500 remaining) and stays yellow all the way up to the cap
  - confirm counter never goes red on valid input
  - confirm counter goes back to muted/yellow when the user trims chars below those thresholds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
