### PR TITLE
feat(ui): brand-voice sections 1 + 2 — inner sub-block containers

### DIFF
--- a/src/components/settings/BrandVoiceForm.tsx
+++ b/src/components/settings/BrandVoiceForm.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect, useRef, useCallback } from "react";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
-import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import { ToneSelector } from "./ToneSelector";
 import { KeyPhrasesInput } from "./KeyPhrasesInput";
@@ -323,27 +322,41 @@ export function BrandVoiceForm() {
         <SaveStatusIndicator status={saveStatus} />
       </div>
 
-      {/* §1 Voice — Tone, Style guidelines, Key phrases */}
+      {/* §1 Voice — Tone, Style guidelines, Key phrases.
+          Inner-contrast pass — three sub-blocks (tone / style guidelines /
+          key phrases) each in their own tinted-bordered container, matching
+          the section-4 pattern. Tone is conceptually about "register",
+          style guidelines is "what to write", key phrases is "vocabulary"
+          — three concerns, three blocks. Combining the latter two would be
+          a single big undifferentiated block. */}
       <Card className="bg-card border-slate-200 shadow-sm">
         <CardHeader>
           <SectionHeader number={1} title="Voice" descriptor="how we sound" />
         </CardHeader>
-        <CardContent className="space-y-8">
+        <CardContent className="space-y-6">
           {/* §4.1 Tone */}
-          <div className="space-y-2">
-            <Label className="text-sm font-medium">Tone</Label>
-            <p className="text-xs text-muted-foreground">
-              How responses should sound to your customers.
-            </p>
+          <div className="rounded-lg border border-slate-200 bg-slate-50/50 p-4 space-y-4">
+            <div className="space-y-1">
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Tone
+              </p>
+              <p className="text-xs text-muted-foreground">
+                How responses should sound to your customers.
+              </p>
+            </div>
             <ToneSelector value={tone} onChange={setTone} disabled={isSaving} />
           </div>
 
           {/* §4.2 Style guidelines */}
-          <div className="space-y-2">
-            <Label className="text-sm font-medium">Style guidelines</Label>
-            <p className="text-xs text-muted-foreground">
-              Specific rules our AI should follow when writing responses.
-            </p>
+          <div className="rounded-lg border border-slate-200 bg-slate-50/50 p-4 space-y-4">
+            <div className="space-y-1">
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Style guidelines
+              </p>
+              <p className="text-xs text-muted-foreground">
+                Specific rules our AI should follow when writing responses.
+              </p>
+            </div>
             <StyleGuidelinesInput
               value={styleGuidelines}
               onChange={setStyleGuidelines}
@@ -361,11 +374,15 @@ export function BrandVoiceForm() {
           </div>
 
           {/* §4.3 Key phrases */}
-          <div className="space-y-2">
-            <Label className="text-sm font-medium">Key phrases</Label>
-            <p className="text-xs text-muted-foreground">
-              Vocabulary and expressions we like to use.
-            </p>
+          <div className="rounded-lg border border-slate-200 bg-slate-50/50 p-4 space-y-4">
+            <div className="space-y-1">
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Key phrases
+              </p>
+              <p className="text-xs text-muted-foreground">
+                Vocabulary and expressions we like to use.
+              </p>
+            </div>
             <KeyPhrasesInput value={keyPhrases} onChange={setKeyPhrases} disabled={isSaving} />
             <ExampleChips
               label="Starter ideas (click to add)"
@@ -378,17 +395,24 @@ export function BrandVoiceForm() {
         </CardContent>
       </Card>
 
-      {/* §2 Examples — Sample responses */}
+      {/* §2 Examples — Sample responses.
+          Single sub-block (no nesting needed since there's only one control)
+          but wrapped in the same tinted-bordered container so the page
+          rhythm reads consistently with sections 1 + 4. */}
       <Card className="bg-card border-slate-200 shadow-sm">
         <CardHeader>
           <SectionHeader number={2} title="Examples" descriptor="what good looks like for us" />
         </CardHeader>
         <CardContent>
-          <div className="space-y-2">
-            <Label className="text-sm font-medium">Sample responses</Label>
-            <p className="text-xs text-muted-foreground">
-              Up to 5 of your actual responses. Our AI uses these as reference to match your voice.
-            </p>
+          <div className="rounded-lg border border-slate-200 bg-slate-50/50 p-4 space-y-4">
+            <div className="space-y-1">
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Sample responses
+              </p>
+              <p className="text-xs text-muted-foreground">
+                Up to 5 of your actual responses. Our AI uses these as reference to match your voice.
+              </p>
+            </div>
             <SampleResponsesInput
               value={sampleResponses}
               onChange={setSampleResponses}

--- a/tests/unit/components/settings/brand-voice-form.test.tsx
+++ b/tests/unit/components/settings/brand-voice-form.test.tsx
@@ -157,6 +157,44 @@ describe("BrandVoiceForm (V2)", () => {
     expect(screen.getByText("Negative-review email")).toBeInTheDocument();
   });
 
+  // Inner-contrast pass continued — sections 1 + 2 get the same eyebrow
+  // sub-block treatment that section 4 got earlier.
+  it("renders the section-1 sub-block eyebrow labels (Tone / Style / Key)", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ data: { brandVoice: mockBrandVoice } }),
+    });
+
+    render(<BrandVoiceForm />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Brand voice")).toBeInTheDocument();
+    });
+
+    // Three sub-blocks inside section 1 — each carries an uppercase
+    // eyebrow label. The previous flat layout used inline <Label>s with
+    // the same text but no eyebrow styling; we assert presence of the
+    // text and let the visual treatment ride on the CSS.
+    expect(screen.getByText("Tone")).toBeInTheDocument();
+    expect(screen.getByText("Style guidelines")).toBeInTheDocument();
+    expect(screen.getByText("Key phrases")).toBeInTheDocument();
+  });
+
+  it("renders the section-2 sub-block eyebrow label (Sample responses)", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ data: { brandVoice: mockBrandVoice } }),
+    });
+
+    render(<BrandVoiceForm />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Brand voice")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Sample responses")).toBeInTheDocument();
+  });
+
   // Iter-7 hierarchy pass: APPEND chips now render a leading `+` glyph so
   // users can tell at a glance the chip extends a list rather than
   // replaces a field value.


### PR DESCRIPTION
## Summary

Extends the section-4 sub-block pattern from #133 to sections 1 (Voice) and 2 (Examples) on the brand voice page.

**Section 1 — Voice** gets three sub-blocks (one per control), each in its own tinted-bordered container with an uppercase eyebrow label:
- **TONE** — single picker, self-contained
- **STYLE GUIDELINES** — list + chip row
- **KEY PHRASES** — list + chip row

You raised the right point that combining style guidelines + key phrases into one "style & vocabulary" block would produce a single big undifferentiated block. They're conceptually separate (rules-of-writing vs vocabulary) and each has its own list + chip row, so keeping them in separate sub-blocks preserves the internal-contrast that the section-4 pattern was designed to give.

**Section 2 — Examples** gets a single sub-block holding the Sample responses control. No nesting (there's only one control), but the same tinted-bordered container so the page rhythm reads consistently across sections 1 + 2 + 4.

**Side-effect** — dropped the now-unused `Label` import from `BrandVoiceForm.tsx`. The inline `<Label>Tone</Label>` / `<Label>Sample responses</Label>` etc. were replaced by the uppercase eyebrow paragraph pattern from section 4, so the `Label` UI primitive isn't needed here anymore.

## Test plan

- [x] `npm run lint:strict` clean
- [x] `npm run type-check` clean
- [x] `npm run test:unit` — 1009 passed, 30 skipped, 0 failed (63 files). Two new `BrandVoiceForm` assertions: section-1 eyebrow labels (Tone / Style guidelines / Key phrases) all render; section-2 eyebrow label (Sample responses) renders.
- [ ] Visual check on staging Preview:
  - confirm section 1 now shows three nested tinted-bordered sub-blocks with uppercase eyebrow labels (TONE / STYLE GUIDELINES / KEY PHRASES)
  - confirm the visual rhythm matches section 4
  - confirm section 2 has a single sub-block (just for visual consistency)
  - confirm section 3 (Personalization) is unaffected by this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
