### PR TITLE
fix(ui): brand-voice nested borders — bump to slate-300 for contrast

### DIFF
--- a/src/components/settings/CollapsibleTextItem.tsx
+++ b/src/components/settings/CollapsibleTextItem.tsx
@@ -219,7 +219,7 @@ export function CollapsibleTextItem({
     <>
       <Card
         className={cn(
-          "p-3 transition-all",
+          "p-3 transition-all border-slate-300",
           !disabled && "cursor-pointer hover:bg-accent/50"
         )}
         onClick={needsExpansion ? toggleExpand : handleStartEdit}

--- a/src/components/settings/KeyPhrasesInput.tsx
+++ b/src/components/settings/KeyPhrasesInput.tsx
@@ -63,6 +63,7 @@ export function KeyPhrasesInput({ value, onChange, disabled }: KeyPhrasesInputPr
           size="icon"
           onClick={addPhrase}
           disabled={disabled || !canAddMore || !inputValue.trim()}
+          className="border-slate-300"
         >
           <Plus className="h-4 w-4" />
         </Button>

--- a/src/components/settings/StyleGuidelinesInput.tsx
+++ b/src/components/settings/StyleGuidelinesInput.tsx
@@ -85,7 +85,7 @@ export function StyleGuidelinesInput({
 
       {/* Add new guideline - distinct card with dashed border */}
       {canAddMore && (
-        <Card className="p-4 border-dashed border-2 border-muted-foreground/30 bg-muted/20">
+        <Card className="p-4 border-dashed border-2 border-slate-300 bg-white">
           <div className="space-y-3">
             <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
               <Plus className="h-4 w-4" />

--- a/src/components/settings/ToneSelector.tsx
+++ b/src/components/settings/ToneSelector.tsx
@@ -55,7 +55,7 @@ export function ToneSelector({ value, onChange, disabled }: ToneSelectorProps) {
               "focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2",
               isSelected
                 ? "border-primary bg-primary/10"
-                : "border-muted bg-background",
+                : "border-slate-300 bg-background",
               disabled && "opacity-50 cursor-not-allowed",
             )}
           >


### PR DESCRIPTION
## Summary

Follow-up to #135. You spotted on Preview that two specific surfaces inside the new sub-blocks had borders that visually disappeared:

1. The four tone cards in section 1 (TONE sub-block).
2. The `+` icon-button next to the key-phrases input.

Root cause is the same as the iter-2 contrast pass — `border-muted` / default `border` / `border-muted-foreground/30` tokens are all near-white in the light theme and barely contrast against `bg-background` / `bg-card`. With the new tinted sub-block parent (`bg-slate-50/50`) added in #135, we now have **three layers of near-white surfaces stacked**, and the inner borders lose what little contrast they had against `bg-card` alone.

**Four controls bumped to `border-slate-300`:**

- **`ToneSelector`** — the four tone cards used `border-muted`. Replaced with `border-slate-300`. Selected state (`border-primary`) and hover state are unchanged.
- **`KeyPhrasesInput`** — the `+` add-button (a `Button variant="outline"`) gets an explicit `border-slate-300` so the affordance is clearly clickable.
- **`StyleGuidelinesInput`** — the "Add New Guideline" dashed Card used `border-muted-foreground/30 bg-muted/20`; now `border-slate-300 bg-white` so the add-affordance is visible on the tinted parent.
- **`CollapsibleTextItem`** — non-editing-mode Card border bumped from default to `border-slate-300` so existing list items have visible edges.

**What I did NOT change:**
- Edit-mode `CollapsibleTextItem` (already has a strong `border-primary/50`).
- Selected-tone state in `ToneSelector` (already `border-primary`).
- The chip pill borders — those read fine against the tinted bg.

## Test plan

- [x] `npm run lint:strict` clean
- [x] `npm run type-check` clean
- [x] `npm run test:unit` — 1009 passed, 30 skipped, 0 failed (63 files). No new assertions added — the change is pure border colour, no behavioral or DOM-structure shift.
- [ ] Visual check on staging Preview:
  - confirm the four tone cards now have visible edges against the slate-tinted TONE sub-block (warm/friendly/polished/empathetic)
  - confirm the `+` button next to the key-phrases input is clearly visible
  - confirm the "Add New Guideline" dashed card in section 1 still reads as "add" (dashed border + plus icon) but with stronger contrast
  - confirm existing guideline / sample-response list items have visible edges

🤖 Generated with [Claude Code](https://claude.com/claude-code)
