### PR TITLE
fix(ui): brand-voice — unify all borders on slate-300

### DIFF
--- a/src/components/settings/BrandVoiceForm.tsx
+++ b/src/components/settings/BrandVoiceForm.tsx
@@ -329,13 +329,13 @@ export function BrandVoiceForm() {
           style guidelines is "what to write", key phrases is "vocabulary"
           — three concerns, three blocks. Combining the latter two would be
           a single big undifferentiated block. */}
-      <Card className="bg-card border-slate-200 shadow-sm">
+      <Card className="bg-card border-slate-300 shadow-sm">
         <CardHeader>
           <SectionHeader number={1} title="Voice" descriptor="how we sound" />
         </CardHeader>
         <CardContent className="space-y-6">
           {/* §4.1 Tone */}
-          <div className="rounded-lg border border-slate-200 bg-slate-50/50 p-4 space-y-4">
+          <div className="rounded-lg border border-slate-300 bg-slate-50/50 p-4 space-y-4">
             <div className="space-y-1">
               <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
                 Tone
@@ -348,7 +348,7 @@ export function BrandVoiceForm() {
           </div>
 
           {/* §4.2 Style guidelines */}
-          <div className="rounded-lg border border-slate-200 bg-slate-50/50 p-4 space-y-4">
+          <div className="rounded-lg border border-slate-300 bg-slate-50/50 p-4 space-y-4">
             <div className="space-y-1">
               <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
                 Style guidelines
@@ -374,7 +374,7 @@ export function BrandVoiceForm() {
           </div>
 
           {/* §4.3 Key phrases */}
-          <div className="rounded-lg border border-slate-200 bg-slate-50/50 p-4 space-y-4">
+          <div className="rounded-lg border border-slate-300 bg-slate-50/50 p-4 space-y-4">
             <div className="space-y-1">
               <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
                 Key phrases
@@ -399,12 +399,12 @@ export function BrandVoiceForm() {
           Single sub-block (no nesting needed since there's only one control)
           but wrapped in the same tinted-bordered container so the page
           rhythm reads consistently with sections 1 + 4. */}
-      <Card className="bg-card border-slate-200 shadow-sm">
+      <Card className="bg-card border-slate-300 shadow-sm">
         <CardHeader>
           <SectionHeader number={2} title="Examples" descriptor="what good looks like for us" />
         </CardHeader>
         <CardContent>
-          <div className="rounded-lg border border-slate-200 bg-slate-50/50 p-4 space-y-4">
+          <div className="rounded-lg border border-slate-300 bg-slate-50/50 p-4 space-y-4">
             <div className="space-y-1">
               <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
                 Sample responses
@@ -423,7 +423,7 @@ export function BrandVoiceForm() {
       </Card>
 
       {/* §3 Personalization — Named-staff + Occasion toggles */}
-      <Card className="bg-card border-slate-200 shadow-sm">
+      <Card className="bg-card border-slate-300 shadow-sm">
         <CardHeader>
           <SectionHeader number={3} title="Personalization" descriptor="what we acknowledge" />
         </CardHeader>
@@ -439,7 +439,7 @@ export function BrandVoiceForm() {
       </Card>
 
       {/* §4 Contact & sign-off — Salutation, sign-off, email invitation */}
-      <Card className="bg-card border-slate-200 shadow-sm">
+      <Card className="bg-card border-slate-300 shadow-sm">
         <CardHeader>
           <SectionHeader number={4} title="Contact & sign-off" descriptor="how we close" />
         </CardHeader>

--- a/src/components/settings/ContactSignoffSection.tsx
+++ b/src/components/settings/ContactSignoffSection.tsx
@@ -109,7 +109,7 @@ export function ContactSignoffSection({
           container with a faint slate tint. Gives the two halves of this
           long section the same figure-on-ground read the section cards
           themselves have on the page surface. */}
-      <div className="rounded-lg border border-slate-200 bg-slate-50/50 p-4 space-y-6">
+      <div className="rounded-lg border border-slate-300 bg-slate-50/50 p-4 space-y-6">
         <div className="space-y-1">
           <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
             Greeting & closing
@@ -177,7 +177,7 @@ export function ContactSignoffSection({
           framing reveal stays nested inside this block (with its own
           tighter border) so the user sees "toggle expanded into more
           controls within the same conceptual area". */}
-      <div className="rounded-lg border border-slate-200 bg-slate-50/50 p-4 space-y-4">
+      <div className="rounded-lg border border-slate-300 bg-slate-50/50 p-4 space-y-4">
         <div className="space-y-1">
           <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
             Negative-review email
@@ -188,7 +188,7 @@ export function ContactSignoffSection({
         </div>
 
         {/* §7.3 Negative-review email invitation toggle */}
-        <div className="flex items-start justify-between gap-4 rounded-md border border-slate-200 bg-card p-4">
+        <div className="flex items-start justify-between gap-4 rounded-md border border-slate-300 bg-card p-4">
           <div className="flex-1 space-y-1">
             <Label htmlFor="neg-email-enabled" className="text-sm font-medium cursor-pointer">
               Invite customers to contact you via email
@@ -211,7 +211,7 @@ export function ContactSignoffSection({
             the new white cards) to a proper solid-bordered white surface
             with a left accent so it visibly "emerged" from the toggle above. */}
         {negativeReviewEmailEnabled && (
-          <div className="space-y-6 rounded-md border border-slate-200 border-l-2 border-l-primary/40 bg-card p-4">
+          <div className="space-y-6 rounded-md border border-slate-300 border-l-2 border-l-primary/40 bg-card p-4">
             <div className="space-y-3">
               <Label className="text-sm font-medium">
                 How should our AI frame the invitation?

--- a/src/components/settings/PersonalizationSection.tsx
+++ b/src/components/settings/PersonalizationSection.tsx
@@ -66,7 +66,7 @@ interface ToggleRowProps {
 
 function ToggleRow({ id, label, description, checked, onCheckedChange, disabled }: ToggleRowProps) {
   return (
-    <div className="flex items-start justify-between gap-4 rounded-md border border-slate-200 bg-slate-50/50 p-4">
+    <div className="flex items-start justify-between gap-4 rounded-md border border-slate-300 bg-slate-50/50 p-4">
       <div className="flex-1 space-y-1">
         <Label htmlFor={id} className="text-sm font-medium cursor-pointer">
           {label}


### PR DESCRIPTION
## Summary

Follow-up to #136. You noted on Preview that the tone-card border weight now reads well, but the **outer** section Cards + sub-block containers were on `border-slate-200` while the **inner** controls were on `border-slate-300` — two weights on the same page that the eye picks up as inconsistency.

**Fix:** standardise everything on `slate-300`. One weight, applied to every structural border on the brand voice page.

**13 borders bumped across three files:**

- **`BrandVoiceForm`** — 4 section Cards + 5 sub-block containers (3 in §1 Voice, 1 in §2 Examples, 1 in §3 Personalization).
- **`ContactSignoffSection`** — 2 sub-block containers + the toggle row + the framing reveal container.
- **`PersonalizationSection`** — the two toggle rows (one class change in the shared `ToggleRow` component).

**Unchanged (these are semantic, not structural):**
- `border-l-2 border-l-primary/40` left-accent stripe on the framing reveal block.
- `border-primary` selected-tone card state in `ToneSelector`.
- `border-primary/50` editing-mode state in `CollapsibleTextItem`.
- `border-dashed border-slate-300` on the "Add New Guideline" affordance (already on slate-300 from #136).

## Test plan

- [x] `npm run lint:strict` clean
- [x] `npm run type-check` clean
- [x] `npm run test:unit` — 1009 passed, 30 skipped, 0 failed (63 files). Pure styling change; no new assertions needed.
- [ ] Visual check on staging Preview:
  - confirm the four section Cards have visibly stronger edges than before
  - confirm all four section Cards and all sub-blocks inside them share the same border weight
  - confirm the tone cards, `+` button, and Add-Guideline affordance still match (they're already on slate-300)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
