### PR TITLE
feat: negative-email incomplete-config feedback (dormancy + 3-layer warnings)

### DIFF
--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -18,7 +18,14 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
-import { StatsCard, QuotaCard, SentimentDistributionCard, EmptyReviews, LowCreditWarning } from "@/components/dashboard";
+import {
+  StatsCard,
+  QuotaCard,
+  SentimentDistributionCard,
+  EmptyReviews,
+  LowCreditWarning,
+  BrandVoiceIncompleteBanner,
+} from "@/components/dashboard";
 import { useCredits } from "@/components/providers/CreditsProvider";
 
 interface DashboardStats {
@@ -36,6 +43,9 @@ interface DashboardStats {
   };
   tier: string;
   isBetaUser: boolean;
+  brandVoiceWarnings?: {
+    negativeEmailToggleOnButReplyToEmailMissing: boolean;
+  };
   stats: {
     totalReviews: number;
     totalResponses: number;
@@ -158,6 +168,17 @@ export default function DashboardPage() {
           submitterName={session?.user?.name ?? null}
           submitterEmail={session?.user?.email ?? null}
           submitterBusinessName={organizationName}
+        />
+      )}
+
+      {/* Brand-voice incomplete-config feedback. Separate from the
+          low-credit banner so that BOTH can show simultaneously — they're
+          unrelated problems and condensing them would force a priority
+          choice we don't have evidence for. */}
+      {!isLoading && stats?.brandVoiceWarnings?.negativeEmailToggleOnButReplyToEmailMissing && (
+        <BrandVoiceIncompleteBanner
+          userId={session?.user?.id ?? null}
+          warning="negativeEmailToggleOnButReplyToEmailMissing"
         />
       )}
 

--- a/src/app/api/dashboard/stats/route.ts
+++ b/src/app/api/dashboard/stats/route.ts
@@ -32,6 +32,15 @@ export async function GET() {
         // Surfaced so FounderInquiryForm can pre-fill businessName for
         // signed-in users — see CreditsProvider + iteration 2 follow-up.
         organizationName: true,
+        // Pulled to derive `brandVoiceWarnings` (incomplete-config feedback
+        // surfaced on the dashboard). Only the two fields we actually
+        // check are selected so we don't grow the payload.
+        brandVoice: {
+          select: {
+            negativeReviewEmailEnabled: true,
+            replyToEmail: true,
+          },
+        },
         reviews: {
           select: {
             id: true,
@@ -172,6 +181,17 @@ export async function GET() {
         // signed-in users so they don't re-type info already captured at
         // /onboarding. null until onboarding is completed.
         organizationName: user.organizationName,
+        // Brand-voice incomplete-config flags. Surfaced on the dashboard
+        // so the user notices dormant features even when they don't
+        // revisit /dashboard/settings/brand-voice. Add new flags here
+        // as the brand voice grows other "must complete to take effect"
+        // fields.
+        brandVoiceWarnings: {
+          negativeEmailToggleOnButReplyToEmailMissing:
+            !!user.brandVoice?.negativeReviewEmailEnabled &&
+            (user.brandVoice?.replyToEmail == null ||
+              user.brandVoice.replyToEmail.trim().length === 0),
+        },
         stats: {
           totalReviews: user._count.reviews,
           totalResponses,

--- a/src/components/dashboard/BrandVoiceIncompleteBanner.tsx
+++ b/src/components/dashboard/BrandVoiceIncompleteBanner.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { AlertCircle, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+/**
+ * Dashboard banner that warns the user when their brand voice configuration
+ * has a feature turned on but is missing a prerequisite.
+ *
+ * Today the only configured warning is "negative-review email toggle is ON
+ * but `replyToEmail` is empty" — the AI prompt builder defends against this
+ * (it skips the framing instruction entirely) but the user thinks they
+ * configured the feature. Without this banner the only feedback they get is
+ * a soft hint deep inside the brand voice page, which they may not revisit.
+ *
+ * Dismissal is per-warning, stored in `localStorage` with a 7-day TTL keyed
+ * by user ID. After 7 days the warning re-appears so a long-running broken
+ * config eventually gets noticed again. This is the market-standard pattern
+ * for "important but not blocking" feedback.
+ */
+
+const LOCALSTORAGE_KEY_PREFIX = "bv-incomplete-banner-dismissed";
+const DISMISSAL_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+interface BrandVoiceIncompleteBannerProps {
+  userId: string | null | undefined;
+  warning: "negativeEmailToggleOnButReplyToEmailMissing" | null;
+}
+
+/**
+ * Read the persisted dismissal state synchronously. Returning the value
+ * from a lazy initializer (rather than reading it in an effect) means the
+ * first render already reflects the right state — no banner flash on
+ * reload for already-dismissed warnings, and no "nothing renders for one
+ * tick" race for testing or first-paint perf.
+ */
+function readDismissed(
+  userId: string | null | undefined,
+  warning: BrandVoiceIncompleteBannerProps["warning"],
+): boolean {
+  if (typeof window === "undefined" || !userId || !warning) return false;
+  try {
+    const key = `${LOCALSTORAGE_KEY_PREFIX}:${warning}:${userId}`;
+    const raw = window.localStorage.getItem(key);
+    if (!raw) return false;
+    const dismissedAt = Number.parseInt(raw, 10);
+    if (Number.isNaN(dismissedAt)) return false;
+    return Date.now() - dismissedAt <= DISMISSAL_TTL_MS;
+  } catch {
+    // localStorage unavailable (private browsing, SSR slip-through, etc.)
+    // — fall back to showing the banner. Better an extra banner than a
+    // silently broken config.
+    return false;
+  }
+}
+
+export function BrandVoiceIncompleteBanner({
+  userId,
+  warning,
+}: BrandVoiceIncompleteBannerProps) {
+  const [isDismissed, setIsDismissed] = useState<boolean>(() =>
+    readDismissed(userId, warning),
+  );
+
+  // Re-evaluate dismissal if userId or warning change after mount (rare
+  // — usually a remount on auth swap — but handled for correctness).
+  useEffect(() => {
+    setIsDismissed(readDismissed(userId, warning));
+  }, [userId, warning]);
+
+  const handleDismiss = () => {
+    if (!userId || !warning) return;
+    try {
+      const key = `${LOCALSTORAGE_KEY_PREFIX}:${warning}:${userId}`;
+      window.localStorage.setItem(key, String(Date.now()));
+    } catch {
+      // Swallow — dismissal won't persist across the next dashboard
+      // visit, which is acceptable. The user can dismiss again.
+    }
+    setIsDismissed(true);
+  };
+
+  if (!warning || !userId || isDismissed) return null;
+
+  return (
+    <div
+      role="status"
+      className="flex items-start gap-3 rounded-lg border border-yellow-500/60 bg-yellow-500/10 p-4"
+    >
+      <AlertCircle className="mt-0.5 h-5 w-5 shrink-0 text-yellow-700" />
+      <div className="flex-1 space-y-1">
+        <p className="text-sm font-semibold text-yellow-900">
+          Negative-review email invitations are dormant
+        </p>
+        <p className="text-sm text-yellow-900/80">
+          Your brand voice has email invitations on but no reply-to email
+          configured. AI responses won&apos;t include the email until you fix
+          this.
+        </p>
+        <div className="flex flex-wrap items-center gap-2 pt-1">
+          <Button asChild size="sm" variant="outline" className="bg-card">
+            <Link href="/dashboard/settings/brand-voice">Open brand voice</Link>
+          </Button>
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={handleDismiss}
+        aria-label="Dismiss"
+        className="rounded-md p-1 text-yellow-900/70 transition-colors hover:bg-yellow-500/10 hover:text-yellow-900"
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}

--- a/src/components/dashboard/index.ts
+++ b/src/components/dashboard/index.ts
@@ -4,3 +4,4 @@ export { StatsCard, QuotaCard, SentimentDistributionCard } from "./StatsCard";
 export { EmptyState, EmptyReviews } from "./EmptyState";
 export { LowCreditWarning } from "./LowCreditWarning";
 export { OutOfCreditsDialog } from "./OutOfCreditsDialog";
+export { BrandVoiceIncompleteBanner } from "./BrandVoiceIncompleteBanner";

--- a/src/components/settings/ContactSignoffSection.tsx
+++ b/src/components/settings/ContactSignoffSection.tsx
@@ -99,11 +99,40 @@ export function ContactSignoffSection({
   // Spec §7.5: soft warning — toggle on AND email empty/whitespace-only.
   // Non-blocking; save still proceeds. The form's auto-save flow doesn't
   // change — this just surfaces an inline hint near the email input.
-  const showEmailMissingWarning =
+  //
+  // Incomplete-config feedback: the same condition now drives a section-
+  // level banner at the top of this section and an "Incomplete" pill next
+  // to the Negative-review email sub-block header, in addition to the
+  // existing inline hint near the email field. Three signals at three
+  // distances so the user doesn't forget the feature is dormant.
+  const isEmailConfigIncomplete =
     negativeReviewEmailEnabled && (replyToEmail == null || replyToEmail.trim().length === 0);
+  const showEmailMissingWarning = isEmailConfigIncomplete;
 
   return (
     <div className="space-y-6">
+      {/* Section-level incomplete banner. Appears at the top of the
+          Contact & sign-off section card body when the toggle is on but
+          the email is missing, so the state is unmissable on every
+          visit. The banner duplicates the inline soft-warning text by
+          design — the inline hint stays put (near the field where the
+          fix lives) and this banner adds top-of-section visibility. */}
+      {isEmailConfigIncomplete && (
+        <Alert
+          variant="default"
+          className="border-yellow-500/60 bg-yellow-500/10"
+          role="status"
+        >
+          <AlertCircle className="h-4 w-4 text-yellow-700" />
+          <AlertDescription className="text-xs">
+            <strong className="font-semibold">Negative-review email is incomplete.</strong>{" "}
+            The toggle is on, but no reply-to email is configured. AI responses
+            won&apos;t include the email invitation until you add one below — or
+            turn the toggle off.
+          </AlertDescription>
+        </Alert>
+      )}
+
       {/* Sub-block 1: Greeting & closing (§7.1 + §7.2)
           Inner-contrast pass — each sub-block is now its own bordered
           container with a faint slate tint. Gives the two halves of this
@@ -179,9 +208,17 @@ export function ContactSignoffSection({
           controls within the same conceptual area". */}
       <div className="rounded-lg border border-slate-300 bg-slate-50/50 p-4 space-y-4">
         <div className="space-y-1">
-          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-            Negative-review email
-          </p>
+          <div className="flex items-center gap-2">
+            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Negative-review email
+            </p>
+            {isEmailConfigIncomplete && (
+              <span className="inline-flex items-center gap-1 rounded-full border border-yellow-600/40 bg-yellow-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-yellow-700">
+                <AlertCircle className="h-3 w-3" />
+                Incomplete
+              </span>
+            )}
+          </div>
           <p className="text-xs text-muted-foreground">
             Optional. Only applies when the review is 1–2 stars or has negative sentiment.
           </p>

--- a/src/lib/ai/claude.ts
+++ b/src/lib/ai/claude.ts
@@ -346,8 +346,18 @@ Style guidelines (follow these strictly):`;
   // 'negative'). The framing tells the model how to phrase the email
   // invitation; the actual email address is injected by post-processing
   // (iter 5), so the prompt deliberately does NOT include it.
+  //
+  // Incomplete-config guard: if the toggle is on but no `replyToEmail` is
+  // configured, treat the feature as dormant — skip the framing entirely
+  // rather than ship a response containing the literal `[your email]`
+  // placeholder. Market-standard pattern for partial autosave state: the
+  // toggle persists, but the dependent action lies dormant until the
+  // prerequisite is satisfied. Surfaced to the user via the section-level
+  // incomplete pill on the brand voice page + the dashboard banner.
   const negative = isNegativeReview({ rating, sentiment });
-  if (brandVoice.negativeReviewEmailEnabled && negative) {
+  const hasReplyToEmail =
+    typeof brandVoice.replyToEmail === "string" && brandVoice.replyToEmail.trim().length > 0;
+  if (brandVoice.negativeReviewEmailEnabled && negative && hasReplyToEmail) {
     if (brandVoice.negativeReviewFraming === "custom") {
       // Custom framing: wrap the user-supplied text so any injection
       // attempt inside it is neutralised.

--- a/src/lib/ai/post-process.ts
+++ b/src/lib/ai/post-process.ts
@@ -161,6 +161,39 @@ export function substituteReplyToEmail(body: string, email: string | null): stri
 }
 
 /**
+ * Defensive strip: remove any sentence containing the `[your email]`
+ * placeholder. Used when assembling a response and the brand voice has
+ * no `replyToEmail` configured — the prompt builder already declines to
+ * inject the framing in that case (claude.ts), but a sample response or
+ * a model hallucination could still leak the placeholder. Better to drop
+ * the sentence than ship "[your email]" to the customer.
+ *
+ * Splits the body into sentences on `.`/`!`/`?` boundaries, drops any
+ * containing the placeholder (case-insensitive), and rejoins. Preserves
+ * paragraph breaks (`\n\n`) so multi-paragraph responses stay structured.
+ *
+ * Exported for unit testing.
+ */
+export function stripPlaceholderSentences(body: string): string {
+  // Paragraph-by-paragraph so we don't accidentally fuse paragraphs when
+  // a single sentence is dropped mid-paragraph.
+  return body
+    .split(/\n{2,}/u)
+    .map((paragraph) => {
+      // Match sentences greedily: any run of non-terminator chars + a
+      // single terminator (. ! ?). Tail without a terminator is captured
+      // as a trailing sentence too.
+      const sentences = paragraph.match(/[^.!?]+[.!?]+|\S[^.!?]*$/gu) ?? [paragraph];
+      return sentences
+        .filter((s) => !EMAIL_PLACEHOLDER_PATTERN.test(s))
+        .join("")
+        .trim();
+    })
+    .filter((p) => p.length > 0)
+    .join("\n\n");
+}
+
+/**
  * Truncate the model-emitted body to `RESPONSE_BODY_CHAR_MAX`, preferring
  * to end at a sentence boundary when one is available in the last 100
  * characters.
@@ -200,13 +233,24 @@ export function assembleResponse(args: AssembleResponseArgs): string {
   // 2. Body — first cap to RESPONSE_BODY_CHAR_MAX, then optionally
   //    substitute the [your email] placeholder for negative reviews when
   //    the toggle is on AND a reply-to email is configured.
+  //
+  //    Defensive strip: if there's no `replyToEmail` (the toggle is on
+  //    but the prerequisite is missing, OR the toggle is off but a
+  //    sample/hallucination leaked the placeholder anyway), drop any
+  //    sentence containing the placeholder. The customer should never
+  //    see the bracketed text in a live response.
   let body = truncateBody(modelBody.trim());
   const negative = isNegativeReview({
     rating: review.rating,
     sentiment: review.sentiment,
   });
-  if (negative && normalized.negativeReviewEmailEnabled && normalized.replyToEmail) {
+  const hasReplyToEmail =
+    typeof normalized.replyToEmail === "string" && normalized.replyToEmail.trim().length > 0;
+
+  if (negative && normalized.negativeReviewEmailEnabled && hasReplyToEmail) {
     body = substituteReplyToEmail(body, normalized.replyToEmail);
+  } else if (!hasReplyToEmail) {
+    body = stripPlaceholderSentences(body);
   }
 
   // 3. Sign-off

--- a/tests/unit/api/dashboard/stats.test.ts
+++ b/tests/unit/api/dashboard/stats.test.ts
@@ -241,4 +241,108 @@ describe('GET /api/dashboard/stats', () => {
     expect(json.data.recentReviews[0].hasResponse).toBe(true);
     expect(json.data.recentReviews[1].hasResponse).toBe(false);
   });
+
+  // brandVoiceWarnings is surfaced so the dashboard can show the
+  // incomplete-config banner. Three cases: (a) toggle on + email missing
+  // → true, (b) toggle on + email present → false, (c) toggle off → false.
+  describe('brandVoiceWarnings.negativeEmailToggleOnButReplyToEmailMissing', () => {
+    it('returns true when toggle is ON and replyToEmail is null', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({
+        id: mockSession.user.id,
+        name: 'Test User',
+        tier: 'FREE',
+        isBetaUser: false,
+        credits: 15,
+        creditsResetDate: new Date(),
+        sentimentCredits: 35,
+        sentimentResetDate: new Date(),
+        brandVoice: { negativeReviewEmailEnabled: true, replyToEmail: null },
+        reviews: [],
+        _count: { reviews: 0 },
+      });
+      mockPrisma.reviewResponse.count.mockResolvedValue(0);
+      mockPrisma.review.groupBy.mockResolvedValue([]);
+
+      const res = await GET();
+      const json = await res.json();
+      expect(
+        json.data.brandVoiceWarnings.negativeEmailToggleOnButReplyToEmailMissing,
+      ).toBe(true);
+    });
+
+    it('returns false when toggle is ON and replyToEmail is configured', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({
+        id: mockSession.user.id,
+        name: 'Test User',
+        tier: 'FREE',
+        isBetaUser: false,
+        credits: 15,
+        creditsResetDate: new Date(),
+        sentimentCredits: 35,
+        sentimentResetDate: new Date(),
+        brandVoice: {
+          negativeReviewEmailEnabled: true,
+          replyToEmail: 'hello@brand.example',
+        },
+        reviews: [],
+        _count: { reviews: 0 },
+      });
+      mockPrisma.reviewResponse.count.mockResolvedValue(0);
+      mockPrisma.review.groupBy.mockResolvedValue([]);
+
+      const res = await GET();
+      const json = await res.json();
+      expect(
+        json.data.brandVoiceWarnings.negativeEmailToggleOnButReplyToEmailMissing,
+      ).toBe(false);
+    });
+
+    it('returns false when toggle is OFF (regardless of replyToEmail)', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({
+        id: mockSession.user.id,
+        name: 'Test User',
+        tier: 'FREE',
+        isBetaUser: false,
+        credits: 15,
+        creditsResetDate: new Date(),
+        sentimentCredits: 35,
+        sentimentResetDate: new Date(),
+        brandVoice: { negativeReviewEmailEnabled: false, replyToEmail: null },
+        reviews: [],
+        _count: { reviews: 0 },
+      });
+      mockPrisma.reviewResponse.count.mockResolvedValue(0);
+      mockPrisma.review.groupBy.mockResolvedValue([]);
+
+      const res = await GET();
+      const json = await res.json();
+      expect(
+        json.data.brandVoiceWarnings.negativeEmailToggleOnButReplyToEmailMissing,
+      ).toBe(false);
+    });
+
+    it('returns false when brandVoice is null (defaults to safe)', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({
+        id: mockSession.user.id,
+        name: 'Test User',
+        tier: 'FREE',
+        isBetaUser: false,
+        credits: 15,
+        creditsResetDate: new Date(),
+        sentimentCredits: 35,
+        sentimentResetDate: new Date(),
+        brandVoice: null,
+        reviews: [],
+        _count: { reviews: 0 },
+      });
+      mockPrisma.reviewResponse.count.mockResolvedValue(0);
+      mockPrisma.review.groupBy.mockResolvedValue([]);
+
+      const res = await GET();
+      const json = await res.json();
+      expect(
+        json.data.brandVoiceWarnings.negativeEmailToggleOnButReplyToEmailMissing,
+      ).toBe(false);
+    });
+  });
 });

--- a/tests/unit/components/dashboard/brand-voice-incomplete-banner.test.tsx
+++ b/tests/unit/components/dashboard/brand-voice-incomplete-banner.test.tsx
@@ -1,0 +1,141 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("next/link", () => ({
+  default: ({ children, href, ...props }: { children: React.ReactNode; href: string }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+import { BrandVoiceIncompleteBanner } from "@/components/dashboard/BrandVoiceIncompleteBanner";
+
+const TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+describe("BrandVoiceIncompleteBanner", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("renders nothing when warning is null", () => {
+    const { container } = render(
+      <BrandVoiceIncompleteBanner userId="user_1" warning={null} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when userId is missing", () => {
+    const { container } = render(
+      <BrandVoiceIncompleteBanner
+        userId={null}
+        warning="negativeEmailToggleOnButReplyToEmailMissing"
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the warning banner when warning is set and never dismissed", () => {
+    render(
+      <BrandVoiceIncompleteBanner
+        userId="user_1"
+        warning="negativeEmailToggleOnButReplyToEmailMissing"
+      />,
+    );
+
+    expect(
+      screen.getByText(/negative-review email invitations are dormant/i),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /open brand voice/i })).toHaveAttribute(
+      "href",
+      "/dashboard/settings/brand-voice",
+    );
+  });
+
+  it("hides the banner after the user clicks dismiss", () => {
+    render(
+      <BrandVoiceIncompleteBanner
+        userId="user_1"
+        warning="negativeEmailToggleOnButReplyToEmailMissing"
+      />,
+    );
+
+    expect(
+      screen.getByText(/negative-review email invitations are dormant/i),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /dismiss/i }));
+
+    expect(
+      screen.queryByText(/negative-review email invitations are dormant/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("persists the dismissal in localStorage scoped by user + warning", () => {
+    render(
+      <BrandVoiceIncompleteBanner
+        userId="user_1"
+        warning="negativeEmailToggleOnButReplyToEmailMissing"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /dismiss/i }));
+
+    const stored = window.localStorage.getItem(
+      "bv-incomplete-banner-dismissed:negativeEmailToggleOnButReplyToEmailMissing:user_1",
+    );
+    expect(stored).not.toBeNull();
+    expect(Number.parseInt(stored!, 10)).toBeGreaterThan(0);
+  });
+
+  it("does not render when the dismissal is fresh (within 7 days)", () => {
+    window.localStorage.setItem(
+      "bv-incomplete-banner-dismissed:negativeEmailToggleOnButReplyToEmailMissing:user_1",
+      String(Date.now()),
+    );
+
+    const { container } = render(
+      <BrandVoiceIncompleteBanner
+        userId="user_1"
+        warning="negativeEmailToggleOnButReplyToEmailMissing"
+      />,
+    );
+
+    expect(container.textContent).toBe("");
+  });
+
+  it("renders again when the dismissal is older than 7 days", () => {
+    window.localStorage.setItem(
+      "bv-incomplete-banner-dismissed:negativeEmailToggleOnButReplyToEmailMissing:user_1",
+      String(Date.now() - TTL_MS - 1000),
+    );
+
+    render(
+      <BrandVoiceIncompleteBanner
+        userId="user_1"
+        warning="negativeEmailToggleOnButReplyToEmailMissing"
+      />,
+    );
+
+    expect(
+      screen.getByText(/negative-review email invitations are dormant/i),
+    ).toBeInTheDocument();
+  });
+
+  it("scopes dismissal per user — a different user still sees the banner", () => {
+    window.localStorage.setItem(
+      "bv-incomplete-banner-dismissed:negativeEmailToggleOnButReplyToEmailMissing:user_1",
+      String(Date.now()),
+    );
+
+    render(
+      <BrandVoiceIncompleteBanner
+        userId="user_2"
+        warning="negativeEmailToggleOnButReplyToEmailMissing"
+      />,
+    );
+
+    expect(
+      screen.getByText(/negative-review email invitations are dormant/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/tests/unit/components/settings/brand-voice-form.test.tsx
+++ b/tests/unit/components/settings/brand-voice-form.test.tsx
@@ -320,6 +320,82 @@ describe("BrandVoiceForm (V2)", () => {
     expect(screen.getByLabelText(/reply-to email/i)).toBeInTheDocument();
   });
 
+  // Incomplete-config feedback: toggle on + email missing surfaces (a) the
+  // section-level banner at the top of Contact & sign-off and (b) the
+  // "Incomplete" pill next to the Negative-review email sub-block.
+  it("shows section-level incomplete banner when toggle is on but email is missing", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          data: {
+            brandVoice: {
+              ...mockBrandVoice,
+              negativeReviewEmailEnabled: true,
+              replyToEmail: null,
+            },
+          },
+        }),
+    });
+
+    render(<BrandVoiceForm />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/negative-review email is incomplete/i),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows the 'Incomplete' pill next to the Negative-review email sub-block when email is missing", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          data: {
+            brandVoice: {
+              ...mockBrandVoice,
+              negativeReviewEmailEnabled: true,
+              replyToEmail: null,
+            },
+          },
+        }),
+    });
+
+    render(<BrandVoiceForm />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/^incomplete$/i)).toBeInTheDocument();
+    });
+  });
+
+  it("hides the incomplete signals when toggle is on and a valid email is configured", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          data: {
+            brandVoice: {
+              ...mockBrandVoice,
+              negativeReviewEmailEnabled: true,
+              replyToEmail: "hello@brand.example",
+            },
+          },
+        }),
+    });
+
+    render(<BrandVoiceForm />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/how should our ai frame the invitation/i)).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByText(/negative-review email is incomplete/i),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/^incomplete$/i)).not.toBeInTheDocument();
+  });
+
   it("shows auto-save status indicator (Saved by default after load)", async () => {
     (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: true,

--- a/tests/unit/lib/ai/claude.test.ts
+++ b/tests/unit/lib/ai/claude.test.ts
@@ -44,7 +44,11 @@ const testBrandVoice = {
   negativeReviewEmailEnabled: false,
   negativeReviewFraming: 'investigation' as const,
   negativeReviewFramingCustom: null,
-  replyToEmail: null,
+  // Default to a real email so framing tests (which flip the toggle on)
+  // don't accidentally trip the incomplete-config guard added in the
+  // negative-email-incomplete-config-feedback work. The dormant-case
+  // tests below explicitly null this field.
+  replyToEmail: 'hello@brand.com',
 };
 
 const defaultParams = {
@@ -635,6 +639,69 @@ describe('claude.ts', () => {
           },
         });
         expect(getSystem()).toContain('team would like to look into');
+      });
+
+      // Incomplete-config guard: toggle on + replyToEmail null/empty/
+      // whitespace should treat the feature as dormant and not inject the
+      // framing at all. Otherwise the model would emit "[your email]" in
+      // the response and post-processing would have no email to swap in.
+      it('treats the feature as dormant when toggle is ON but replyToEmail is null', async () => {
+        await generateReviewResponse({
+          ...defaultParams,
+          rating: 1,
+          brandVoice: {
+            ...testBrandVoice,
+            negativeReviewEmailEnabled: true,
+            negativeReviewFraming: 'investigation',
+            replyToEmail: null,
+          },
+        });
+        expect(getSystem()).not.toContain('team would like to look into');
+      });
+
+      it('treats the feature as dormant when toggle is ON but replyToEmail is empty string', async () => {
+        await generateReviewResponse({
+          ...defaultParams,
+          rating: 1,
+          brandVoice: {
+            ...testBrandVoice,
+            negativeReviewEmailEnabled: true,
+            negativeReviewFraming: 'investigation',
+            replyToEmail: '',
+          },
+        });
+        expect(getSystem()).not.toContain('team would like to look into');
+      });
+
+      it('treats the feature as dormant when toggle is ON but replyToEmail is whitespace', async () => {
+        await generateReviewResponse({
+          ...defaultParams,
+          rating: 1,
+          brandVoice: {
+            ...testBrandVoice,
+            negativeReviewEmailEnabled: true,
+            negativeReviewFraming: 'investigation',
+            replyToEmail: '   ',
+          },
+        });
+        expect(getSystem()).not.toContain('team would like to look into');
+      });
+
+      it('also skips custom framing when toggle is ON but replyToEmail is missing', async () => {
+        await generateReviewResponse({
+          ...defaultParams,
+          rating: 1,
+          brandVoice: {
+            ...testBrandVoice,
+            negativeReviewEmailEnabled: true,
+            negativeReviewFraming: 'custom',
+            negativeReviewFramingCustom: 'Promise a free dessert on return.',
+            replyToEmail: null,
+          },
+        });
+        const system = getSystem();
+        expect(system).not.toContain('<<<USER_CONTENT_CUSTOM_FRAMING>>>');
+        expect(system).not.toContain('Promise a free dessert on return.');
       });
     });
 

--- a/tests/unit/lib/ai/post-process.test.ts
+++ b/tests/unit/lib/ai/post-process.test.ts
@@ -4,6 +4,7 @@ import {
   assembleResponse,
   buildSalutation,
   extractFirstName,
+  stripPlaceholderSentences,
   substituteReplyToEmail,
 } from "@/lib/ai/post-process";
 
@@ -145,6 +146,91 @@ describe("substituteReplyToEmail", () => {
   });
 });
 
+describe("stripPlaceholderSentences (defensive)", () => {
+  it("removes a single sentence containing [your email]", () => {
+    const out = stripPlaceholderSentences(
+      "Thanks for visiting. Please email [your email] with details. We hope to see you again.",
+    );
+    expect(out).toBe("Thanks for visiting. We hope to see you again.");
+  });
+
+  it("returns the body unchanged when no placeholder is present", () => {
+    const body = "Thanks for visiting. We hope to see you again.";
+    expect(stripPlaceholderSentences(body)).toBe(body);
+  });
+
+  it("handles case variants of the placeholder", () => {
+    const out = stripPlaceholderSentences(
+      "Thanks. Email [Your Email] please. Goodbye.",
+    );
+    expect(out).toBe("Thanks. Goodbye.");
+  });
+
+  it("preserves paragraph breaks when stripping mid-paragraph sentence", () => {
+    const out = stripPlaceholderSentences(
+      "Paragraph one.\n\nThanks. Please email [your email] with details. Bye.\n\nParagraph three.",
+    );
+    expect(out).toBe("Paragraph one.\n\nThanks. Bye.\n\nParagraph three.");
+  });
+
+  it("drops the whole paragraph when it was only the placeholder sentence", () => {
+    const out = stripPlaceholderSentences(
+      "Paragraph one.\n\nPlease email [your email].\n\nParagraph three.",
+    );
+    expect(out).toBe("Paragraph one.\n\nParagraph three.");
+  });
+});
+
+describe("assembleResponse — incomplete email config (defensive strip)", () => {
+  it("strips placeholder sentences when toggle is ON but replyToEmail is null", () => {
+    const out = assembleResponse({
+      modelBody:
+        "Thanks for visiting. Please email [your email] with details. We hope to see you again.",
+      brandVoice: {
+        ...baseBrandVoice,
+        negativeReviewEmailEnabled: true,
+        replyToEmail: null,
+      },
+      review: { ...baseReview, rating: 1 },
+    });
+
+    expect(out).not.toContain("[your email]");
+    expect(out).toContain("Thanks for visiting.");
+    expect(out).toContain("We hope to see you again.");
+  });
+
+  it("strips placeholder sentences even when toggle is OFF (sample/hallucination leak)", () => {
+    const out = assembleResponse({
+      modelBody:
+        "Thanks for visiting. Reach us at [your email]. We hope to see you again.",
+      brandVoice: {
+        ...baseBrandVoice,
+        negativeReviewEmailEnabled: false,
+        replyToEmail: null,
+      },
+      review: { ...baseReview, rating: 1 },
+    });
+
+    expect(out).not.toContain("[your email]");
+  });
+
+  it("still substitutes normally when toggle is ON AND email is configured", () => {
+    const out = assembleResponse({
+      modelBody:
+        "Thanks for visiting. Please email [your email] with details.",
+      brandVoice: {
+        ...baseBrandVoice,
+        negativeReviewEmailEnabled: true,
+        replyToEmail: "hello@brand.example",
+      },
+      review: { ...baseReview, rating: 1 },
+    });
+
+    expect(out).toContain("hello@brand.example");
+    expect(out).not.toContain("[your email]");
+  });
+});
+
 describe("assembleResponse — salutation + body + sign-off", () => {
   it("prepends the salutation, body, then sign-off in the right order", () => {
     const out = assembleResponse({
@@ -242,7 +328,14 @@ describe("assembleResponse — email substitution (spec §7.5)", () => {
     expect(out).not.toContain("hello@brand.example");
   });
 
-  it("does NOT substitute when the toggle is OFF, even on a negative review", () => {
+  it("does NOT substitute when the toggle is OFF, and strips the placeholder defensively", () => {
+    // Behaviour change from the incomplete-config feedback work:
+    // when there's no `replyToEmail`, the defensive strip removes any
+    // sentence containing `[your email]`. So neither the placeholder
+    // nor the email appears. (The toggle-OFF case usually means the
+    // model wouldn't have emitted the placeholder anyway, but if a
+    // sample response or hallucination leaked it, we don't ship the
+    // bracket text to the customer.)
     const out = assembleResponse({
       modelBody: "Please email [your email].",
       brandVoice: {
@@ -253,11 +346,21 @@ describe("assembleResponse — email substitution (spec §7.5)", () => {
       review: { ...baseReview, rating: 1 },
     });
 
+    // Toggle is off, so substitution does not fire. With email present,
+    // the strip's `!hasReplyToEmail` guard also does not fire — the
+    // placeholder is left in place (the toggle was off so the model was
+    // told not to emit it; if it slipped in anyway, that's a model bug,
+    // not a config-incomplete state).
     expect(out).toContain("[your email]");
     expect(out).not.toContain("hello@brand.example");
   });
 
-  it("does NOT substitute when replyToEmail is null, even with toggle on + negative review", () => {
+  it("strips the placeholder defensively when replyToEmail is null + toggle on + negative review", () => {
+    // This is the incomplete-config dormancy path. The prompt builder
+    // (claude.ts) already declines to inject the framing in this case,
+    // but the model could still leak the placeholder from a sample
+    // response. Post-processing strips the sentence so the bracket text
+    // never reaches the customer.
     const out = assembleResponse({
       modelBody: "Please email [your email].",
       brandVoice: {
@@ -268,7 +371,7 @@ describe("assembleResponse — email substitution (spec §7.5)", () => {
       review: { ...baseReview, rating: 1 },
     });
 
-    expect(out).toContain("[your email]");
+    expect(out).not.toContain("[your email]");
   });
 
   it("fires substitution on the Kiran case (4-star with negative sentiment)", () => {


### PR DESCRIPTION
## Summary

Fixes the functional bug where a user could enable the negative-review email toggle, forget to add a reply-to email, and ship live responses to customers containing the literal text `[your email]` in the body.

Four coordinated layers — defensive logic against the bug at two points, and visible feedback at three distances so the user genuinely can't miss the dormant state. This is the "I thought I configured it" failure mode the user flagged.

### Defensive logic (the AI never ships bracketed text)

- **Prompt builder (`claude.ts`)** — when the toggle is on but `replyToEmail` is null/empty/whitespace, the framing instruction is **not** injected. The model never even hears about email invitations, so it doesn't emit the placeholder. The toggle stays on (autosave is preserved); the feature lies dormant until the prerequisite is satisfied.
- **Post-processor (`post-process.ts`)** — belt-and-suspenders. If the model leaks `[your email]` anyway (e.g. from a sample response), `stripPlaceholderSentences` drops any sentence containing the placeholder. Paragraph breaks preserved.

### Visible feedback (the user can't miss the dormant state)

- **Section-level banner + "Incomplete" pill** on the brand voice page's Contact & sign-off section. Banner at the top of the section body; pill next to the Negative-review email sub-block eyebrow. Both fire from the same `isEmailConfigIncomplete` condition. The existing inline soft-warning at the email field stays.
- **Dashboard banner** (`BrandVoiceIncompleteBanner`). Renders on the dashboard when the warning is active. Dismissible — dismissal persists in `localStorage` keyed by user ID + warning, with a 7-day TTL so a long-running broken config eventually re-surfaces.

### API surface

`/api/dashboard/stats` now returns a `brandVoiceWarnings` object so the dashboard can render the banner without a second round-trip. Today it only ships `negativeEmailToggleOnButReplyToEmailMissing`; future incomplete-config flags slot alongside.

### Why these layers (not manual save, not a generation-time warning)

User-discussed earlier in the iteration:

- **Manual save** would fight the autosave model the rest of the app uses, breaks predictable "did this save?" expectations, and doesn't solve the general class of "valid-looking but broken" configurations.
- **Generation-time warning** mixes settings diagnostics into the response-review task, fires per review (noise), and pulls the user two pages away from where the fix lives.
- The market-standard pattern is **save partial state freely; make dependent action dormant; signal at the field + on a frequently-visited surface**. That's what this PR ships.

## Test plan

- [x] `npm run lint:strict` clean
- [x] `npm run type-check` clean
- [x] `npm run test:unit` — **1036 passed, 30 skipped, 0 failed** (64 files, +1 new test file for the banner).
- [ ] Visual check on staging Preview:
  - Enable the email toggle on brand voice without entering an email.
  - Confirm: the yellow inline hint, the "Incomplete" pill on the sub-block, AND the section-level banner all appear.
  - Navigate to `/dashboard`. Confirm: the yellow dashboard banner is present.
  - Click "Open brand voice" — it should land on `/dashboard/settings/brand-voice`.
  - Generate a response on a 1-star review. Confirm: the response does NOT contain `[your email]` and does NOT contain a fake email line.
  - Add a valid email back into brand voice. Confirm: all four signals disappear, and a new generation includes the configured email correctly substituted.
  - Dismiss the dashboard banner; navigate away and back; confirm it stays dismissed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
