### PR TITLE
refactor(ui): trim incomplete-feedback to two warnings + deep-link dashboard CTA

### DIFF
--- a/src/components/dashboard/BrandVoiceIncompleteBanner.tsx
+++ b/src/components/dashboard/BrandVoiceIncompleteBanner.tsx
@@ -101,7 +101,12 @@ export function BrandVoiceIncompleteBanner({
         </p>
         <div className="flex flex-wrap items-center gap-2 pt-1">
           <Button asChild size="sm" variant="outline" className="bg-card">
-            <Link href="/dashboard/settings/brand-voice">Open brand voice</Link>
+            {/* Deep-link to the Negative-review email sub-block anchor in
+                ContactSignoffSection so the user lands on the broken
+                control rather than the top of the brand voice page. */}
+            <Link href="/dashboard/settings/brand-voice#negative-review-email">
+              Open brand voice
+            </Link>
           </Button>
         </div>
       </div>

--- a/src/components/settings/BrandVoiceForm.tsx
+++ b/src/components/settings/BrandVoiceForm.tsx
@@ -119,6 +119,23 @@ export function BrandVoiceForm() {
     fetchBrandVoice();
   }, []);
 
+  // Honor a URL hash (e.g. `#negative-review-email`) by scrolling the
+  // target sub-block into view once the form has rendered. The browser's
+  // built-in hash navigation fires on initial page load before our async
+  // data fetch resolves, so the target element doesn't exist yet — by
+  // the time `isLoading` flips to false the browser has already given
+  // up. This effect re-runs the scroll itself.
+  useEffect(() => {
+    if (isLoading) return;
+    if (typeof window === "undefined" || !window.location.hash) return;
+    const id = window.location.hash.slice(1);
+    if (!id) return;
+    const el = document.getElementById(id);
+    if (el) {
+      el.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+  }, [isLoading]);
+
   const performSave = useCallback(async () => {
     if (!brandVoice) return;
 

--- a/src/components/settings/ContactSignoffSection.tsx
+++ b/src/components/settings/ContactSignoffSection.tsx
@@ -100,38 +100,16 @@ export function ContactSignoffSection({
   // Non-blocking; save still proceeds. The form's auto-save flow doesn't
   // change — this just surfaces an inline hint near the email input.
   //
-  // Incomplete-config feedback: the same condition now drives a section-
-  // level banner at the top of this section and an "Incomplete" pill next
-  // to the Negative-review email sub-block header, in addition to the
-  // existing inline hint near the email field. Three signals at three
-  // distances so the user doesn't forget the feature is dormant.
+  // Incomplete-config feedback: the same condition drives an "Incomplete"
+  // pill next to the Negative-review email sub-block header in addition
+  // to the existing inline hint near the email field. (The top-of-section
+  // banner was removed in the trim pass — three signals were too many.)
   const isEmailConfigIncomplete =
     negativeReviewEmailEnabled && (replyToEmail == null || replyToEmail.trim().length === 0);
   const showEmailMissingWarning = isEmailConfigIncomplete;
 
   return (
     <div className="space-y-6">
-      {/* Section-level incomplete banner. Appears at the top of the
-          Contact & sign-off section card body when the toggle is on but
-          the email is missing, so the state is unmissable on every
-          visit. The banner duplicates the inline soft-warning text by
-          design — the inline hint stays put (near the field where the
-          fix lives) and this banner adds top-of-section visibility. */}
-      {isEmailConfigIncomplete && (
-        <Alert
-          variant="default"
-          className="border-yellow-500/60 bg-yellow-500/10"
-          role="status"
-        >
-          <AlertCircle className="h-4 w-4 text-yellow-700" />
-          <AlertDescription className="text-xs">
-            <strong className="font-semibold">Negative-review email is incomplete.</strong>{" "}
-            The toggle is on, but no reply-to email is configured. AI responses
-            won&apos;t include the email invitation until you add one below — or
-            turn the toggle off.
-          </AlertDescription>
-        </Alert>
-      )}
 
       {/* Sub-block 1: Greeting & closing (§7.1 + §7.2)
           Inner-contrast pass — each sub-block is now its own bordered
@@ -205,8 +183,17 @@ export function ContactSignoffSection({
           Own bordered container matching sub-block 1. The conditional
           framing reveal stays nested inside this block (with its own
           tighter border) so the user sees "toggle expanded into more
-          controls within the same conceptual area". */}
-      <div className="rounded-lg border border-slate-300 bg-slate-50/50 p-4 space-y-4">
+          controls within the same conceptual area".
+
+          `id="negative-review-email"` makes this sub-block a deep-link
+          target — the dashboard `BrandVoiceIncompleteBanner` CTA lands
+          here directly so users with the incomplete config don't have
+          to scroll-hunt to the right control. `scroll-mt-24` keeps it
+          clear of the sticky dashboard header on hash navigation. */}
+      <div
+        id="negative-review-email"
+        className="scroll-mt-24 rounded-lg border border-slate-300 bg-slate-50/50 p-4 space-y-4"
+      >
         <div className="space-y-1">
           <div className="flex items-center gap-2">
             <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">

--- a/tests/unit/components/dashboard/brand-voice-incomplete-banner.test.tsx
+++ b/tests/unit/components/dashboard/brand-voice-incomplete-banner.test.tsx
@@ -46,9 +46,11 @@ describe("BrandVoiceIncompleteBanner", () => {
     expect(
       screen.getByText(/negative-review email invitations are dormant/i),
     ).toBeInTheDocument();
+    // Deep-link to the sub-block anchor so the user lands on the broken
+    // control rather than the top of the brand voice page.
     expect(screen.getByRole("link", { name: /open brand voice/i })).toHaveAttribute(
       "href",
-      "/dashboard/settings/brand-voice",
+      "/dashboard/settings/brand-voice#negative-review-email",
     );
   });
 

--- a/tests/unit/components/settings/brand-voice-form.test.tsx
+++ b/tests/unit/components/settings/brand-voice-form.test.tsx
@@ -321,9 +321,11 @@ describe("BrandVoiceForm (V2)", () => {
   });
 
   // Incomplete-config feedback: toggle on + email missing surfaces (a) the
-  // section-level banner at the top of Contact & sign-off and (b) the
-  // "Incomplete" pill next to the Negative-review email sub-block.
-  it("shows section-level incomplete banner when toggle is on but email is missing", async () => {
+  // "Incomplete" pill next to the Negative-review email sub-block and
+  // (b) the inline soft-warning at the email field. The earlier
+  // section-level banner at the top of Contact & sign-off was removed in
+  // the trim pass — three warnings on the same page were too many.
+  it("does NOT show a section-level incomplete banner anywhere (trimmed)", async () => {
     (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: true,
       json: () =>
@@ -340,11 +342,16 @@ describe("BrandVoiceForm (V2)", () => {
 
     render(<BrandVoiceForm />);
 
+    // The pill still appears, so we wait for that to confirm the
+    // incomplete state is detected before asserting the banner is
+    // absent.
     await waitFor(() => {
-      expect(
-        screen.getByText(/negative-review email is incomplete/i),
-      ).toBeInTheDocument();
+      expect(screen.getByText(/^incomplete$/i)).toBeInTheDocument();
     });
+
+    expect(
+      screen.queryByText(/negative-review email is incomplete/i),
+    ).not.toBeInTheDocument();
   });
 
   it("shows the 'Incomplete' pill next to the Negative-review email sub-block when email is missing", async () => {
@@ -390,10 +397,26 @@ describe("BrandVoiceForm (V2)", () => {
       expect(screen.getByText(/how should our ai frame the invitation/i)).toBeInTheDocument();
     });
 
-    expect(
-      screen.queryByText(/negative-review email is incomplete/i),
-    ).not.toBeInTheDocument();
     expect(screen.queryByText(/^incomplete$/i)).not.toBeInTheDocument();
+  });
+
+  // Anchor target for the dashboard banner deep-link. Click "Open brand
+  // voice" on the dashboard incomplete-config banner and the user lands
+  // on the sub-block directly — `#negative-review-email` is the id we
+  // attach to sub-block 2 in `ContactSignoffSection`.
+  it("attaches id='negative-review-email' to the Negative-review email sub-block", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ data: { brandVoice: mockBrandVoice } }),
+    });
+
+    render(<BrandVoiceForm />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Negative-review email")).toBeInTheDocument();
+    });
+
+    expect(document.getElementById("negative-review-email")).not.toBeNull();
   });
 
   it("shows auto-save status indicator (Saved by default after load)", async () => {


### PR DESCRIPTION
## Summary

Follow-up to #138. Two small UX refinements based on your testing:

### 1. Drop the section-4 top banner — three warnings was too many

You spotted that on the brand voice page, the same incomplete-config state was surfaced three times in the same view:

1. Section-level banner at the top of Contact & sign-off
2. "Incomplete" pill on the Negative-review email sub-block
3. Inline soft-warning beside the empty Reply-to email field

Removed the section-level banner. Kept the other two:
- The **pill** tells the user *which* control is incomplete.
- The **inline hint** tells the user *how* to fix it.

The dashboard banner is the third signal globally, but it lives on a separate page so it doesn't add to the local warning count.

### 2. Dashboard "Open brand voice" CTA now deep-links to the sub-block

The dashboard CTA used to land users at the top of the brand voice page, leaving them to scroll-hunt for the broken control. With Contact & sign-off being the lowest section, that's a lot of scrolling for someone who just clicked a warning that says "you have a problem here."

Three small changes wire this up:
- `ContactSignoffSection` — sub-block 2 carries `id="negative-review-email"` (with `scroll-mt-24` for sticky-header clearance).
- `BrandVoiceIncompleteBanner` — CTA href becomes `/dashboard/settings/brand-voice#negative-review-email`.
- `BrandVoiceForm` — a small `useEffect` honours the URL hash **after** the async fetch resolves. The browser's built-in hash-anchor scroll fires on initial page load, but by then our data fetch hasn't resolved and the target element doesn't exist yet — so the browser gives up. This effect re-runs the scroll once the form has rendered.

## Test plan

- [x] `npm run lint:strict` clean
- [x] `npm run type-check` clean
- [x] `npm run test:unit` — 1037 passed, 30 skipped, 0 failed (64 files). Negative assertion added confirming the section-level banner is gone; positive assertion added confirming the sub-block carries the deep-link anchor; dashboard banner href assertion updated.
- [ ] Visual check on staging Preview:
  - Enable the email toggle without entering an email. Confirm: only the pill + inline hint appear (no top-of-section banner).
  - Navigate to `/dashboard`. Click "Open brand voice" on the dashboard banner.
  - Confirm: the brand voice page loads and scrolls smoothly to the Negative-review email sub-block (not the top).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
