### PR TITLE
feat(ai): register-aware contractions guidance per tone + apology-formality rule

### DIFF
--- a/src/lib/ai/claude.ts
+++ b/src/lib/ai/claude.ts
@@ -156,6 +156,38 @@ function renderToneLabel(tone: string): string {
 }
 
 /**
+ * Tone-specific register guidance injected after the tone label. Today
+ * primarily about contractions ("we're" vs "we are") — `polished_formal`
+ * brands sound stiff if the model uses contractions; `warm_casual` brands
+ * sound stiff if it doesn't. The choice should follow the brand's tone
+ * preset.
+ *
+ * Iter-7 follow-up: the user flagged that contractions feel AI-frequent
+ * across all generations. They DO feel AI-frequent — but the actual issue
+ * is contractions used at the WRONG register, not contractions themselves.
+ * This helper ties register to tone so the model's default contraction
+ * behavior matches what the brand selected.
+ *
+ * Returns an empty string for unrecognised tone keys so the prompt stays
+ * valid (the upstream `normalizeBrandVoice` should already have mapped
+ * legacy values into the V2 set, but defensive default).
+ */
+function getRegisterGuidance(tone: string): string {
+  switch (tone as BrandVoiceToneV2) {
+    case "warm_casual":
+      return "Register: use contractions naturally (we're, we'll, it's, you're). Write the way you'd speak to a returning guest at the door.";
+    case "friendly_professional":
+      return "Register: moderate use of contractions is fine where they read naturally. Default to natural conversational English.";
+    case "polished_formal":
+      return "Register: avoid contractions. Write 'we are', not 'we're'. 'I will', not 'I'll'. 'We would', not 'we'd'. The slightly more formal cadence is what makes the response read polished.";
+    case "empathetic_attentive":
+      return "Register: lean slightly formal on apologies — fewer contractions when expressing regret ('we are deeply sorry', not 'we're deeply sorry'). Contractions are fine elsewhere if they read naturally.";
+    default:
+      return "";
+  }
+}
+
+/**
  * Render the ratingContext label that prefaces a sample response. "any" means
  * the sample applies to all reviews; 1–5 means the sample is a typical
  * response to a review of that star rating.
@@ -309,6 +341,14 @@ IMPORTANT INSTRUCTIONS:
 
 BRAND VOICE CONFIGURATION:
 - Tone: ${renderToneLabel(brandVoice.tone)}`;
+
+  // Register guidance — primarily contractions ("we're" vs "we are"). Tone-
+  // preset specific, so casual brands sound natural and formal brands
+  // sound polished without a universal contraction ban.
+  const registerGuidance = getRegisterGuidance(brandVoice.tone);
+  if (registerGuidance) {
+    prompt += `\n- ${registerGuidance}`;
+  }
 
   // Optional one-time tone override (regeneration with a different register).
   if (toneModifier) {

--- a/src/lib/ai/structure-templates.ts
+++ b/src/lib/ai/structure-templates.ts
@@ -134,7 +134,8 @@ Specificity is required, not optional:
 
 Register:
 - Write as a manager apologising in person, not as a corporate statement. Acknowledge briefly, commit briefly, close hopefully. Do not theatrically self-flagellate.
-- DO NOT self-criticise in the reply. Acknowledge that the issue happened, but do NOT state what we should have done differently, do NOT characterise our team or service as having failed, and do NOT volunteer operational fixes. A manager apologising in person says "I'm sorry this happened" — they do not list our shortcomings in public.`;
+- DO NOT self-criticise in the reply. Acknowledge that the issue happened, but do NOT state what we should have done differently, do NOT characterise our team or service as having failed, and do NOT volunteer operational fixes. A manager apologising in person says "I'm sorry this happened" — they do not list our shortcomings in public.
+- Lean slightly more formal than the brand's usual tone when expressing the apology itself. Apologies land with more weight in measured language — prefer "we are deeply sorry" over "we're deeply sorry" in the apology paragraph, even when the brand's tone usually allows contractions. Outside the apology paragraph, the brand's normal register applies.`;
 
 const TEMPLATES: Record<StructureTemplateKey, string> = {
   positive: POSITIVE_TEMPLATE,

--- a/tests/unit/lib/ai/claude.test.ts
+++ b/tests/unit/lib/ai/claude.test.ts
@@ -884,5 +884,64 @@ describe('claude.ts', () => {
         expect(getSystem()).toContain('Friendly & professional');
       });
     });
+
+    // 5/25 prompt-tuning iter-2 follow-up — register guidance per tone.
+    // Contractions are not a universal AI tell; they're a register issue.
+    // The model now gets explicit guidance based on the brand's tone
+    // preset, so casual brands sound natural and formal brands stay
+    // polished without a blanket contraction ban.
+    describe('per-tone register guidance (contractions)', () => {
+      it('injects no-contraction guidance for polished_formal', async () => {
+        await generateReviewResponse({
+          ...defaultParams,
+          brandVoice: { ...testBrandVoice, tone: 'polished_formal' },
+        });
+        const system = getSystem();
+        expect(system.toLowerCase()).toContain('avoid contractions');
+        expect(system).toContain("'we are', not 'we're'");
+      });
+
+      it('injects use-contractions guidance for warm_casual', async () => {
+        await generateReviewResponse({
+          ...defaultParams,
+          brandVoice: { ...testBrandVoice, tone: 'warm_casual' },
+        });
+        const system = getSystem();
+        expect(system.toLowerCase()).toContain('use contractions naturally');
+      });
+
+      it('injects moderate-contractions guidance for friendly_professional', async () => {
+        await generateReviewResponse({
+          ...defaultParams,
+          brandVoice: { ...testBrandVoice, tone: 'friendly_professional' },
+        });
+        const system = getSystem();
+        expect(system.toLowerCase()).toContain('moderate use of contractions');
+      });
+
+      it('injects formal-on-apologies guidance for empathetic_attentive', async () => {
+        await generateReviewResponse({
+          ...defaultParams,
+          brandVoice: { ...testBrandVoice, tone: 'empathetic_attentive' },
+        });
+        const system = getSystem();
+        expect(system.toLowerCase()).toContain('lean slightly formal on apologies');
+        expect(system.toLowerCase()).toContain('fewer contractions when expressing regret');
+      });
+
+      it('falls back to the default register guidance when given an unknown tone', async () => {
+        await generateReviewResponse({
+          ...defaultParams,
+          brandVoice: { ...testBrandVoice, tone: 'made_up_tone' as unknown as string },
+        });
+        const system = getSystem();
+        // `normalizeBrandVoice` runs upstream and maps unknown tone keys
+        // to the default V2 key (friendly_professional). So the unknown
+        // tone gets the friendly_professional register guidance, not
+        // empty guidance — this preserves a predictable register signal
+        // even on bad inputs.
+        expect(system.toLowerCase()).toContain('moderate use of contractions');
+      });
+    });
   });
 });

--- a/tests/unit/lib/ai/structure-templates.test.ts
+++ b/tests/unit/lib/ai/structure-templates.test.ts
@@ -182,6 +182,17 @@ describe("getStructureTemplate", () => {
     const out = getStructureTemplate({ rating: 1, sentiment: null });
     expect(out.toLowerCase()).toContain("must not end on the apology");
   });
+
+  // 5/25 prompt-tuning iter-2 follow-up — register-aware contractions.
+  // The apology paragraph specifically leans slightly more formal than
+  // the brand's usual tone, even when the brand's tone allows
+  // contractions. Apologies land with more weight in measured language.
+  it("requires the apology paragraph to lean slightly more formal than the brand's usual tone", () => {
+    const out = getStructureTemplate({ rating: 1, sentiment: null });
+    expect(out.toLowerCase()).toContain("lean slightly more formal");
+    expect(out.toLowerCase()).toContain("we are deeply sorry");
+    expect(out.toLowerCase()).toContain("we're deeply sorry");
+  });
 });
 
 describe("UNIVERSAL_STRUCTURAL_RULES", () => {


### PR DESCRIPTION
## Summary

You flagged that contractions ("I'm", "I'll", "we're", "I'd") feel AI-frequent in generated responses. After discussion we landed on a more nuanced fix than a universal ban:

**Contractions aren't a universal AI tell — they're a register issue.** Casual brands (Chicken Shop's own replies use "we're thrilled" and "we'll be sure to") should naturally use contractions. Premium/formal brands (Aqua Shard's own replies use "we are extremely disappointed") should naturally avoid them. The same contraction is wrong for one brand and right for another. A blanket ban would force casual brands to sound stiffer than their own human-written replies.

The gate is the brand's tone preset, not the contraction itself.

### Two coordinated changes

**1. Per-tone register guidance** — new `getRegisterGuidance(tone)` helper in `claude.ts` injects a tone-specific sentence right after the tone label in the prompt:

| Tone | Guidance |
|---|---|
| `warm_casual` | "use contractions naturally (we're, we'll, ...)" |
| `friendly_professional` | "moderate use of contractions is fine where they read naturally" |
| `polished_formal` | "avoid contractions — 'we are', not 'we're'" |
| `empathetic_attentive` | "lean slightly formal on apologies — fewer contractions when expressing regret" |

For brands without uploaded samples, this drives default contraction behaviour from the tone they selected.

**2. Apology-formality rule on negative reviews** — added to the negative template's Register block:

> "Lean slightly more formal than the brand's usual tone when expressing the apology itself. Prefer 'we are deeply sorry' over 'we're deeply sorry' in the apology paragraph, even when the brand's tone usually allows contractions. Outside the apology paragraph, the brand's normal register applies."

Even on a casual brand, the apology sentence pulls one notch more formal because apologies land with more weight in measured language. This is the apology-specific layer that complements the per-tone guidance.

### What this does NOT do

- Universal contraction ban — explicitly rejected. The Chicken Shop case proves contractions can be the right choice.
- Per-language contraction rules — out of scope. Contractions are an English-specific concept; other languages have their own formality markers and the model handles those natively.
- Override sample responses — when samples are uploaded, the existing "samples teach voice" principle means the model will follow the sample's contraction usage. The tone-preset register guidance is the default-behaviour anchor.

## Test plan

- [x] `npm run lint:strict` clean
- [x] `npm run type-check` clean
- [x] `npm run test:unit` — **1078 passed, 30 skipped, 0 failed** (64 files). 6 new assertions: 5 for per-tone register injection, 1 for apology-formality rule.
- [ ] **Round-trip on Preview** (post-merge): regenerate the 6 spreadsheet reviews and confirm:
  - Aqua Shard responses (configured `friendly_professional` by default, but premium-register brand) — fewer contractions in apologies; "we are deeply sorry" rather than "we're".
  - Chicken Shop responses — contractions used naturally where they fit.
  - Spot-check that polished_formal tone, if selected on Aqua Shard, removes contractions wholesale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
