### PR TITLE
feat(ai): business-agnostic CONTEXT block + broadened occasion fragment (scope-of-apology fix)

### DIFF
--- a/src/lib/ai/claude.ts
+++ b/src/lib/ai/claude.ts
@@ -332,6 +332,13 @@ function buildSystemPrompt(args: {
 
   let prompt = `You are a customer service representative writing responses to customer reviews.
 
+CONTEXT — what's actually happening:
+A customer interacted with a business (a meal, a stay, a purchase, an appointment, an experience). After that interaction, they left a public review of it. You are writing the business's public reply to that specific review.
+
+The review may mention surrounding context — a trip, an anniversary, a milestone, the reason behind the visit, the people they were with. That context is what the interaction meant to the customer; it is NOT something the business is responsible for. The business's reply is always scoped to the interaction itself: the service, the staff, the experience with the business. The reply may acknowledge surrounding context as meaningful to the customer, but the apology, the commitment, and the forward-look are about the business's own service — not the broader occasion, trip, or evening.
+
+Example scope error to avoid (taken from a real generation): writing "I sincerely apologize that your partner's birthday celebration and your family's first visit to London didn't meet expectations." The business does not apologise for the trip to London — they apologise for the dining experience at the restaurant. The first visit to London is context; the experience at the restaurant is the scope.
+
 IMPORTANT INSTRUCTIONS:
 1. Write the response in ${language} (the same language as the review).
 2. Keep the response body between 500 and 750 characters. Communicate in fewer sentences — do not pad (max ${RESPONSE_BODY_CHAR_MAX} characters as a hard backstop).

--- a/src/lib/ai/structure-templates.ts
+++ b/src/lib/ai/structure-templates.ts
@@ -157,7 +157,7 @@ export const NAMED_STAFF_FRAGMENT =
   "If the reviewer mentions a staff member by name, thank them specifically and note that you'll share the feedback with that person.";
 
 export const OCCASION_FRAGMENT =
-  "If the reviewer mentions a special occasion (birthday, anniversary, first visit, returning visit), acknowledge it specifically in the response.";
+  "If the reviewer mentions a special occasion (birthday, anniversary, milestone) or a meaningful reason for the interaction (first time using the business, a returning customer, a long-anticipated visit, a significant purchase), acknowledge it specifically. Acknowledgement is about recognising what the interaction meant to the customer — it does NOT extend the scope of any apology, commitment, or forward-look to the broader context (the trip, the milestone year, the occasion as a whole). Those stay scoped to the interaction with the business.";
 
 export type NegativeReviewFraming =
   | "management_contact"

--- a/tests/unit/lib/ai/claude.test.ts
+++ b/tests/unit/lib/ai/claude.test.ts
@@ -447,6 +447,60 @@ describe('claude.ts', () => {
       return mockCreate.mock.calls[0][0].system as string;
     }
 
+    // 5/25 prompt-tuning iter-2 follow-up — top-level business-agnostic
+    // context block at the very top of the system prompt. Sets the
+    // conceptual frame (interaction vs. surrounding context) so the
+    // model scopes apologies/commitments to the business's own service
+    // rather than the broader trip/occasion. Generalises across business
+    // types (hospitality, retail, services, SaaS) so the rules don't
+    // pre-code restaurant-specific framing.
+    describe('top-level context block', () => {
+      it('introduces the interaction-vs-context distinction', async () => {
+        await generateReviewResponse(defaultParams);
+        const system = getSystem();
+        expect(system).toContain("CONTEXT — what's actually happening");
+        expect(system.toLowerCase()).toContain('interacted with a business');
+        expect(system.toLowerCase()).toContain('the business\'s reply is always scoped to the interaction itself');
+      });
+
+      it('uses business-agnostic vocabulary (meal/stay/purchase/appointment), not restaurant-coded', async () => {
+        await generateReviewResponse(defaultParams);
+        const system = getSystem();
+        // Whitelist of neutral terms in the context block.
+        expect(system.toLowerCase()).toContain('a meal, a stay, a purchase, an appointment');
+        // The context block uses neutral framing — explicitly avoids
+        // hardcoding "restaurant" as the only business type.
+        const contextBlockMatch = system.match(/CONTEXT — what's actually happening[\s\S]+?(?=IMPORTANT INSTRUCTIONS)/);
+        expect(contextBlockMatch).not.toBeNull();
+        const contextBlock = (contextBlockMatch?.[0] ?? '').toLowerCase();
+        // The context block should mention "business" generically rather
+        // than coding the business model as a restaurant. The "London"
+        // example phrase IS allowed because it's referencing a concrete
+        // observed scope error — that's documentation, not framing.
+        expect(contextBlock).toContain('business');
+      });
+
+      it('explicitly flags the London-trip scope error as the example to avoid', async () => {
+        await generateReviewResponse(defaultParams);
+        const system = getSystem();
+        // Real example from a generation: model included "first visit
+        // to London" in the apology's scope. Reproduced in the prompt
+        // so the model has a concrete example of the mistake it should
+        // NOT make.
+        expect(system).toContain("first visit to London");
+        expect(system.toLowerCase()).toContain('the business does not apologise for the trip');
+      });
+
+      it('places the context block ABOVE the IMPORTANT INSTRUCTIONS section', async () => {
+        await generateReviewResponse(defaultParams);
+        const system = getSystem();
+        const contextIdx = system.indexOf("CONTEXT — what's actually happening");
+        const instructionsIdx = system.indexOf('IMPORTANT INSTRUCTIONS');
+        expect(contextIdx).toBeGreaterThanOrEqual(0);
+        expect(instructionsIdx).toBeGreaterThan(contextIdx);
+      });
+    });
+
     describe('style guidelines (the headline JSON-render bug fix)', () => {
       it('renders styleGuidelines as a bullet list, NOT as JSON', async () => {
         await generateReviewResponse({

--- a/tests/unit/lib/ai/structure-templates.test.ts
+++ b/tests/unit/lib/ai/structure-templates.test.ts
@@ -260,11 +260,33 @@ describe("NAMED_STAFF_FRAGMENT", () => {
 });
 
 describe("OCCASION_FRAGMENT", () => {
-  it("instructs the model to acknowledge birthdays/anniversaries/first/returning visits", () => {
+  // 5/25 prompt-tuning iter-2 follow-up — broadened to cover non-
+  // hospitality businesses (retail, services, SaaS support). The
+  // hospitality-specific cases (birthday, anniversary) stay, but
+  // "first visit / returning visit" are now generalised to
+  // "first time using the business / returning customer" so the
+  // fragment doesn't pre-code a visit-based business model.
+  it("acknowledges hospitality-shaped occasions (birthdays, anniversaries, milestones)", () => {
     expect(OCCASION_FRAGMENT).toContain("birthday");
     expect(OCCASION_FRAGMENT).toContain("anniversary");
-    expect(OCCASION_FRAGMENT).toContain("first visit");
-    expect(OCCASION_FRAGMENT).toContain("returning visit");
+    expect(OCCASION_FRAGMENT).toContain("milestone");
+  });
+
+  it("covers non-visit business models (first-time customers, returning customers, significant purchases)", () => {
+    expect(OCCASION_FRAGMENT).toContain("first time using the business");
+    expect(OCCASION_FRAGMENT).toContain("returning customer");
+    expect(OCCASION_FRAGMENT).toContain("significant purchase");
+  });
+
+  // Scope-of-acknowledgement rule: the occasion fragment now explicitly
+  // says the acknowledgement does NOT extend the scope of the apology
+  // or commitment to the surrounding context. This is the same principle
+  // as the top-level context block in claude.ts but applied at the
+  // fragment level so the model sees it both globally and locally.
+  it("forbids extending scope of apology/commitment to the broader context", () => {
+    expect(OCCASION_FRAGMENT.toLowerCase()).toContain("does not extend the scope");
+    expect(OCCASION_FRAGMENT.toLowerCase()).toContain("the broader context");
+    expect(OCCASION_FRAGMENT.toLowerCase()).toContain("stay scoped to the interaction with the business");
   });
 });
 


### PR DESCRIPTION
## Summary

You spotted a real scope error in a generated response:

> *"I sincerely apologize that your partner's birthday celebration and your family's first visit to London didn't meet expectations."*

The business doesn't apologise for the trip to London. They apologise for the dining experience at the restaurant. The model collapsed two things — *surrounding context* ("first time visiting London") and *the thing being apologised for* (the dinner at Aqua Shard) — into one sentence.

This is a category error the model makes when it engages with reviewer context too literally. It picks up surrounding context (a trip, an anniversary, a milestone) and includes it in the apology's scope, when the apology should narrowly be about what the business controls.

You then made three sharper observations:

1. **It applies on positives too, not just negatives** — a model saying *"thank you for choosing us for your wedding anniversary year"* makes the same error in reverse.
2. **The model needs upstream context, not downstream rules** — explain *what's happening* so the model can derive correct behaviour, rather than enumerating every wrong pattern.
3. **We're scaling beyond hospitality** — the framing must work for retail, services, SaaS support, not just restaurants.

This PR ships the fix.

### Three coordinated changes

**1. New top-level CONTEXT block in the system prompt** (claude.ts):

```
CONTEXT — what's actually happening:
A customer interacted with a business (a meal, a stay, a purchase, an
appointment, an experience). After that interaction, they left a public
review of it. You are writing the business's public reply to that
specific review.

The review may mention surrounding context — a trip, an anniversary, a
milestone, the reason behind the visit, the people they were with. That
context is what the interaction meant to the customer; it is NOT
something the business is responsible for. The business's reply is
always scoped to the interaction itself: the service, the staff, the
experience with the business. The reply may acknowledge surrounding
context as meaningful to the customer, but the apology, the commitment,
and the forward-look are about the business's own service — not the
broader occasion, trip, or evening.

Example scope error to avoid (taken from a real generation): writing "I
sincerely apologize that your partner's birthday celebration and your
family's first visit to London didn't meet expectations." The business
does not apologise for the trip to London — they apologise for the
dining experience at the restaurant. The first visit to London is
context; the experience at the restaurant is the scope.
```

Goes at the very top of the prompt — above IMPORTANT INSTRUCTIONS, above BRAND VOICE CONFIGURATION. Sets the conceptual frame everything else operates in.

Includes the real London example as a documented "scope error to avoid" so the model has a concrete anchor for the mistake it should NOT make.

**Vocabulary is deliberately business-agnostic** — "a meal, a stay, a purchase, an appointment, an experience" covers hospitality, retail, services, SaaS support. The framing scales to non-restaurant customers without re-coding.

**2. Broadened OCCASION_FRAGMENT** (structure-templates.ts):

Previous wording used hospitality-coded terms ("first visit", "returning visit"). New wording covers more business models:
- Special occasions: birthday, anniversary, milestone (hospitality-friendly)
- Meaningful reasons: first time using the business, returning customer, long-anticipated visit, significant purchase (covers non-hospitality)

Plus an explicit scope-of-acknowledgement rule layered into the fragment itself — the interaction-vs-context distinction reinforced at the fragment level so the model sees it both globally (in the context block) and locally (when occasion-acknowledgement is being triggered).

**3. Drop restaurant-specific example** — turned out the iter-2 anti-self-criticism wording was already business-agnostic. No change needed.

### What this does NOT do

- **Refactor the rest of the prompt for business-agnostic phrasing** — too speculative. We don't have non-hospitality customers yet. Touch only what was clearly biased (the occasion fragment).
- **Add separate templates per business type** — not needed; the universal framing in the context block + the fragment-level rules cover the patterns we know about.

## Test plan

- [x] `npm run lint:strict` clean
- [x] `npm run type-check` clean
- [x] `npm run test:unit` — **1084 passed, 30 skipped, 0 failed** (64 files). 7 new assertions: 4 for the top-level context block, 3 for the broadened occasion fragment.
- [ ] **Round-trip on Preview** (post-merge): regenerate Hema's review and confirm:
  - The "first visit to London" framing is gone from the apology scope.
  - The acknowledgement of the special-occasion / first-visit context remains, but separately from the apology's scope.
  - No regressions on the other 5 spreadsheet reviews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
