### PR TITLE
feat: drop per-regen tone selector — brand voice tone applies, Additional Instructions is the only knob

### DIFF
--- a/src/app/api/reviews/[id]/regenerate/route.ts
+++ b/src/app/api/reviews/[id]/regenerate/route.ts
@@ -13,19 +13,14 @@ interface RouteParams {
   params: Promise<{ id: string }>;
 }
 
-// Iter 6 cutover: tone accepts the V2 4-key set (matches the brand-voice
-// form's tone selector exactly, per spec §8.1). `additionalInstructions`
-// is the new free-text per-regeneration directive — not persisted, capped
-// at 500 chars. The route forwards it as `customRegenerateInstructions`
-// to claude.ts where the iter-1 sanitize helper wraps it before injecting
-// into the user prompt.
+// 5/25 simplification: the per-regeneration tone override was removed
+// from the dialog. The brand voice tone applies as configured; users
+// who want a one-off register change use the Additional Instructions
+// free-text field. `additionalInstructions` stays as the only per-
+// regeneration knob — capped at 500 chars, not persisted, wrapped via
+// the sanitize helper in claude.ts before injection into the user
+// prompt.
 const regenerateSchema = z.object({
-  tone: z.enum([
-    "warm_casual",
-    "friendly_professional",
-    "polished_formal",
-    "empathetic_attentive",
-  ]),
   additionalInstructions: z.string().max(500).optional(),
 });
 
@@ -67,7 +62,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
           success: false,
           error: {
             code: "VALIDATION_ERROR",
-            message: "Tone is required. Must be one of: professional, friendly, empathetic",
+            message: "Invalid regenerate request body.",
             details: validationResult.error.issues,
           },
         },
@@ -75,7 +70,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       );
     }
 
-    const { tone, additionalInstructions } = validationResult.data;
+    const { additionalInstructions } = validationResult.data;
 
     // Get user with credits
     const user = await prisma.user.findUnique({
@@ -164,14 +159,17 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     // Get brand voice
     const brandVoice = await getOrCreateBrandVoice(session.user.id);
 
-    // Generate new response with tone modifier
+    // Generate new response — brand voice tone applies as configured.
     // E2E mock opt-in (header gate — see DECISIONS.md #61).
     const e2eMockOptIn = request.headers.get("x-e2e-mock") === "1";
 
-    // Iter 4: pass the V2 brand voice row directly; the iter-3 V2→legacy
-    // projection is gone (DECISION 55). Sentiment is forwarded so the
-    // rating-conditional structure router can pick the right template
-    // (sentiment overrides rating — see spec §9.5).
+    // Iter 4: pass the V2 brand voice row directly. Sentiment is forwarded
+    // so the rating-conditional structure router can pick the right
+    // template (sentiment overrides rating — see spec §9.5).
+    //
+    // 5/25 simplification: `toneModifier` is no longer forwarded. The
+    // brand voice tone is applied via the brandVoice arg; per-regen
+    // overrides go through `customRegenerateInstructions` (free text).
     let generatedResponse;
     try {
       generatedResponse = await generateReviewResponse({
@@ -181,7 +179,6 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
         sentiment: review.sentiment,
         detectedLanguage: review.detectedLanguage,
         brandVoice,
-        toneModifier: tone,
         // Iter 6: forward the per-regeneration free-text directive to the
         // iter-1 sanitize-wrapped slot in claude.ts. Single-use, not
         // persisted; ZOD-capped at 500 chars upstream.
@@ -231,7 +228,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
         platform: review.platform,
         rating: review.rating,
         previousTone: review.response.toneUsed,
-        newTone: tone,
+        newTone: brandVoice.tone,
         regeneratedAt: new Date().toISOString(),
       }
     );
@@ -272,7 +269,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
         where: { id: review.response!.id },
         data: {
           responseText,
-          toneUsed: tone,
+          toneUsed: brandVoice.tone,
           generationModel: generatedResponse.model || DEFAULT_MODEL,
           creditsUsed: CREDIT_COSTS.REGENERATE_RESPONSE,
           isEdited: false, // Reset edited flag on regeneration

--- a/src/components/reviews/ResponsePanel.tsx
+++ b/src/components/reviews/ResponsePanel.tsx
@@ -173,7 +173,6 @@ export function ResponsePanel({
   };
 
   const handleRegenerate = async (payload: {
-    tone: "warm_casual" | "friendly_professional" | "polished_formal" | "empathetic_attentive";
     additionalInstructions?: string;
   }) => {
     setIsLoading(true);
@@ -200,10 +199,17 @@ export function ResponsePanel({
             : null
         );
         toast.success(`Response regenerated!`);
-        // PostHog: response_regenerated. Tone is one of the V2 4-key set
-        // (post-iter-6); additionalInstructions presence is the only other
-        // signal we currently surface as an event property.
-        trackResponseRegenerated({ tone: payload.tone });
+        // PostHog: response_regenerated. The dialog no longer carries a
+        // per-regeneration tone override (5/25 simplification — the brand
+        // voice tone applies as configured). Report the tone the server
+        // persisted, which is the brand voice tone for default regens.
+        trackResponseRegenerated({
+          tone: result.data.response.toneUsed as
+            | "warm_casual"
+            | "friendly_professional"
+            | "polished_formal"
+            | "empathetic_attentive",
+        });
         refreshCredits();
         onResponseUpdate?.(); // This will fetch fresh data including the new version
       } else {

--- a/src/components/reviews/ToneModifier.tsx
+++ b/src/components/reviews/ToneModifier.tsx
@@ -11,46 +11,37 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
-import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import { Sparkles, Briefcase, Smile, Heart, Coffee } from "lucide-react";
-import {
-  BRAND_VOICE_TONES_V2,
-  BRAND_VOICE_TONE_INFO_V2,
-  type BrandVoiceToneV2,
-} from "@/lib/constants";
+import { Sparkles } from "lucide-react";
 
 /**
- * Regenerate dialog (iter 6).
+ * Regenerate dialog.
  *
- * Spec §8.1 — the tone-modifier presets now match the four V2 brand voice
- * tones exactly (`warm_casual`, `friendly_professional`, `polished_formal`,
- * `empathetic_attentive`). The legacy `apologetic` option is dropped
- * because (a) it duplicated the empathetic preset semantically and (b) the
- * iter-4 prompt builder treats apology as content-routed via the structure
- * templates, not as a register.
+ * 5/25 simplification — the per-regeneration tone selector was removed.
  *
- * Spec §8.2 — a new "Additional instructions" textarea (free text, 500
- * char cap, single-use, not persisted) lets the user attach a per-
- * regeneration directive like "mention our loyalty program once" or
- * "address the dessert complaint specifically". The value is sent in the
- * regenerate request body as `additionalInstructions` and forwarded to
- * the iter-1 `customRegenerateInstructions` slot on `claude.ts`, which
- * wraps it via the sanitize helper before injecting into the user prompt.
+ * The previous version of this dialog let users override the brand voice
+ * tone for a single regeneration. In practice, businesses set a brand
+ * voice tone once and keep it stable; the per-regeneration override was
+ * duplicating a setting that already exists on the brand voice page. The
+ * one legitimate edge case (tonally mismatched review where the manager
+ * wants to break brand voice for one reply) is served just as well by
+ * the Additional Instructions textarea ("respond more warmly for this
+ * one") with even more flexibility than picking a preset.
+ *
+ * What stays:
+ *  - Additional Instructions textarea (free text, 500 char cap, single-
+ *    use, not persisted). Wrapped via the sanitize helper before
+ *    injection into the user prompt (see claude.ts customRegenerate-
+ *    Instructions slot).
+ *  - Brand voice tone applies as configured. No user input on tone in
+ *    this dialog.
  */
-const TONE_ICONS: Record<BrandVoiceToneV2, React.ReactNode> = {
-  warm_casual: <Coffee className="h-4 w-4" />,
-  friendly_professional: <Smile className="h-4 w-4" />,
-  polished_formal: <Briefcase className="h-4 w-4" />,
-  empathetic_attentive: <Heart className="h-4 w-4" />,
-};
 
 export const ADDITIONAL_INSTRUCTIONS_MAX = 500;
 
 interface ToneModifierProps {
   onRegenerate: (_payload: {
-    tone: BrandVoiceToneV2;
     additionalInstructions?: string;
   }) => Promise<void>;
   isLoading?: boolean;
@@ -65,14 +56,12 @@ export function ToneModifier({
   creditsNeeded = 1.0,
 }: ToneModifierProps) {
   const [open, setOpen] = useState(false);
-  const [selectedTone, setSelectedTone] = useState<BrandVoiceToneV2>("friendly_professional");
   const [additionalInstructions, setAdditionalInstructions] = useState("");
   const instructionsRef = useRef<HTMLTextAreaElement>(null);
 
   const handleRegenerate = async () => {
     const trimmed = additionalInstructions.trim();
     await onRegenerate({
-      tone: selectedTone,
       additionalInstructions: trimmed.length > 0 ? trimmed : undefined,
     });
     setOpen(false);
@@ -98,33 +87,20 @@ export function ToneModifier({
         </Button>
       </DialogTrigger>
       {/*
-        Dialog sizing:
-          - `sm:max-w-2xl` widens the dialog at tablet+ so the 2-col tone
-            grid has room to breathe without forcing the descriptions to
-            wrap aggressively.
-          - `max-h-[90vh]` caps the overall height to 90% of the viewport
-            so the dialog never overflows on short screens. Combined with
-            `flex flex-col` on the content and `flex-1 overflow-y-auto`
-            on the body region, the header + footer stay anchored while
-            the tone grid + additional-instructions block scroll internally
-            when needed.
-      */}
-      {/*
-        Iter 6 follow-up — the description text was trimmed from a two-line
-        wordy summary to a single short scope note, the "Current tone" line
-        was removed (it was rarely useful and ate vertical space), and the
-        field order was swapped so the more-commonly-used Additional
-        instructions textarea sits above the tone grid and is autofocused
-        when the dialog opens. The tone grid now sits below the textarea
-        but most of it is still above the fold on a typical viewport.
+        Dialog sizing after tone-selector removal:
+          - `sm:max-w-2xl` retained — the textarea reads better with width.
+          - No more `max-h-[90vh] flex flex-col flex-1 overflow-y-auto` —
+            without the tone grid the dialog content is short enough to
+            never overflow a typical viewport. Removed the scrollable
+            body region entirely.
       */}
       <DialogContent
-        className="flex max-h-[90vh] flex-col sm:max-w-2xl"
+        className="sm:max-w-2xl"
         onOpenAutoFocus={(event) => {
           // Default Radix behaviour focuses the first focusable element
-          // (which would be the Close × in the corner). Override to put
-          // the cursor in the Additional instructions textarea — the
-          // primary input for this dialog.
+          // (the Close × in the corner). Override to put the cursor in
+          // the Additional instructions textarea — the only input on
+          // this dialog.
           event.preventDefault();
           instructionsRef.current?.focus();
         }}
@@ -134,80 +110,28 @@ export function ToneModifier({
           <DialogDescription>Apply just for this regeneration.</DialogDescription>
         </DialogHeader>
 
-        {/* Scrollable body: header + footer stay fixed; this region scrolls
-            internally when content exceeds the viewport-capped dialog height.
-            Padding notes:
-              - `pb-4` (no `pt-`) — the DialogContent's parent `gap-4` already
-                gives breathing room between the header and this region; an
-                extra `pt-4` here doubled the gap.
-              - `px-1` — small horizontal padding so the textarea/grid focus
-                rings don't get clipped by the dialog's outer p-6 edge. */}
-        <div className="flex-1 space-y-5 overflow-y-auto pb-4 px-1">
-          {/* Additional instructions — free text. Iter 6 follow-up: hoisted
-              above the tone grid because typing instructions is the more
-              common path; autofocused on dialog open via onOpenAutoFocus. */}
-          <div className="space-y-2">
-            <Label htmlFor="additional-instructions" className="text-sm font-medium">
-              Additional instructions (optional)
-            </Label>
-            <p className="text-xs text-muted-foreground">
-              Anything specific you want this response to mention or address.
-            </p>
-            <Textarea
-              id="additional-instructions"
-              ref={instructionsRef}
-              value={additionalInstructions}
-              onChange={(e) => setAdditionalInstructions(e.target.value)}
-              maxLength={ADDITIONAL_INSTRUCTIONS_MAX}
-              rows={3}
-              placeholder='e.g. "mention our loyalty program" or "address the dessert complaint specifically"'
-              className="resize-none"
-            />
-            <p
-              className={`text-xs ${isOverLimit ? "text-destructive" : "text-muted-foreground"}`}
-            >
-              {additionalInstructions.length} / {ADDITIONAL_INSTRUCTIONS_MAX} characters
-            </p>
-          </div>
-
-          {/* Tone modifier — V2 4-key set, rendered as a 2-col grid at sm+ */}
-          <div className="space-y-2">
-            <Label className="text-sm font-medium">Change the tone for this response (optional)</Label>
-            <p className="text-xs text-muted-foreground">
-              Pick a different tone to use just for this regeneration.
-            </p>
-            <RadioGroup
-              value={selectedTone}
-              onValueChange={(value) => setSelectedTone(value as BrandVoiceToneV2)}
-              className="grid grid-cols-1 gap-2 sm:grid-cols-2"
-            >
-              {BRAND_VOICE_TONES_V2.map((tone) => {
-                const info = BRAND_VOICE_TONE_INFO_V2[tone];
-                const isSelected = selectedTone === tone;
-                return (
-                  <div
-                    key={tone}
-                    className={`flex items-start space-x-3 p-3 rounded-lg border cursor-pointer transition-colors hover:bg-accent ${
-                      isSelected ? "border-primary bg-accent/50" : "border-border"
-                    }`}
-                    onClick={() => setSelectedTone(tone)}
-                  >
-                    <RadioGroupItem value={tone} id={`tone-${tone}`} className="mt-1" />
-                    <div className="flex-1">
-                      <Label
-                        htmlFor={`tone-${tone}`}
-                        className="flex items-center gap-2 cursor-pointer font-medium"
-                      >
-                        {TONE_ICONS[tone]}
-                        {info.label}
-                      </Label>
-                      <p className="text-sm text-muted-foreground mt-1">{info.description}</p>
-                    </div>
-                  </div>
-                );
-              })}
-            </RadioGroup>
-          </div>
+        <div className="space-y-2">
+          <Label htmlFor="additional-instructions" className="text-sm font-medium">
+            Additional instructions (optional)
+          </Label>
+          <p className="text-xs text-muted-foreground">
+            Anything specific you want this response to mention or address.
+          </p>
+          <Textarea
+            id="additional-instructions"
+            ref={instructionsRef}
+            value={additionalInstructions}
+            onChange={(e) => setAdditionalInstructions(e.target.value)}
+            maxLength={ADDITIONAL_INSTRUCTIONS_MAX}
+            rows={3}
+            placeholder='e.g. "mention our loyalty program" or "address the dessert complaint specifically"'
+            className="resize-none"
+          />
+          <p
+            className={`text-xs ${isOverLimit ? "text-destructive" : "text-muted-foreground"}`}
+          >
+            {additionalInstructions.length} / {ADDITIONAL_INSTRUCTIONS_MAX} characters
+          </p>
         </div>
 
         <DialogFooter className="flex-col gap-2 sm:flex-row">

--- a/tests/unit/api/reviews/regenerate.test.ts
+++ b/tests/unit/api/reviews/regenerate.test.ts
@@ -40,11 +40,21 @@ const mockGenerateReviewResponse = vi.hoisted(() =>
 
 const mockGetOrCreateBrandVoice = vi.hoisted(() =>
   vi.fn().mockResolvedValue({
-    tone: 'professional',
-    formality: 3,
+    // V2 tone key — 5/25 simplification persists the brand voice tone to
+    // the DB on regenerate (the tone selector was dropped from the
+    // dialog; the brand voice tone applies as configured).
+    tone: 'friendly_professional',
     keyPhrases: [],
-    styleNotes: null,
+    styleGuidelines: [],
     sampleResponses: [],
+    acknowledgeNamedStaff: true,
+    acknowledgeOccasions: true,
+    salutationPattern: 'Dear {firstName},',
+    signoffLines: 'Warmest regards,\nThe Team',
+    negativeReviewEmailEnabled: false,
+    negativeReviewFraming: 'investigation',
+    negativeReviewFramingCustom: null,
+    replyToEmail: null,
   }),
 );
 
@@ -171,7 +181,7 @@ describe('POST /api/reviews/[id]/regenerate', () => {
     mockAuth.mockResolvedValueOnce(null);
     const req = createRequest('/api/reviews/review-1/regenerate', {
       method: 'POST',
-      body: { tone: 'friendly_professional' },
+      body: {},
     });
 
     const res = await POST(req, routeParams({ id: 'review-1' }));
@@ -182,32 +192,29 @@ describe('POST /api/reviews/[id]/regenerate', () => {
     expect(json.error.code).toBe('UNAUTHORIZED');
   });
 
-  it('returns 400 for missing tone', async () => {
+  // 5/25 simplification — tone field was removed from the request body.
+  // Empty bodies are now valid; the brand voice tone applies as
+  // configured.
+  it('accepts an empty request body (tone field is no longer required)', async () => {
+    mockPrisma.user.findUnique.mockResolvedValueOnce(baseUser);
+    mockPrisma.review.findFirst.mockResolvedValueOnce(reviewWithResponse);
+    mockPrisma.responseVersion.create.mockResolvedValueOnce({});
+    mockPrisma.reviewResponse.update.mockResolvedValueOnce({
+      ...existingResponse,
+      responseText: 'We appreciate your feedback!',
+      toneUsed: 'friendly_professional',
+      isEdited: false,
+      editedAt: null,
+      updatedAt: new Date(),
+    });
+
     const req = createRequest('/api/reviews/review-1/regenerate', {
       method: 'POST',
       body: {},
     });
 
     const res = await POST(req, routeParams({ id: 'review-1' }));
-    const json = await res.json();
-
-    expect(res.status).toBe(400);
-    expect(json.success).toBe(false);
-    expect(json.error.code).toBe('VALIDATION_ERROR');
-  });
-
-  it('returns 400 for invalid tone value', async () => {
-    const req = createRequest('/api/reviews/review-1/regenerate', {
-      method: 'POST',
-      body: { tone: 'aggressive' },
-    });
-
-    const res = await POST(req, routeParams({ id: 'review-1' }));
-    const json = await res.json();
-
-    expect(res.status).toBe(400);
-    expect(json.success).toBe(false);
-    expect(json.error.code).toBe('VALIDATION_ERROR');
+    expect(res.status).toBe(200);
   });
 
   it('returns 402 when insufficient credits', async () => {
@@ -215,7 +222,7 @@ describe('POST /api/reviews/[id]/regenerate', () => {
     mockPrisma.user.findUnique.mockResolvedValueOnce(noCreditsUser);
     const req = createRequest('/api/reviews/review-1/regenerate', {
       method: 'POST',
-      body: { tone: 'friendly_professional' },
+      body: {},
     });
 
     const res = await POST(req, routeParams({ id: 'review-1' }));
@@ -231,7 +238,7 @@ describe('POST /api/reviews/[id]/regenerate', () => {
     mockPrisma.review.findFirst.mockResolvedValueOnce(null);
     const req = createRequest('/api/reviews/nonexistent/regenerate', {
       method: 'POST',
-      body: { tone: 'friendly_professional' },
+      body: {},
     });
 
     const res = await POST(req, routeParams({ id: 'nonexistent' }));
@@ -247,7 +254,7 @@ describe('POST /api/reviews/[id]/regenerate', () => {
     mockPrisma.review.findFirst.mockResolvedValueOnce(reviewWithoutResponse);
     const req = createRequest('/api/reviews/review-1/regenerate', {
       method: 'POST',
-      body: { tone: 'friendly_professional' },
+      body: {},
     });
 
     const res = await POST(req, routeParams({ id: 'review-1' }));
@@ -273,7 +280,7 @@ describe('POST /api/reviews/[id]/regenerate', () => {
 
     const req = createRequest('/api/reviews/review-1/regenerate', {
       method: 'POST',
-      body: { tone: 'friendly_professional' },
+      body: {},
     });
 
     const res = await POST(req, routeParams({ id: 'review-1' }));
@@ -297,7 +304,7 @@ describe('POST /api/reviews/[id]/regenerate', () => {
 
     const req = createRequest('/api/reviews/review-1/regenerate', {
       method: 'POST',
-      body: { tone: 'friendly_professional' },
+      body: {},
     });
 
     await POST(req, routeParams({ id: 'review-1' }));
@@ -315,7 +322,7 @@ describe('POST /api/reviews/[id]/regenerate', () => {
     );
   });
 
-  it('deducts 1 credit on regeneration', async () => {
+  it('deducts 1 credit on regeneration and uses brand voice tone (no per-regen override)', async () => {
     mockPrisma.user.findUnique.mockResolvedValueOnce(baseUser);
     mockPrisma.review.findFirst.mockResolvedValueOnce(reviewWithResponse);
     mockPrisma.responseVersion.create.mockResolvedValueOnce({});
@@ -326,12 +333,14 @@ describe('POST /api/reviews/[id]/regenerate', () => {
 
     const req = createRequest('/api/reviews/review-1/regenerate', {
       method: 'POST',
-      body: { tone: 'empathetic_attentive' },
+      body: {},
     });
 
     await POST(req, routeParams({ id: 'review-1' }));
 
     // deductCreditsAtomic(userId, amount, action, reviewId, responseId, details)
+    // The newTone in the audit trail is the brand voice tone — there is
+    // no per-regen tone override (5/25 simplification).
     expect(mockDeductCreditsAtomic).toHaveBeenCalledWith(
       'clu1234567890abcdef',
       1,
@@ -342,7 +351,33 @@ describe('POST /api/reviews/[id]/regenerate', () => {
         reviewId: 'review-1',
         platform: 'Google',
         previousTone: 'professional',
-        newTone: 'empathetic_attentive',
+        newTone: 'friendly_professional',
+      }),
+    );
+  });
+
+  it('persists the brand voice tone as the new toneUsed (not from request body)', async () => {
+    mockPrisma.user.findUnique.mockResolvedValueOnce(baseUser);
+    mockPrisma.review.findFirst.mockResolvedValueOnce(reviewWithResponse);
+    mockPrisma.responseVersion.create.mockResolvedValueOnce({});
+    mockPrisma.reviewResponse.update.mockResolvedValueOnce({
+      ...existingResponse,
+      responseText: 'We appreciate your feedback!',
+    });
+
+    const req = createRequest('/api/reviews/review-1/regenerate', {
+      method: 'POST',
+      body: {},
+    });
+
+    await POST(req, routeParams({ id: 'review-1' }));
+
+    expect(mockPrisma.reviewResponse.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          // From the mocked brand voice (the only source of tone now).
+          toneUsed: 'friendly_professional',
+        }),
       }),
     );
   });
@@ -354,7 +389,7 @@ describe('POST /api/reviews/[id]/regenerate', () => {
 
     const req = createRequest('/api/reviews/review-1/regenerate', {
       method: 'POST',
-      body: { tone: 'friendly_professional' },
+      body: {},
     });
 
     const res = await POST(req, routeParams({ id: 'review-1' }));
@@ -366,6 +401,25 @@ describe('POST /api/reviews/[id]/regenerate', () => {
     // Neither credit deduction nor version save should happen
     expect(mockDeductCreditsAtomic).not.toHaveBeenCalled();
     expect(mockPrisma.reviewResponse.update).not.toHaveBeenCalled();
+  });
+
+  // 5/25 simplification — the route no longer forwards `toneModifier` to
+  // generateReviewResponse. The brand voice tone applies via the
+  // `brandVoice` arg already.
+  it('does NOT forward a toneModifier to generateReviewResponse', async () => {
+    mockPrisma.user.findUnique.mockResolvedValueOnce(baseUser);
+    mockPrisma.review.findFirst.mockResolvedValueOnce(reviewWithResponse);
+    mockPrisma.responseVersion.create.mockResolvedValueOnce({});
+    mockPrisma.reviewResponse.update.mockResolvedValueOnce(existingResponse);
+
+    const req = createRequest('/api/reviews/review-1/regenerate', {
+      method: 'POST',
+      body: {},
+    });
+    await POST(req, routeParams({ id: 'review-1' }));
+
+    const callArgs = mockGenerateReviewResponse.mock.calls[0][0];
+    expect(callArgs).not.toHaveProperty('toneModifier');
   });
 
   // ─── Iteration 1: prompt-injection audit logging (spec §10.6) ────
@@ -383,7 +437,7 @@ describe('POST /api/reviews/[id]/regenerate', () => {
 
       const req = createRequest('/api/reviews/review-1/regenerate', {
         method: 'POST',
-        body: { tone: 'friendly_professional' },
+        body: {},
       });
 
       await POST(req, routeParams({ id: 'review-1' }));
@@ -401,7 +455,7 @@ describe('POST /api/reviews/[id]/regenerate', () => {
 
       const req = createRequest('/api/reviews/review-1/regenerate', {
         method: 'POST',
-        body: { tone: 'friendly_professional' },
+        body: {},
       });
 
       await POST(req, routeParams({ id: 'review-1' }));
@@ -426,7 +480,7 @@ describe('POST /api/reviews/[id]/regenerate', () => {
 
       const req = createRequest('/api/reviews/review-1/regenerate', {
         method: 'POST',
-        body: { tone: 'friendly_professional' },
+        body: {},
       });
       await POST(req, routeParams({ id: 'review-1' }));
 
@@ -442,8 +496,8 @@ describe('POST /api/reviews/[id]/regenerate', () => {
     });
   });
 
-  // ─── Iteration 6: additionalInstructions plumbing ─────────────────
-  describe('additionalInstructions (iter 6)', () => {
+  // ─── additionalInstructions plumbing (iter 6 / 5/25 simplified) ──
+  describe('additionalInstructions', () => {
     it('forwards additionalInstructions to generateReviewResponse as customRegenerateInstructions', async () => {
       mockPrisma.user.findUnique.mockResolvedValueOnce(baseUser);
       mockPrisma.review.findFirst.mockResolvedValueOnce(reviewWithResponse);
@@ -453,15 +507,15 @@ describe('POST /api/reviews/[id]/regenerate', () => {
       const req = createRequest('/api/reviews/review-1/regenerate', {
         method: 'POST',
         body: {
-          tone: 'friendly_professional',
           additionalInstructions: 'Mention our loyalty program once.',
         },
       });
       await POST(req, routeParams({ id: 'review-1' }));
 
+      // 5/25 simplification — no `toneModifier` is forwarded. The brand
+      // voice tone applies via the `brandVoice` arg.
       expect(mockGenerateReviewResponse).toHaveBeenCalledWith(
         expect.objectContaining({
-          toneModifier: 'friendly_professional',
           customRegenerateInstructions: 'Mention our loyalty program once.',
         }),
       );
@@ -475,13 +529,12 @@ describe('POST /api/reviews/[id]/regenerate', () => {
 
       const req = createRequest('/api/reviews/review-1/regenerate', {
         method: 'POST',
-        body: { tone: 'friendly_professional' },
+        body: {},
       });
       await POST(req, routeParams({ id: 'review-1' }));
 
       expect(mockGenerateReviewResponse).toHaveBeenCalledWith(
         expect.objectContaining({
-          toneModifier: 'friendly_professional',
           customRegenerateInstructions: undefined,
         }),
       );
@@ -491,7 +544,6 @@ describe('POST /api/reviews/[id]/regenerate', () => {
       const req = createRequest('/api/reviews/review-1/regenerate', {
         method: 'POST',
         body: {
-          tone: 'friendly_professional',
           additionalInstructions: 'a'.repeat(501),
         },
       });

--- a/tests/unit/components/reviews/tone-modifier.test.tsx
+++ b/tests/unit/components/reviews/tone-modifier.test.tsx
@@ -2,9 +2,10 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import { ToneModifier } from "@/components/reviews/ToneModifier";
 
-// Iter 6: tone presets now align with BRAND_VOICE_TONES_V2 (spec §8.1).
-// onRegenerate signature changed from `(_tone: string) => Promise<void>` to
-// `(_payload: { tone, additionalInstructions? }) => Promise<void>`.
+// 5/25 simplification — the per-regeneration tone selector was removed.
+// `onRegenerate` signature is now just `(_payload: { additionalInstructions?: string }) => Promise<void>`.
+// Brand voice tone applies as configured; users override on a per-
+// regen basis via the Additional Instructions textarea.
 describe("ToneModifier", () => {
   const defaultProps = {
     onRegenerate: vi.fn().mockResolvedValue(undefined),
@@ -27,21 +28,49 @@ describe("ToneModifier", () => {
     expect(screen.getByRole("button", { name: /regenerate/i })).toBeDisabled();
   });
 
-  it("opens dialog and shows the four V2 tone presets", async () => {
+  it("opens dialog with the Additional Instructions textarea + Regenerate footer", async () => {
     render(<ToneModifier {...defaultProps} />);
 
     fireEvent.click(screen.getByRole("button", { name: /regenerate/i }));
 
     await waitFor(() => {
       expect(screen.getByText("Regenerate response")).toBeInTheDocument();
-      expect(screen.getByText("Warm & casual")).toBeInTheDocument();
-      expect(screen.getByText("Friendly & professional")).toBeInTheDocument();
-      expect(screen.getByText("Polished & formal")).toBeInTheDocument();
-      expect(screen.getByText("Empathetic & attentive")).toBeInTheDocument();
     });
+
+    expect(screen.getByLabelText(/additional instructions/i)).toBeInTheDocument();
   });
 
-  it("does not surface the deprecated 'Apologetic' option (spec §8.1)", async () => {
+  // 5/25 simplification — the four V2 tone preset cards are gone from the
+  // dialog entirely. The brand voice tone applies as configured; users
+  // override on a per-regen basis via free-text in the Additional
+  // Instructions field.
+  it("no longer renders the four V2 tone preset cards", async () => {
+    render(<ToneModifier {...defaultProps} />);
+    fireEvent.click(screen.getByRole("button", { name: /regenerate/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Regenerate response")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText("Warm & casual")).not.toBeInTheDocument();
+    expect(screen.queryByText("Friendly & professional")).not.toBeInTheDocument();
+    expect(screen.queryByText("Polished & formal")).not.toBeInTheDocument();
+    expect(screen.queryByText("Empathetic & attentive")).not.toBeInTheDocument();
+  });
+
+  it("no longer renders a tone radiogroup or any radio inputs", async () => {
+    render(<ToneModifier {...defaultProps} />);
+    fireEvent.click(screen.getByRole("button", { name: /regenerate/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Regenerate response")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole("radiogroup")).not.toBeInTheDocument();
+    expect(screen.queryAllByRole("radio")).toHaveLength(0);
+  });
+
+  it("does not surface the deprecated 'Apologetic' option", async () => {
     render(<ToneModifier {...defaultProps} />);
     fireEvent.click(screen.getByRole("button", { name: /regenerate/i }));
 
@@ -52,46 +81,7 @@ describe("ToneModifier", () => {
     expect(screen.queryByText(/apologetic/i)).not.toBeInTheDocument();
   });
 
-  it("renders the tone options as a 2-col grid at sm+ (1 col on mobile)", async () => {
-    render(<ToneModifier {...defaultProps} />);
-    fireEvent.click(screen.getByRole("button", { name: /regenerate/i }));
-
-    await waitFor(() => {
-      expect(screen.getByText("Warm & casual")).toBeInTheDocument();
-    });
-
-    const radioGroup = screen.getByRole("radiogroup");
-    // Layout classes are applied to the RadioGroup wrapper. We assert the
-    // CSS classes are present rather than computed styles because jsdom
-    // doesn't run a real layout engine — class presence is the meaningful
-    // signal here.
-    expect(radioGroup.className).toContain("grid");
-    expect(radioGroup.className).toContain("grid-cols-1");
-    expect(radioGroup.className).toContain("sm:grid-cols-2");
-  });
-
-  it("constrains the dialog to 90vh and makes the body scrollable so header/footer stay visible", async () => {
-    render(<ToneModifier {...defaultProps} />);
-    fireEvent.click(screen.getByRole("button", { name: /regenerate/i }));
-
-    await waitFor(() => {
-      expect(screen.getByRole("dialog")).toBeInTheDocument();
-    });
-
-    const dialog = screen.getByRole("dialog");
-    // The dialog itself is capped at 90vh and laid out as a flex column so
-    // the header + footer stay anchored while the body scrolls.
-    expect(dialog.className).toContain("max-h-[90vh]");
-    expect(dialog.className).toContain("flex");
-    expect(dialog.className).toContain("flex-col");
-
-    // The scrollable body region carries flex-1 + overflow-y-auto.
-    const scrollable = dialog.querySelector(".overflow-y-auto");
-    expect(scrollable).not.toBeNull();
-    expect(scrollable!.className).toContain("flex-1");
-  });
-
-  it("renders the new Additional instructions textarea with the 500-char cap", async () => {
+  it("renders the Additional instructions textarea with the 500-char cap", async () => {
     render(<ToneModifier {...defaultProps} />);
     fireEvent.click(screen.getByRole("button", { name: /regenerate/i }));
 
@@ -111,21 +101,7 @@ describe("ToneModifier", () => {
     });
   });
 
-  it("does not render the 'Current tone' line (removed in iter-6 follow-up UX fix)", async () => {
-    render(<ToneModifier {...defaultProps} />);
-    fireEvent.click(screen.getByRole("button", { name: /regenerate/i }));
-
-    await waitFor(() => {
-      expect(screen.getByText("Regenerate response")).toBeInTheDocument();
-    });
-
-    // The line was rarely useful, ate vertical space, and could mislead
-    // (it showed the *previous* regeneration's tone, not what the next
-    // regeneration would use). Iter-6 follow-up removed it.
-    expect(screen.queryByText(/current tone:/i)).not.toBeInTheDocument();
-  });
-
-  it("renders the trimmed one-line description", async () => {
+  it("renders the trimmed one-line dialog description", async () => {
     render(<ToneModifier {...defaultProps} />);
     fireEvent.click(screen.getByRole("button", { name: /regenerate/i }));
 
@@ -137,26 +113,6 @@ describe("ToneModifier", () => {
     expect(screen.queryByText(/pick a different tone, add specific instructions/i)).not.toBeInTheDocument();
   });
 
-  it("renders Additional instructions BEFORE the tone grid (iter-6 follow-up — primary input first)", async () => {
-    render(<ToneModifier {...defaultProps} />);
-    fireEvent.click(screen.getByRole("button", { name: /regenerate/i }));
-
-    await waitFor(() => {
-      expect(screen.getByLabelText(/additional instructions/i)).toBeInTheDocument();
-    });
-
-    // Both fields render inside the same scrollable body region. The
-    // textarea's label should appear earlier in the DOM than the radio
-    // group's heading, so the user sees instructions first.
-    const dialog = screen.getByRole("dialog");
-    const html = dialog.innerHTML;
-    const instructionsIdx = html.indexOf("Additional instructions");
-    const toneIdx = html.indexOf("Change the tone");
-    expect(instructionsIdx).toBeGreaterThan(-1);
-    expect(toneIdx).toBeGreaterThan(-1);
-    expect(instructionsIdx).toBeLessThan(toneIdx);
-  });
-
   it("autofocuses the Additional instructions textarea when the dialog opens", async () => {
     render(<ToneModifier {...defaultProps} />);
     fireEvent.click(screen.getByRole("button", { name: /regenerate/i }));
@@ -166,13 +122,14 @@ describe("ToneModifier", () => {
     });
 
     // Radix's default focus would land on the first focusable element
-    // (Close ×). Iter-6 follow-up overrides onOpenAutoFocus to put focus
-    // in the textarea — the primary input.
+    // (Close ×). The dialog overrides onOpenAutoFocus to put focus in
+    // the textarea — now the only input on the dialog.
     expect(screen.getByLabelText(/additional instructions/i)).toHaveFocus();
   });
 
-  it("calls onRegenerate with the selected V2 tone key in a payload object", async () => {
-    render(<ToneModifier {...defaultProps} />);
+  it("calls onRegenerate with an additionalInstructions-only payload (no tone field)", async () => {
+    const onRegenerate = vi.fn().mockResolvedValue(undefined);
+    render(<ToneModifier {...defaultProps} onRegenerate={onRegenerate} />);
 
     fireEvent.click(screen.getByRole("button", { name: /regenerate/i }));
 
@@ -180,19 +137,20 @@ describe("ToneModifier", () => {
       expect(screen.getByText("Regenerate response")).toBeInTheDocument();
     });
 
-    // Pick "Warm & casual" via its label.
-    fireEvent.click(screen.getByText("Warm & casual"));
-
     const dialogButtons = screen.getAllByRole("button", { name: /^regenerate$/i });
     const confirmBtn = dialogButtons[dialogButtons.length - 1];
     fireEvent.click(confirmBtn);
 
     await waitFor(() => {
-      expect(defaultProps.onRegenerate).toHaveBeenCalledWith({
-        tone: "warm_casual",
+      expect(onRegenerate).toHaveBeenCalledWith({
         additionalInstructions: undefined,
       });
     });
+
+    // The payload must NOT contain a tone field — the tone is the brand
+    // voice's configured tone, applied server-side, not a per-regen choice.
+    const callArgs = onRegenerate.mock.calls[0][0];
+    expect(callArgs).not.toHaveProperty("tone");
   });
 
   it("forwards additionalInstructions in the payload when the user types into the textarea", async () => {
@@ -205,7 +163,6 @@ describe("ToneModifier", () => {
       expect(screen.getByLabelText(/additional instructions/i)).toBeInTheDocument();
     });
 
-    // Default selection is `friendly_professional` (matches the form default).
     fireEvent.change(screen.getByLabelText(/additional instructions/i), {
       target: { value: "Mention our loyalty program." },
     });
@@ -216,7 +173,6 @@ describe("ToneModifier", () => {
 
     await waitFor(() => {
       expect(onRegenerate).toHaveBeenCalledWith({
-        tone: "friendly_professional",
         additionalInstructions: "Mention our loyalty program.",
       });
     });
@@ -242,11 +198,9 @@ describe("ToneModifier", () => {
     fireEvent.click(confirmBtn);
 
     await waitFor(() => {
-      expect(onRegenerate).toHaveBeenCalledWith(
-        expect.objectContaining({
-          additionalInstructions: undefined,
-        }),
-      );
+      expect(onRegenerate).toHaveBeenCalledWith({
+        additionalInstructions: undefined,
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary

The regenerate dialog asked users to pick a tone every time they regenerated a response. In practice, businesses set their brand voice tone once on the brand voice page and keep it stable — the per-regen selector was asking them to re-decide a setting they already configured. The one legitimate edge case (a tonally mismatched review where the manager wants to break brand voice for one reply) is served just as well — with more flexibility — by free text in the Additional Instructions field ("respond more warmly for this one").

Since we have no real users yet, removing UI users might have come to rely on is not a concern. **This is exactly the kind of pre-launch simplification we should be doing while it's free.**

### What changes

**`ToneModifier.tsx`** — the four V2 tone preset cards, the radio grid, the `selectedTone` state, and the related layout (90vh max-height + flex column + internal scroll body) are gone. The dialog now contains:
- Title + description
- Additional Instructions textarea (500-char cap, single-use, wrapped via sanitize helper)
- Credit cost + Cancel/Regenerate footer

`onRegenerate` payload simplified to `{ additionalInstructions?: string }`.

**`ResponsePanel.tsx`** — `handleRegenerate` accepts the simpler payload. The PostHog `response_regenerated` event now reports the SERVER-persisted `toneUsed` (which is the brand voice tone) so the event property typing stays consistent with the V2 4-key set.

**`/api/reviews/[id]/regenerate` route** — Zod schema drops `tone` entirely. The route no longer forwards `toneModifier` to `generateReviewResponse`. DB writes and audit-trail entries read tone from `brandVoice.tone`, not from the request body. The brand voice arg already carries the tone via `getOrCreateBrandVoice`; no behavioural change in what tone is applied.

### What this does NOT do

- **Does not change how the brand voice tone is applied** — the brand voice page still configures the tone, and that tone still drives generations (including regenerations).
- **Does not remove the iter-1 `customRegenerateInstructions` plumbing** — that's the slot Additional Instructions feeds. Still works exactly as before.
- **Does not remove the `toneModifier` parameter from `claude.ts:generateReviewResponse`** — kept as an optional param for tests and any future per-call override. Just not used from the regenerate route anymore.

## Test plan

- [x] `npm run lint:strict` clean
- [x] `npm run type-check` clean
- [x] `npm run test:unit` — **1083 passed, 30 skipped, 0 failed** (64 files). Test count dropped by 1 net (added ~3 negative assertions confirming the tone selector is gone; removed ~4 that asserted its specific rendering).
- [ ] Visual check on staging Preview:
  - Open the regenerate dialog. Confirm only the Additional Instructions textarea + footer; no tone cards.
  - Confirm the dialog is shorter than before.
  - Regenerate without typing anything — confirm the response uses the configured brand voice tone.
  - Regenerate with "respond more warmly for this one" — confirm the response shifts register while still grounded in the brand voice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
