### PR TITLE
chore(ui): remove em-dashes from user-facing text + add UI text conventions to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,19 @@ if (!result.success) {
 }
 ```
 
+## UI text conventions
+
+These rules apply when writing or editing **user-facing UI text**: JSX text nodes, button labels, headings, descriptions, placeholders, toasts, alerts, email content, page titles. The goal is to keep BrandsIQ's UI from feeling AI-generated.
+
+- **Never use em-dashes ("—") in UI text.** Use commas, periods, parentheses, or colons. Em-dashes are an AI-writing tell and shouldn't appear in product copy.
+- If you find an em-dash in existing UI text while editing a file, fix it as part of the change.
+
+**What is NOT in scope for this rule:**
+- **Code comments** (`// …`, `/* … */`, JSDoc blocks). Free-form notes for developers; not rendered.
+- **Documentation files** (`docs/`, `DECISIONS.md`, `PROGRESS.md`, `MVP.md`, this `CLAUDE.md`). Internal narrative.
+- **AI prompt source files** (`src/lib/ai/sanitize.ts`, `src/lib/ai/structure-templates.ts`, `src/lib/ai/claude.ts`, `src/lib/ai/post-process.ts`, `src/lib/ai/brand-voice-normalize.ts`) — these files contain the prompt that bans em-dashes in AI-generated responses; the prompt has to describe the character to ban it.
+- **Test files** that intentionally assert em-dash-related rules.
+
 ## Critical Gotchas
 
 | Issue | Solution |

--- a/src/app/(dashboard)/dashboard/admin/beta-invites/page.tsx
+++ b/src/app/(dashboard)/dashboard/admin/beta-invites/page.tsx
@@ -131,7 +131,7 @@ export default function BetaInvitesAdminPage() {
         <CardHeader>
           <CardTitle>Generate a new invite</CardTitle>
           <CardDescription>
-            Optionally add notes (e.g. who this invite is for) — visible only
+            Optionally add notes (e.g. who this invite is for). Visible only
             to you.
           </CardDescription>
         </CardHeader>
@@ -244,10 +244,10 @@ export default function BetaInvitesAdminPage() {
                           {formatDateTime(invite.expiresAt)}
                         </td>
                         <td className="py-3 pr-4 text-muted-foreground">
-                          {invite.usedBy?.email ?? "—"}
+                          {invite.usedBy?.email ?? "-"}
                         </td>
                         <td className="py-3 pr-4 text-muted-foreground max-w-[200px] truncate">
-                          {invite.notes ?? "—"}
+                          {invite.notes ?? "-"}
                         </td>
                         <td className="py-3 pr-4 text-right">
                           {invite.status === "active" && (

--- a/src/app/(dashboard)/dashboard/admin/founder-inquiries/page.tsx
+++ b/src/app/(dashboard)/dashboard/admin/founder-inquiries/page.tsx
@@ -257,7 +257,7 @@ export default function FounderInquiriesAdminPage() {
                         </td>
                         <td className="py-3 pr-4">
                           <div className="space-y-0.5">
-                            <div>{inquiry.submitterName ?? "—"}</div>
+                            <div>{inquiry.submitterName ?? "-"}</div>
                             {inquiry.submitterEmail && (
                               <a
                                 href={`mailto:${inquiry.submitterEmail}`}
@@ -269,7 +269,7 @@ export default function FounderInquiriesAdminPage() {
                           </div>
                         </td>
                         <td className="py-3 pr-4 text-muted-foreground">
-                          {inquiry.businessName ?? "—"}
+                          {inquiry.businessName ?? "-"}
                         </td>
                         <td className="py-3 pr-4 text-muted-foreground">
                           {formatDateTime(inquiry.createdAt)}
@@ -310,7 +310,7 @@ export default function FounderInquiriesAdminPage() {
                 <DialogTitle>{TYPE_LABEL[activeInquiry.type]}</DialogTitle>
                 <DialogDescription>
                   Submitted {formatDateTime(activeInquiry.createdAt)}
-                  {activeInquiry.source ? ` — via ${activeInquiry.source}` : ""}
+                  {activeInquiry.source ? ` (via ${activeInquiry.source})` : ""}
                 </DialogDescription>
               </DialogHeader>
 

--- a/src/app/(dashboard)/onboarding/onboarding-form.tsx
+++ b/src/app/(dashboard)/onboarding/onboarding-form.tsx
@@ -364,7 +364,7 @@ export function OnboardingForm() {
                   <MapPin className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
                   <Input
                     id="locationName"
-                    placeholder="e.g. The Bear Bakery — Shoreditch"
+                    placeholder="e.g. The Bear Bakery, Shoreditch"
                     className="pl-10"
                     maxLength={VALIDATION_LIMITS.LOCATION_NAME_MAX}
                     disabled={isSubmitting}
@@ -450,8 +450,8 @@ export function OnboardingForm() {
                   />
                   <p className="text-xs text-muted-foreground">
                     {signupIntent === "yes" || (watch("signupChallengeText")?.trim().length ?? 0) > 0
-                      ? "Submitting this will request beta access — the founder will reach out within 24 hours."
-                      : "Optional — helps us understand who's signing up."}
+                      ? "Submitting this will request beta access. The founder will reach out within 24 hours."
+                      : "Optional. Helps us understand who's signing up."}
                   </p>
                 </div>
               </section>

--- a/src/app/pricing/pricing-client.tsx
+++ b/src/app/pricing/pricing-client.tsx
@@ -181,11 +181,11 @@ export function PricingClient({ currentPhase }: { currentPhase: SystemPhase }) {
             <AlertCircle className="h-5 w-5 text-primary shrink-0 mt-0.5" />
             <div>
               <p className="font-semibold text-foreground">
-                You&apos;re in the closed beta — thank you!
+                You&apos;re in the closed beta. Thank you!
               </p>
               <p className="text-sm text-muted-foreground mt-1">
                 Below is a preview of the commercial plans we&apos;ll launch
-                later — we&apos;ll be in touch before then.
+                later. We&apos;ll be in touch before then.
               </p>
             </div>
           </div>
@@ -203,7 +203,7 @@ export function PricingClient({ currentPhase }: { currentPhase: SystemPhase }) {
                 </p>
                 <p className="text-sm text-muted-foreground mt-1">
                   Tiers below preview the commercial plans. To use BrandsIQ
-                  today, request a beta invite — we&apos;ll reach out within
+                  today, request a beta invite. We&apos;ll reach out within
                   24 hours.
                 </p>
               </div>

--- a/src/components/settings/BrandVoiceForm.tsx
+++ b/src/components/settings/BrandVoiceForm.tsx
@@ -71,7 +71,7 @@ const DEFAULT_BRAND_VOICE: Omit<BrandVoiceDataV2, "id"> = {
 
 // Starter chips — spec §4.2 / §4.3.
 const STYLE_GUIDELINE_STARTERS: readonly string[] = [
-  "Avoid corporate language — write the way you'd speak to a returning guest",
+  "Avoid corporate language, write the way you'd speak to a returning guest",
   "For negative reviews, take ownership before explaining",
   "Keep 5-star responses concise; allow more length for complaints",
   'Use "our" rather than "the" when referring to staff',
@@ -508,7 +508,7 @@ export function BrandVoiceForm() {
  *   - Large muted numeral on the left — gives the reader an at-a-glance
  *     "section 2 of 4" cue without forcing them to read every title.
  *   - Bold title in primary text colour.
- *   - Em-dash + muted descriptor inline on the same line — replaces the
+ *   - Colon + muted descriptor inline on the same line, replacing the
  *     stacked CardTitle + CardDescription pair so the section header
  *     reads as one rhythm instead of two paragraphs.
  *
@@ -535,7 +535,7 @@ function SectionHeader({
       <h2 className="text-lg font-semibold tracking-tight">
         {title}
         <span className="ml-2 text-sm font-normal text-muted-foreground/90">
-          — {descriptor}
+          : {descriptor}
         </span>
       </h2>
     </div>

--- a/src/components/settings/ProfileForm.tsx
+++ b/src/components/settings/ProfileForm.tsx
@@ -422,7 +422,7 @@ export function ProfileForm() {
               <Label>Plan</Label>
               <div className="text-sm">
                 <span className="font-medium">{planLabel}</span>
-                <span className="text-muted-foreground"> — {planSubtext}</span>
+                <span className="text-muted-foreground"> ({planSubtext})</span>
               </div>
             </div>
           </section>
@@ -547,7 +547,7 @@ export function ProfileForm() {
                 <MapPin className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
                 <Input
                   id="locationName"
-                  placeholder='e.g. "The Bear Bakery — Shoreditch"'
+                  placeholder='e.g. "The Bear Bakery, Shoreditch"'
                   className="pl-10"
                   maxLength={VALIDATION_LIMITS.LOCATION_NAME_MAX}
                   value={locationName}
@@ -594,7 +594,7 @@ export function ProfileForm() {
                     <SelectValue placeholder="Select platform" />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="__none__">— None —</SelectItem>
+                    <SelectItem value="__none__">None</SelectItem>
                     {PLATFORMS.map((value) => (
                       <SelectItem key={value} value={value}>
                         {value}

--- a/src/components/shared/FounderInquiryForm.tsx
+++ b/src/components/shared/FounderInquiryForm.tsx
@@ -86,7 +86,7 @@ const DEFAULT_COPY: Record<
   },
   general: {
     heading: "Get in touch",
-    description: "We'd love to hear from you — leave a note below and we'll reply.",
+    description: "We'd love to hear from you. Leave a note below and we'll reply.",
     messageLabel: "Message",
     messagePlaceholder: "How can we help?",
     submitLabel: "Send",
@@ -186,7 +186,7 @@ export function FounderInquiryForm({
         <div className="mx-auto w-12 h-12 rounded-full bg-green-100 flex items-center justify-center">
           <Check className="h-6 w-6 text-green-600" />
         </div>
-        <h3 className="text-lg font-semibold">Thanks — we&apos;ll be in touch.</h3>
+        <h3 className="text-lg font-semibold">Thanks, we&apos;ll be in touch.</h3>
         <p className="text-sm text-muted-foreground">
           We aim to reply within 24 hours.
         </p>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -87,7 +87,7 @@ export const BRAND_VOICE_TONE_INFO_V2: Record<
   },
   friendly_professional: {
     label: "Friendly & professional",
-    description: "Warm but composed — the default for most hospitality brands",
+    description: "Warm but composed, the default for most hospitality brands",
     icon: "smile",
   },
   polished_formal: {
@@ -97,7 +97,7 @@ export const BRAND_VOICE_TONE_INFO_V2: Record<
   },
   empathetic_attentive: {
     label: "Empathetic & attentive",
-    description: "For guests whose experience matters most — used heavily on complaints",
+    description: "For guests whose experience matters most, used heavily on complaints",
     icon: "heart",
   },
 };

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -117,7 +117,7 @@ export async function sendPasswordResetEmail(email: string, token: string) {
 function buildWelcomePlanSection(isBetaUser: boolean): { headerLine: string; planTitle: string; planItems: string[]; closing: string } {
   if (isBetaUser) {
     return {
-      headerLine: "You're on the BrandsIQ closed beta — your account is verified and ready.",
+      headerLine: "You're on the BrandsIQ closed beta. Your account is verified and ready.",
       planTitle: "Your beta plan includes:",
       planItems: [
         `${BETA_PLAN.credits} AI-generated responses per month`,
@@ -251,7 +251,7 @@ export async function sendFounderInquiryNotification(params: {
       from: FROM_EMAIL,
       to: FOUNDER_PUBLIC_EMAIL,
       replyTo,
-      subject: `[BrandsIQ] ${typeLabel[type]}${businessName ? ` — ${businessName}` : ""}`,
+      subject: `[BrandsIQ] ${typeLabel[type]}${businessName ? ` (${businessName})` : ""}`,
       html: `
         <!DOCTYPE html>
         <html>
@@ -277,8 +277,8 @@ ${escapeHtml(message)}
             </div>
 
             <p style="color: #999; font-size: 12px; margin-bottom: 0;">
-              Reply to this email to respond — your reply will go directly to ${submitterEmail ? `<a href="mailto:${submitterEmail}" style="color: #4f46e5;">${escapeHtml(submitterEmail)}</a>` : "the submitter"}.
-              ${submitterEmail ? "" : "<br>(No submitter email captured — check the inquiry ID in the admin dashboard for any user context.)"}
+              Reply to this email to respond. Your reply will go directly to ${submitterEmail ? `<a href="mailto:${submitterEmail}" style="color: #4f46e5;">${escapeHtml(submitterEmail)}</a>` : "the submitter"}.
+              ${submitterEmail ? "" : "<br>(No submitter email captured. Check the inquiry ID in the admin dashboard for any user context.)"}
             </p>
           </body>
         </html>

--- a/tests/unit/components/pricing/pricing-client.test.tsx
+++ b/tests/unit/components/pricing/pricing-client.test.tsx
@@ -79,7 +79,7 @@ describe("PricingClient — phase_1 banner state", () => {
       ).toBeInTheDocument();
     });
     expect(
-      screen.getByText(/you're in the closed beta — thank you!/i),
+      screen.getByText(/you're in the closed beta\. thank you!/i),
     ).toBeInTheDocument();
     expect(
       screen.getByText(/preview of the commercial plans we'll launch later/i),

--- a/tests/unit/components/settings/brand-voice-form.test.tsx
+++ b/tests/unit/components/settings/brand-voice-form.test.tsx
@@ -107,13 +107,14 @@ describe("BrandVoiceForm (V2)", () => {
     });
 
     // The descriptor lives inside the same h2 as the title, prefixed
-    // with an em-dash. Querying by the descriptor text confirms the
+    // with a colon. Querying by the descriptor text confirms the
     // inline-descriptor rendering pattern is in place for all four
-    // sections.
-    expect(screen.getByText(/— how we sound/)).toBeInTheDocument();
-    expect(screen.getByText(/— what good looks like for us/)).toBeInTheDocument();
-    expect(screen.getByText(/— what we acknowledge/)).toBeInTheDocument();
-    expect(screen.getByText(/— how we close/)).toBeInTheDocument();
+    // sections. (Em-dash was replaced with a colon in the UI text
+    // cleanup pass — em-dashes are banned in UI per CLAUDE.md.)
+    expect(screen.getByText(/: how we sound/)).toBeInTheDocument();
+    expect(screen.getByText(/: what good looks like for us/)).toBeInTheDocument();
+    expect(screen.getByText(/: what we acknowledge/)).toBeInTheDocument();
+    expect(screen.getByText(/: how we close/)).toBeInTheDocument();
   });
 
   it("renders the page header as a plain heading (not a Card)", async () => {


### PR DESCRIPTION
## Summary

Two coordinated tasks per discussion:

1. **One-time cleanup pass** — removed all 22 em-dashes from UI-rendering text across 9 source files. Em-dashes are an AI-writing tell; they shouldn't appear in product copy.
2. **CLAUDE.md rule** — new "UI text conventions" section bans em-dashes in UI text going forward, with explicit scope (JSX text, button labels, descriptions, placeholders, toasts, alerts, email content) and explicit non-scope (code comments, documentation files, AI prompt source files, test files asserting em-dash rules).

### Why CLAUDE.md instead of CI grep

CI grep is *detection* (catches em-dashes after they ship). CLAUDE.md is *prevention* (Claude Code reads it on every session, so em-dashes never get generated in the first place). With Claude Code as the primary code generator and no other contributors yet, CLAUDE.md is sufficient. If non-Claude-Code commits become a real source of em-dashes later, we add the CI grep step then.

### The 22 cleanup edits

Investigation: 282 raw em-dash matches across 62 files. 260 of those are in **code comments** (`//`, `/* */`, JSDoc) — not rendered, not UI. The 5 AI-prompt source files (`sanitize.ts`, `structure-templates.ts`, `claude.ts`, `post-process.ts`, `brand-voice-normalize.ts`) legitimately contain em-dashes because they build the prompt that bans them in AI responses. Of the remaining 22, each was reviewed individually and replaced with a comma, period, parentheses, colon, or plain hyphen (for empty-cell placeholders).

| File | # edits | Type |
|---|---|---|
| `src/lib/constants.ts` | 2 | Tone preset descriptions |
| `src/lib/email.ts` | 4 | Outgoing email body + subject |
| `src/components/settings/BrandVoiceForm.tsx` | 2 | Starter chip + section-header descriptor |
| `src/components/settings/ProfileForm.tsx` | 3 | Location placeholder + SelectItem + plan subtext |
| `src/components/shared/FounderInquiryForm.tsx` | 2 | Inquiry description + thank-you heading |
| `src/app/pricing/pricing-client.tsx` | 3 | Beta-banner copy (3 sentences) |
| `src/app/(dashboard)/onboarding/onboarding-form.tsx` | 3 | Location placeholder + intent-helper messages |
| `src/app/(dashboard)/dashboard/admin/founder-inquiries/page.tsx` | 3 | Empty-cell glyphs + dialog metadata |
| `src/app/(dashboard)/dashboard/admin/beta-invites/page.tsx` | 3 | Empty-cell glyphs + admin copy |
| **Total** | **22** | |

**Empty-cell convention.** 5 of the 22 were em-dashes used as a single-character "blank cell" glyph in admin tables. Per discussion, replaced with plain hyphen `-` for consistency (the alternative — exempting empty-cell glyphs from the rule — would have been a subtle exception that becomes a future foot-gun).

**Test fixture data NOT changed.** Strings like `name: "Bear Bakery — Shoreditch"` in `profile.test.ts` test that the API accepts em-dash-containing input — they're testing the DATA path, not UI rendering. Those stay.

### Test plan

- [x] `npm run lint:strict` clean
- [x] `npm run type-check` clean
- [x] `npm run test:unit` — **1083 passed, 30 skipped, 0 failed** (64 files). Two existing assertions that read the changed copy were updated:
  - `pricing-client.test.tsx`: "closed beta — thank you!" → "closed beta. Thank you!"
  - `brand-voice-form.test.tsx`: section descriptors changed from "— how we sound" pattern to ": how we sound" pattern for all four sections
- [ ] Visual check on staging Preview:
  - confirm tone preset cards no longer show em-dashes
  - confirm brand voice section headers read "1 Voice: how we sound" etc.
  - confirm pricing banner reads naturally without em-dashes
  - confirm onboarding location placeholder reads "e.g. The Bear Bakery, Shoreditch"
  - confirm admin table empty cells show plain hyphens

🤖 Generated with [Claude Code](https://claude.com/claude-code)
