### PR TITLE
feat: persist regenerate Additional Instructions + collapsed reveal in version history + PostHog metadata

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -2096,12 +2096,37 @@ The brand voice redesign + the iter-7 / iter-8 follow-ups together comprise **98
 | 96 | Apology paragraph leans more formal than the brand's usual tone (apologies land with more weight in measured language) | Brand Voice / Iter 8 | May 25 | Low ✅ | ✅ Implemented |
 | 97 | Top-level business-agnostic CONTEXT block in the system prompt — interaction vs. surrounding context scope distinction | Brand Voice / Iter 8 | May 25 | Low ✅ | ✅ Implemented |
 | 98 | `OCCASION_FRAGMENT` broadened to cover non-hospitality businesses; scope-of-acknowledgement rule layered in | Brand Voice / Iter 8 | May 25 | Low ✅ | ✅ Implemented |
+| 99 | Persist `additionalInstructions` on `ReviewResponse` + `ResponseVersion`; surface collapsed in version history; PostHog telemetry sends metadata only (no raw text) | Brand Voice / regen-instructions persistence | May 26 | Low ✅ | ✅ Implemented |
 
 *Table will grow as decisions are made*
+
+### Persist additional instructions (regenerate dialog free-text)
+
+**Context.** The "Additional instructions" textarea on the regenerate dialog (iter-6 / spec §8.2) was single-use and not persisted. Users had no way to recall what they had asked the AI to do in a previous regeneration, and we had no way to learn what overrides users were typing.
+
+#### Decision 99: Persist `additionalInstructions` on `ReviewResponse` + `ResponseVersion`; surface collapsed in version history; PostHog telemetry sends metadata only.
+
+- **Decision (storage):** Add `additionalInstructions String? @db.Text` to BOTH `ReviewResponse` and `ResponseVersion`. The live row carries the instruction that produced the *current* state; the archive snapshots whatever produced each *previous* state. On regenerate, the prior `ReviewResponse.additionalInstructions` is copied into the new `ResponseVersion` row alongside `responseText`, `toneUsed`, etc.; the new request's `additionalInstructions` lands on the live row. On manual edits, the live row's `additionalInstructions` is cleared (edits aren't AI-generated, so no instruction is associated); the archive preserves whatever produced the pre-edit state.
+- **Decision (UI):** Render a collapsed "Show regenerate instructions" button per `ResponseVersion` row only when the field is non-empty. State tracked independently from the existing response-text "Show more" toggle. When expanded, the instruction appears in a small bordered panel with a "Regenerate instructions" eyebrow label. Most regens have no instruction, so most rows render no button.
+- **Decision (telemetry):** Extend `trackResponseRegenerated` with `hadAdditionalInstructions: boolean` + `instructionLength?: number`. Raw text is NOT sent to PostHog — it lives in Postgres for ad-hoc analysis via SQL + LLM tagging scripts. Keeps PostHog free of free-form PII.
+- **Alternatives considered:**
+  - *Store on `ResponseVersion` only* — wrong, the live row would lose its instruction immediately after the regen completed. The live row needs the field too.
+  - *Fire-and-forget to PostHog without DB storage* — loses the ability to recategorize later. PostHog requires categorization at write-time; the DB lets us re-explore the raw text whenever new questions come up.
+  - *Persist initial-generation instructions too* — N/A today. The initial-generate route has no instruction field. Leaving the column nullable means future work (e.g., a "polish my draft" feature on initial generate, flagged below) can populate it naturally without a schema change.
+- **GDPR posture:** `additionalInstructions` cascades with `ReviewResponse` → `Review` → `User` deletes. No special audit semantics. Same risk profile as the response text itself.
+- **Future consideration:** the user flagged interest in a draft-polishing feature on the *initial* generate flow — user pastes a draft, AI polishes it. Today's `customRegenerateInstructions` slot works as a hack but isn't designed for this (the prompt framing is "additional instructions", not "user-supplied draft to refine"). A proper implementation would add a parallel slot in the prompt builder with its own framing and override semantics. Out of scope for this PR; captured for future evidence-driven decision.
+- **Risk:** Low ✅. Additive migration. No existing data affected (existing rows have null). Cascade deletes preserved.
 
 ---
 
 ## Change Log
+
+**May 26, 2026** — Brand Voice / persist additional instructions
+- New nullable column `additionalInstructions String? @db.Text` on both `ReviewResponse` (live row) and `ResponseVersion` (archive). Migration `20260526120000_add_response_additional_instructions` is additive; no data backfill (Decision 99).
+- Regenerate route writes the new instruction to the live `ReviewResponse` row and archives the previous instruction into the new `ResponseVersion` row. Whitespace-only input normalised to null.
+- Manual edit route clears the live row's `additionalInstructions` (edits aren't AI-gen) and archives the previous value into the new `ResponseVersion`.
+- `ResponseVersionHistory.tsx` renders a collapsed "Show regenerate instructions" button per version when the field is non-empty. Expanded panel shows a "Regenerate instructions" eyebrow + the raw text. Independent toggle from the response-text "Show more".
+- `trackResponseRegenerated` extended with `hadAdditionalInstructions: boolean` + `instructionLength?: number`. Raw text NOT sent — it lives in Postgres for ad-hoc analysis.
 
 **May 25, 2026** — Brand Voice / Iteration 8 (default-voice prompt tuning)
 - Top-level business-agnostic CONTEXT block in `claude.ts:buildSystemPrompt` (Decision 97) — interaction vs. surrounding-context scope distinction with the real London-trip scope error documented as the example to avoid. PR #144.
@@ -2294,4 +2319,4 @@ The brand voice redesign + the iter-7 / iter-8 follow-ups together comprise **98
 
 **Note:** This document should be updated after each prompt execution. When in doubt about whether something is a "decision," document it - better to over-document than under-document.
 
-**Last Reviewed:** May 25, 2026 (Brand Voice / Iteration 8 — default-voice prompt tuning: reviewer-protection guardrails, anti-self-flagellation blocklist, specificity, mixed-review rebalance, sample scoping, regenerate scoped precedence, anti-self-criticism rule, money-echo ban, contact-channel structural fix, multilingual concept framing, register-aware contractions, apology formality, business-agnostic CONTEXT block, broadened occasion fragment. Iteration 7 above covered the incomplete-email-config feedback work (defensive prompt + post-process + 3-distance UI warnings).)
+**Last Reviewed:** May 26, 2026 (regen-instructions persistence: schema columns + UI reveal + PostHog metadata-only telemetry. Earlier on May 25 — Brand Voice / Iteration 8 — default-voice prompt tuning: reviewer-protection guardrails, anti-self-flagellation blocklist, specificity, mixed-review rebalance, sample scoping, regenerate scoped precedence, anti-self-criticism rule, money-echo ban, contact-channel structural fix, multilingual concept framing, register-aware contractions, apology formality, business-agnostic CONTEXT block, broadened occasion fragment. Iteration 7 above covered the incomplete-email-config feedback work (defensive prompt + post-process + 3-distance UI warnings).)

--- a/prisma/migrations/20260526120000_add_response_additional_instructions/migration.sql
+++ b/prisma/migrations/20260526120000_add_response_additional_instructions/migration.sql
@@ -1,0 +1,23 @@
+-- Persist the per-regeneration "Additional instructions" the user typed
+-- into the regenerate dialog. Two columns, both nullable, both `text` so
+-- they accept the Zod-capped 500-char input without any DB-level cap of
+-- their own.
+--
+-- `review_responses.additionalInstructions`     — the instruction that
+--   produced the CURRENT live response. Null on initial generation, null
+--   after manual edits, non-null only when the latest action was a
+--   regenerate with the dialog's textarea filled in.
+--
+-- `response_versions.additionalInstructions`    — snapshot of the field
+--   archived alongside the response that produced an older row. Lets the
+--   version-history UI surface "what did the user type to produce this
+--   older response?".
+--
+-- Both columns are nullable + additive — no data backfill, no DB-level
+-- constraint, no risk to existing rows.
+
+ALTER TABLE "review_responses"
+  ADD COLUMN "additionalInstructions" text;
+
+ALTER TABLE "response_versions"
+  ADD COLUMN "additionalInstructions" text;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -250,6 +250,14 @@ model ReviewResponse {
   toneUsed        String @default("default")
   generationModel String @default("claude-sonnet-4-20250514")
 
+  // Free-text per-regeneration directive the user typed into the
+  // "Additional instructions" field on the regenerate dialog. Null on
+  // initial generations (the initial-generate route has no such field)
+  // and null after manual edits (edits aren't AI-generated, so there's
+  // no instruction associated). Capped at 500 chars at the Zod boundary.
+  // See DECISIONS.md "Persist additional instructions" entry.
+  additionalInstructions String? @db.Text
+
   isPublished Boolean   @default(false)
   publishedAt DateTime?
 
@@ -273,6 +281,11 @@ model ResponseVersion {
   toneUsed     String
   creditsUsed  Int     @default(1)
   isEdited     Boolean @default(false) // true if this version was manually edited
+
+  // Snapshot of `ReviewResponse.additionalInstructions` at the time this
+  // version was archived. Lets the version-history UI show "what did the
+  // user type to produce this older response?" alongside each row.
+  additionalInstructions String? @db.Text
 
   originalCreatedAt DateTime? // When the response was originally generated (null for legacy records)
   createdAt         DateTime  @default(now()) // When this version record was created (moved to history)

--- a/src/app/api/reviews/[id]/regenerate/route.ts
+++ b/src/app/api/reviews/[id]/regenerate/route.ts
@@ -252,7 +252,13 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     // Update response and save old version in a transaction
     const updatedResponse = await prisma.$transaction(async (tx) => {
       // First, save the CURRENT (old) response to version history
-      // This allows the user to restore to the previous version
+      // This allows the user to restore to the previous version.
+      //
+      // The archived row preserves whatever produced the PREVIOUS state:
+      // text, tone, credits, edited-flag, AND the additionalInstructions
+      // that produced that previous state. This is how the version-
+      // history UI can later show "what did the user type to produce this
+      // older response?" alongside each row.
       await tx.responseVersion.create({
         data: {
           reviewResponseId: review.response!.id,
@@ -260,11 +266,15 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
           toneUsed: review.response!.toneUsed,
           creditsUsed: review.response!.creditsUsed, // Credits used for the old generation
           isEdited: review.response!.isEdited, // Preserve edited status for history
+          additionalInstructions: review.response!.additionalInstructions, // Snapshot the instruction that produced the OLD state
           originalCreatedAt: review.response!.createdAt, // Preserve original creation timestamp
         },
       });
 
-      // Then update ReviewResponse with new text
+      // Then update ReviewResponse with new text. The NEW state's
+      // `additionalInstructions` is whatever the user just typed (or
+      // null if the textarea was empty/whitespace).
+      const trimmedInstructions = additionalInstructions?.trim();
       const updated = await tx.reviewResponse.update({
         where: { id: review.response!.id },
         data: {
@@ -274,6 +284,10 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
           creditsUsed: CREDIT_COSTS.REGENERATE_RESPONSE,
           isEdited: false, // Reset edited flag on regeneration
           editedAt: null,
+          additionalInstructions:
+            trimmedInstructions && trimmedInstructions.length > 0
+              ? trimmedInstructions
+              : null,
         },
       });
 

--- a/src/app/api/reviews/[id]/response/route.ts
+++ b/src/app/api/reviews/[id]/response/route.ts
@@ -98,8 +98,11 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
     const updatedResponse = await prisma.$transaction(async (tx) => {
       // Skip if the text hasn't actually changed
       if (responseText !== review.response!.responseText) {
-        // Save the current (pre-edit) text to version history
-        // Preserve the creditsUsed and isEdited of the current response
+        // Save the current (pre-edit) text to version history.
+        // Preserve the creditsUsed, isEdited, and additionalInstructions
+        // of the current response so the archive records "what produced
+        // this older state" — same archive contract as the regenerate
+        // route uses.
         await tx.responseVersion.create({
           data: {
             reviewResponseId: review.response!.id,
@@ -107,11 +110,14 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
             toneUsed: review.response!.toneUsed,
             creditsUsed: review.response!.creditsUsed,
             isEdited: review.response!.isEdited,
+            additionalInstructions: review.response!.additionalInstructions,
           },
         });
       }
 
-      // Update the response with new text
+      // Update the response with new text. Manual edits aren't AI-
+      // generated, so `additionalInstructions` is cleared on the live
+      // row — there's no instruction associated with the edited text.
       const updated = await tx.reviewResponse.update({
         where: { id: review.response!.id },
         data: {
@@ -119,6 +125,7 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
           isEdited: true,
           editedAt: new Date(),
           creditsUsed: 0,
+          additionalInstructions: null,
         },
       });
 

--- a/src/app/api/reviews/[id]/route.ts
+++ b/src/app/api/reviews/[id]/route.ts
@@ -92,6 +92,11 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
                   toneUsed: v.toneUsed,
                   creditsUsed: v.creditsUsed,
                   isEdited: v.isEdited,
+                  // The user-typed regenerate instruction that produced
+                  // this archived version (null for initial-generation
+                  // archives and for archives created when no instruction
+                  // was provided).
+                  additionalInstructions: v.additionalInstructions,
                   createdAt: v.createdAt.toISOString(),
                   originalCreatedAt: v.originalCreatedAt?.toISOString() ?? v.createdAt.toISOString(),
                 })),

--- a/src/components/reviews/ResponsePanel.tsx
+++ b/src/components/reviews/ResponsePanel.tsx
@@ -203,12 +203,24 @@ export function ResponsePanel({
         // per-regeneration tone override (5/25 simplification — the brand
         // voice tone applies as configured). Report the tone the server
         // persisted, which is the brand voice tone for default regens.
+        //
+        // 5/26: also report whether the user typed an instruction and
+        // how long it was. Raw text is NOT sent to PostHog — it lives in
+        // Postgres on ResponseVersion for ad-hoc analysis. PostHog event
+        // properties stay free of free-form PII.
+        const trimmedInstructions = payload.additionalInstructions?.trim();
+        const hadAdditionalInstructions =
+          !!trimmedInstructions && trimmedInstructions.length > 0;
         trackResponseRegenerated({
           tone: result.data.response.toneUsed as
             | "warm_casual"
             | "friendly_professional"
             | "polished_formal"
             | "empathetic_attentive",
+          hadAdditionalInstructions,
+          instructionLength: hadAdditionalInstructions
+            ? trimmedInstructions.length
+            : undefined,
         });
         refreshCredits();
         onResponseUpdate?.(); // This will fetch fresh data including the new version

--- a/src/components/reviews/ResponseVersionHistory.tsx
+++ b/src/components/reviews/ResponseVersionHistory.tsx
@@ -8,7 +8,7 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
-import { ChevronDown, History, Clock, Sparkles } from "lucide-react";
+import { ChevronDown, History, Clock, Sparkles, MessageSquareText } from "lucide-react";
 
 interface Version {
   id: string;
@@ -16,6 +16,11 @@ interface Version {
   toneUsed: string;
   creditsUsed: number;
   isEdited: boolean;
+  // User-typed regenerate-instructions that produced this archived
+  // version. Null when no instruction was provided (initial generation,
+  // empty textarea, manual edit). When present, the version-history UI
+  // surfaces a collapsed "Show regenerate instructions" affordance.
+  additionalInstructions?: string | null;
   createdAt: string;
   originalCreatedAt: string;
 }
@@ -83,6 +88,12 @@ export function ResponseVersionHistory({
 }: ResponseVersionHistoryProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [expandedVersionId, setExpandedVersionId] = useState<string | null>(null);
+  // Independent toggle for the "Show regenerate instructions" affordance.
+  // Tracked separately from the response-text "Show more" so the user
+  // can expand the instruction without expanding the response (and vice
+  // versa). Most versions have no instruction, so this state stays null
+  // most of the time.
+  const [expandedInstructionVersionId, setExpandedInstructionVersionId] = useState<string | null>(null);
 
   if (versions.length === 0) {
     return null;
@@ -168,6 +179,44 @@ export function ResponseVersionHistory({
                   {isExpanded ? "Show less" : "Show more"}
                 </Button>
               )}
+
+              {/* Regenerate-instructions reveal — only rendered when a
+                  non-empty instruction was archived with this version.
+                  Collapsed by default so it doesn't take screen space
+                  for typical regens (most have no instruction). */}
+              {version.additionalInstructions &&
+                version.additionalInstructions.trim().length > 0 && (
+                  <div className="space-y-2">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-7 px-2 text-xs gap-1"
+                      onClick={() =>
+                        setExpandedInstructionVersionId(
+                          expandedInstructionVersionId === version.id ? null : version.id,
+                        )
+                      }
+                    >
+                      <MessageSquareText className="h-3 w-3" />
+                      {expandedInstructionVersionId === version.id
+                        ? "Hide regenerate instructions"
+                        : "Show regenerate instructions"}
+                    </Button>
+                    {expandedInstructionVersionId === version.id && (
+                      <div className="rounded-md border border-slate-300 bg-card p-3 space-y-1">
+                        <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                          Regenerate instructions
+                        </p>
+                        <p
+                          className="text-sm text-foreground whitespace-pre-wrap"
+                          dir={textDirection}
+                        >
+                          {version.additionalInstructions}
+                        </p>
+                      </div>
+                    )}
+                  </div>
+                )}
             </div>
           );
         })}

--- a/src/lib/posthog-events.ts
+++ b/src/lib/posthog-events.ts
@@ -207,11 +207,30 @@ export function trackResponseGenerated(props: { tone: string }): void {
 }
 
 /**
- * Fires when the user regenerates an existing response with a different
- * tone modifier.
+ * Fires when the user regenerates an existing response.
+ *
+ * Properties:
+ *  - `tone` — the brand voice tone applied (5/25: tone selector dropped
+ *    from the dialog, so this is always the brand voice tone).
+ *  - `hadAdditionalInstructions` — boolean. Did the user type anything
+ *    into the regenerate dialog's textarea? Tells us how often the
+ *    feature is used at all.
+ *  - `instructionLength` — character length of the trimmed instruction,
+ *    or undefined when none was provided. Lets us see the distribution
+ *    of how much users type (one-liner instruction vs. paragraph). Raw
+ *    text is NOT sent — PostHog stays free of free-form PII; the raw
+ *    text is queryable in Postgres for ad-hoc analysis.
  */
-export function trackResponseRegenerated(props: { tone: string }): void {
-  capture("response_regenerated", { tone: props.tone });
+export function trackResponseRegenerated(props: {
+  tone: string;
+  hadAdditionalInstructions: boolean;
+  instructionLength?: number;
+}): void {
+  capture("response_regenerated", {
+    tone: props.tone,
+    hadAdditionalInstructions: props.hadAdditionalInstructions,
+    instructionLength: props.instructionLength,
+  });
 }
 
 /**

--- a/tests/unit/api/reviews/regenerate.test.ts
+++ b/tests/unit/api/reviews/regenerate.test.ts
@@ -138,6 +138,9 @@ const existingResponse = {
   generationModel: 'claude-sonnet-4-20250514',
   isPublished: false,
   publishedAt: null,
+  // 5/26 — persisted regenerate-instruction field. The default fixture
+  // represents an initial-generation response (no instruction).
+  additionalInstructions: null as string | null,
   createdAt: new Date('2026-01-15'),
   updatedAt: new Date('2026-01-15'),
 };
@@ -317,6 +320,106 @@ describe('POST /api/reviews/[id]/regenerate', () => {
           toneUsed: 'professional',
           creditsUsed: 1,
           isEdited: false,
+          // 5/26 — the snapshot must carry the additionalInstructions
+          // value that was on the PREVIOUS state of the response. Our
+          // default fixture has null (initial generation), so the
+          // archive also gets null.
+          additionalInstructions: null,
+        }),
+      }),
+    );
+  });
+
+  // 5/26 — when the previous response was itself a regen (had an
+  // instruction), that instruction must be archived to the new version.
+  it('archives the previous additionalInstructions value into the new version row', async () => {
+    mockPrisma.user.findUnique.mockResolvedValueOnce(baseUser);
+    mockPrisma.review.findFirst.mockResolvedValueOnce({
+      ...reviewWithResponse,
+      response: {
+        ...existingResponse,
+        additionalInstructions: 'Be more apologetic about the dessert',
+      },
+    });
+    mockPrisma.responseVersion.create.mockResolvedValueOnce({});
+    mockPrisma.reviewResponse.update.mockResolvedValueOnce(existingResponse);
+
+    const req = createRequest('/api/reviews/review-1/regenerate', {
+      method: 'POST',
+      body: { additionalInstructions: 'Mention the loyalty program' },
+    });
+    await POST(req, routeParams({ id: 'review-1' }));
+
+    expect(mockPrisma.responseVersion.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          // The archive snapshots the OLD instruction (what produced
+          // the response we're replacing).
+          additionalInstructions: 'Be more apologetic about the dessert',
+        }),
+      }),
+    );
+  });
+
+  // 5/26 — the LIVE row (ReviewResponse) gets the NEW instruction.
+  it('persists the new additionalInstructions on the live ReviewResponse row', async () => {
+    mockPrisma.user.findUnique.mockResolvedValueOnce(baseUser);
+    mockPrisma.review.findFirst.mockResolvedValueOnce(reviewWithResponse);
+    mockPrisma.responseVersion.create.mockResolvedValueOnce({});
+    mockPrisma.reviewResponse.update.mockResolvedValueOnce(existingResponse);
+
+    const req = createRequest('/api/reviews/review-1/regenerate', {
+      method: 'POST',
+      body: { additionalInstructions: 'Mention the loyalty program' },
+    });
+    await POST(req, routeParams({ id: 'review-1' }));
+
+    expect(mockPrisma.reviewResponse.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          additionalInstructions: 'Mention the loyalty program',
+        }),
+      }),
+    );
+  });
+
+  it('writes null to the live row when no additionalInstructions was provided', async () => {
+    mockPrisma.user.findUnique.mockResolvedValueOnce(baseUser);
+    mockPrisma.review.findFirst.mockResolvedValueOnce(reviewWithResponse);
+    mockPrisma.responseVersion.create.mockResolvedValueOnce({});
+    mockPrisma.reviewResponse.update.mockResolvedValueOnce(existingResponse);
+
+    const req = createRequest('/api/reviews/review-1/regenerate', {
+      method: 'POST',
+      body: {},
+    });
+    await POST(req, routeParams({ id: 'review-1' }));
+
+    expect(mockPrisma.reviewResponse.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          additionalInstructions: null,
+        }),
+      }),
+    );
+  });
+
+  it('normalises whitespace-only additionalInstructions to null on the live row', async () => {
+    mockPrisma.user.findUnique.mockResolvedValueOnce(baseUser);
+    mockPrisma.review.findFirst.mockResolvedValueOnce(reviewWithResponse);
+    mockPrisma.responseVersion.create.mockResolvedValueOnce({});
+    mockPrisma.reviewResponse.update.mockResolvedValueOnce(existingResponse);
+
+    const req = createRequest('/api/reviews/review-1/regenerate', {
+      method: 'POST',
+      body: { additionalInstructions: '   \n\n   ' },
+    });
+    await POST(req, routeParams({ id: 'review-1' }));
+
+    expect(mockPrisma.reviewResponse.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          additionalInstructions: null,
         }),
       }),
     );

--- a/tests/unit/api/reviews/response-edit.test.ts
+++ b/tests/unit/api/reviews/response-edit.test.ts
@@ -77,6 +77,9 @@ const existingResponse = {
   generationModel: 'claude-sonnet-4-20250514',
   isPublished: false,
   publishedAt: null,
+  // 5/26 — persisted regenerate-instruction field. Default fixture is
+  // null (initial-generation state).
+  additionalInstructions: null as string | null,
   createdAt: new Date('2026-01-15'),
   updatedAt: new Date('2026-01-15'),
 };
@@ -277,5 +280,60 @@ describe('PUT /api/reviews/[id]/response', () => {
     expect(res.status).toBe(200);
     expect(json.success).toBe(true);
     expect(mockPrisma.responseVersion.create).not.toHaveBeenCalled();
+  });
+
+  // 5/26 — manual edits are not AI-generated. The live row's
+  // `additionalInstructions` is cleared (set to null); the archive
+  // preserves whatever produced the previous state.
+  it('clears additionalInstructions on the live row when manually editing', async () => {
+    mockPrisma.review.findFirst.mockResolvedValueOnce({
+      ...reviewWithResponse,
+      response: {
+        ...existingResponse,
+        additionalInstructions: 'Be more apologetic about the dessert',
+      },
+    });
+    mockPrisma.responseVersion.create.mockResolvedValueOnce({});
+    mockPrisma.reviewResponse.update.mockResolvedValueOnce(existingResponse);
+
+    const req = createRequest('/api/reviews/review-1/response', {
+      method: 'PUT',
+      body: { responseText: 'A hand-edited reply.' },
+    });
+    await PUT(req, routeParams({ id: 'review-1' }));
+
+    expect(mockPrisma.reviewResponse.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          additionalInstructions: null,
+        }),
+      }),
+    );
+  });
+
+  it('archives the previous additionalInstructions into the new ResponseVersion row', async () => {
+    mockPrisma.review.findFirst.mockResolvedValueOnce({
+      ...reviewWithResponse,
+      response: {
+        ...existingResponse,
+        additionalInstructions: 'Be more apologetic about the dessert',
+      },
+    });
+    mockPrisma.responseVersion.create.mockResolvedValueOnce({});
+    mockPrisma.reviewResponse.update.mockResolvedValueOnce(existingResponse);
+
+    const req = createRequest('/api/reviews/review-1/response', {
+      method: 'PUT',
+      body: { responseText: 'A hand-edited reply.' },
+    });
+    await PUT(req, routeParams({ id: 'review-1' }));
+
+    expect(mockPrisma.responseVersion.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          additionalInstructions: 'Be more apologetic about the dessert',
+        }),
+      }),
+    );
   });
 });

--- a/tests/unit/components/reviews/response-version-history.test.tsx
+++ b/tests/unit/components/reviews/response-version-history.test.tsx
@@ -89,4 +89,89 @@ describe("ResponseVersionHistory", () => {
 
     expect(screen.getByText("Show more")).toBeInTheDocument();
   });
+
+  // 5/26 — regenerate-instructions reveal. The button is collapsed by
+  // default and only renders when the archived version carries a non-
+  // empty instruction.
+  describe("regenerate-instructions reveal", () => {
+    it("does NOT render the 'Show regenerate instructions' button when no instruction was archived", () => {
+      // mockVersions both have `additionalInstructions` undefined / unset.
+      render(<ResponseVersionHistory versions={mockVersions} />);
+      fireEvent.click(screen.getByText("Version History (2)"));
+
+      expect(
+        screen.queryByText(/show regenerate instructions/i),
+      ).not.toBeInTheDocument();
+    });
+
+    it("does NOT render the button when additionalInstructions is empty/whitespace", () => {
+      const versions = [{ ...mockVersions[0], additionalInstructions: "   " }];
+      render(<ResponseVersionHistory versions={versions} />);
+      fireEvent.click(screen.getByText("Version History (1)"));
+
+      expect(
+        screen.queryByText(/show regenerate instructions/i),
+      ).not.toBeInTheDocument();
+    });
+
+    it("renders the collapsed button when a non-empty instruction was archived", () => {
+      const versions = [
+        {
+          ...mockVersions[0],
+          additionalInstructions: "Be more apologetic about the dessert",
+        },
+      ];
+      render(<ResponseVersionHistory versions={versions} />);
+      fireEvent.click(screen.getByText("Version History (1)"));
+
+      // Button is visible, panel is collapsed (the instruction text is
+      // NOT rendered yet).
+      expect(
+        screen.getByText(/show regenerate instructions/i),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText("Be more apologetic about the dessert"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("expands to reveal the instruction text on click; toggles back to hidden", () => {
+      const versions = [
+        {
+          ...mockVersions[0],
+          additionalInstructions: "Be more apologetic about the dessert",
+        },
+      ];
+      render(<ResponseVersionHistory versions={versions} />);
+      fireEvent.click(screen.getByText("Version History (1)"));
+
+      // Reveal
+      fireEvent.click(screen.getByText(/show regenerate instructions/i));
+      expect(
+        screen.getByText("Be more apologetic about the dessert"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/hide regenerate instructions/i),
+      ).toBeInTheDocument();
+
+      // Hide again
+      fireEvent.click(screen.getByText(/hide regenerate instructions/i));
+      expect(
+        screen.queryByText("Be more apologetic about the dessert"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("renders the section label 'Regenerate instructions' when expanded", () => {
+      const versions = [
+        {
+          ...mockVersions[0],
+          additionalInstructions: "Mention loyalty",
+        },
+      ];
+      render(<ResponseVersionHistory versions={versions} />);
+      fireEvent.click(screen.getByText("Version History (1)"));
+      fireEvent.click(screen.getByText(/show regenerate instructions/i));
+
+      expect(screen.getByText("Regenerate instructions")).toBeInTheDocument();
+    });
+  });
 });

--- a/tests/unit/lib/posthog-events.test.ts
+++ b/tests/unit/lib/posthog-events.test.ts
@@ -172,10 +172,28 @@ describe("posthog-events — AI usage", () => {
     });
   });
 
-  it("trackResponseRegenerated carries tone", () => {
-    trackResponseRegenerated({ tone: "empathetic" });
+  it("trackResponseRegenerated carries tone and instruction metadata (no raw text)", () => {
+    trackResponseRegenerated({
+      tone: "empathetic",
+      hadAdditionalInstructions: true,
+      instructionLength: 42,
+    });
     expect(captureMock).toHaveBeenCalledWith("response_regenerated", {
       tone: "empathetic",
+      hadAdditionalInstructions: true,
+      instructionLength: 42,
+    });
+  });
+
+  it("trackResponseRegenerated reports the false case + undefined length when no instruction was typed", () => {
+    trackResponseRegenerated({
+      tone: "friendly_professional",
+      hadAdditionalInstructions: false,
+    });
+    expect(captureMock).toHaveBeenCalledWith("response_regenerated", {
+      tone: "friendly_professional",
+      hadAdditionalInstructions: false,
+      instructionLength: undefined,
     });
   });
 


### PR DESCRIPTION
## Summary

Persists the user's "Additional instructions" text from the regenerate dialog so it can be referenced later (by the user via version history, by us via direct DB queries) and lightly tracked in PostHog telemetry.

Per discussion: **Path A (persist in DB)** with metadata-only PostHog telemetry on top. Raw text stays in Postgres for ad-hoc analysis; PostHog stays free of free-form PII. The DB-backed approach preserves analytical flexibility (we can recategorize the data later when new questions come up).

### What changes

**Schema (additive migration).** A nullable `additionalInstructions text` column on BOTH `ReviewResponse` (the live row) and `ResponseVersion` (the archive). Both columns are nullable; no DB-level constraint; no data backfill needed. Existing rows get null and work fine.

**Routes.**
- **Regenerate** — writes the new instruction to the live `ReviewResponse` row (trimmed, whitespace-only normalised to null). Before that, archives the previous `additionalInstructions` into the new `ResponseVersion` row alongside `responseText`, `toneUsed`, `creditsUsed`, `isEdited`.
- **Manual edit** — clears the live row's `additionalInstructions` (edits aren't AI-generated, so no instruction is associated). Archives the pre-edit value into the new `ResponseVersion`.
- **Review detail GET** — each version in the response payload includes the field. UI uses it.
- **Initial generate** — unchanged. No instruction to write; the new column on `ReviewResponse` is nullable for that flow.

**UI.** `ResponseVersionHistory.tsx` gains a collapsed "Show regenerate instructions" affordance per version row, rendered only when the field is non-empty. State tracked independently from the existing response-text "Show more" toggle. When expanded, the instruction appears in a small bordered+tinted panel with a "Regenerate instructions" uppercase eyebrow label.

**PostHog.** `trackResponseRegenerated` extended with `hadAdditionalInstructions: boolean` + `instructionLength?: number`. Raw text NOT sent.

### Future consideration documented in DECISIONS.md

The user flagged interest in a "polish my draft" feature on initial generation. Today's `customRegenerateInstructions` slot works as a hack but isn't designed for it (framing is "additional instructions", not "user-supplied draft to refine"). A proper implementation would add a parallel slot in the prompt builder with its own framing and override semantics. **Out of scope for this PR**, captured for future evidence-driven decision.

### GDPR / data posture

Cascade-deletes with `ReviewResponse` → `Review` → `User`. No special audit semantics. Same risk profile as the response text itself (which we already store).

## Test plan

- [x] `npm run lint:strict` clean
- [x] `npm run type-check` clean
- [x] `npm run test:unit` — **1095 passed, 30 skipped, 0 failed** (64 files). 12 net new test cases across the four touched test files. Migration verified against local Postgres separately.
- [ ] Manual smoke test on Preview after merge:
  - regenerate without typing anything → verify version-history shows the new entry without a "Show regenerate instructions" button
  - regenerate WITH text → verify the button appears on the new history row, expands to show the typed text
  - manually edit the response after a regen-with-instructions → verify the archive preserves the instruction and the new live response has no instruction associated
  - check PostHog dashboard for the new event properties on a `response_regenerated` event

🤖 Generated with [Claude Code](https://claude.com/claude-code)
