### PR TITLE
fix(ui): surface additionalInstructions on the live response

### DIFF
--- a/src/app/api/reviews/[id]/generate/route.ts
+++ b/src/app/api/reviews/[id]/generate/route.ts
@@ -274,6 +274,10 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
           generationModel: result.generationModel,
           isEdited: result.isEdited,
           isPublished: result.isPublished,
+          // 5/26 — initial generation has no per-regeneration instruction,
+          // but the field is included for response-shape consistency with
+          // the regenerate/edit routes. Always null here.
+          additionalInstructions: result.additionalInstructions,
           createdAt: result.createdAt.toISOString(),
         },
         creditsRemaining: creditResult.user?.credits ?? user.credits - CREDIT_COSTS.GENERATE_RESPONSE,

--- a/src/app/api/reviews/[id]/regenerate/route.ts
+++ b/src/app/api/reviews/[id]/regenerate/route.ts
@@ -306,6 +306,9 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
           generationModel: updatedResponse.generationModel,
           isEdited: updatedResponse.isEdited,
           isPublished: updatedResponse.isPublished,
+          // 5/26 — surface the persisted instruction so the client can
+          // refresh the live-response reveal without a follow-up GET.
+          additionalInstructions: updatedResponse.additionalInstructions,
           createdAt: updatedResponse.createdAt.toISOString(),
           updatedAt: updatedResponse.updatedAt.toISOString(),
         },

--- a/src/app/api/reviews/[id]/response/route.ts
+++ b/src/app/api/reviews/[id]/response/route.ts
@@ -143,6 +143,9 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
           editedAt: updatedResponse.editedAt?.toISOString() || null,
           toneUsed: updatedResponse.toneUsed,
           isPublished: updatedResponse.isPublished,
+          // 5/26 — surface the (now-null) instruction so the client can
+          // collapse the live-response reveal after a manual edit.
+          additionalInstructions: updatedResponse.additionalInstructions,
           createdAt: updatedResponse.createdAt.toISOString(),
           updatedAt: updatedResponse.updatedAt.toISOString(),
         },

--- a/src/app/api/reviews/[id]/route.ts
+++ b/src/app/api/reviews/[id]/route.ts
@@ -81,6 +81,11 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
                 generationModel: review.response.generationModel,
                 isPublished: review.response.isPublished,
                 publishedAt: review.response.publishedAt?.toISOString() || null,
+                // 5/26 — user-typed regenerate instruction that produced
+                // the CURRENT live response. Null for initial-generation
+                // state, null after a manual edit (edits aren't AI-gen),
+                // null for regens where the textarea was empty.
+                additionalInstructions: review.response.additionalInstructions,
                 createdAt: review.response.createdAt.toISOString(),
                 updatedAt: review.response.updatedAt.toISOString(),
                 totalCreditsUsed:

--- a/src/components/reviews/ResponsePanel.tsx
+++ b/src/components/reviews/ResponsePanel.tsx
@@ -16,6 +16,7 @@ import {
   ChevronDown,
   ChevronUp,
   Coins,
+  MessageSquareText,
 } from "lucide-react";
 import { useSession } from "next-auth/react";
 import { ResponseEditor } from "./ResponseEditor";
@@ -49,6 +50,12 @@ interface Response {
   generationModel: string;
   isPublished: boolean;
   publishedAt: string | null;
+  // User-typed regenerate-instruction that produced the CURRENT live
+  // response. Null for initial-generation state, null after a manual
+  // edit (edits aren't AI-gen), and null for regens where the textarea
+  // was empty. When non-empty, the "Show regenerate instructions"
+  // reveal appears beneath the response text.
+  additionalInstructions?: string | null;
   createdAt: string;
   updatedAt: string;
   totalCreditsUsed: number;
@@ -119,6 +126,11 @@ export function ResponsePanel({
   const [isLoading, setIsLoading] = useState(false);
   const [localResponse, setLocalResponse] = useState<Response | null>(response);
   const [isResponseExpanded, setIsResponseExpanded] = useState(false);
+  // 5/26 — independent toggle for the live response's "Show regenerate
+  // instructions" affordance. Collapsed by default; most responses
+  // (initial generations, manual edits, no-instruction regens) have a
+  // null instruction and never render the button at all.
+  const [isInstructionExpanded, setIsInstructionExpanded] = useState(false);
   const [showOutOfCreditsDialog, setShowOutOfCreditsDialog] = useState(false);
   const [outOfCreditsActionType, setOutOfCreditsActionType] = useState<"generate" | "regenerate">("generate");
 
@@ -156,9 +168,17 @@ export function ResponsePanel({
                 responseText: result.data.response.responseText,
                 isEdited: result.data.response.isEdited,
                 editedAt: result.data.response.editedAt,
+                // Manual edits clear `additionalInstructions` on the
+                // server (the live row has no AI-gen instruction
+                // associated with hand-edited text). Mirror that in
+                // local state and collapse the reveal so a stale
+                // expanded panel doesn't linger.
+                additionalInstructions:
+                  result.data.response.additionalInstructions ?? null,
               }
             : null
         );
+        setIsInstructionExpanded(false);
         setIsEditing(false);
         toast.success("Response updated!");
         onResponseUpdate?.();
@@ -195,9 +215,17 @@ export function ResponsePanel({
                 toneUsed: result.data.response.toneUsed,
                 isEdited: false,
                 editedAt: null,
+                // Carry the server-persisted instruction onto the live
+                // row so the reveal renders for the new state. `null`
+                // when the textarea was empty for this regen.
+                additionalInstructions:
+                  result.data.response.additionalInstructions ?? null,
               }
             : null
         );
+        // Collapse the reveal by default for the new instruction. The
+        // user can expand it again from the button below the response.
+        setIsInstructionExpanded(false);
         toast.success(`Response regenerated!`);
         // PostHog: response_regenerated. The dialog no longer carries a
         // per-regeneration tone override (5/25 simplification — the brand
@@ -292,6 +320,11 @@ export function ResponsePanel({
           generationModel: result.data.response.generationModel,
           isPublished: false,
           publishedAt: null,
+          // Initial generation never carries an instruction — the
+          // dialog/textarea is a regenerate-only knob — so this is
+          // effectively always null here. Kept for shape consistency.
+          additionalInstructions:
+            result.data.response.additionalInstructions ?? null,
           createdAt: result.data.response.createdAt,
           updatedAt: result.data.response.createdAt,
           totalCreditsUsed: result.data.response.creditsUsed,
@@ -472,6 +505,43 @@ export function ResponsePanel({
                 </Button>
               )}
             </div>
+
+            {/* Regenerate-instructions reveal for the LIVE response.
+                Mirrors the per-version pattern in ResponseVersionHistory:
+                only renders when a non-empty instruction is associated
+                with the current state. Collapsed by default so a typical
+                regen (no instruction) doesn't add visual noise. */}
+            {localResponse.additionalInstructions &&
+              localResponse.additionalInstructions.trim().length > 0 && (
+                <div className="space-y-2">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 px-2 text-xs gap-1"
+                    onClick={() =>
+                      setIsInstructionExpanded((prev) => !prev)
+                    }
+                  >
+                    <MessageSquareText className="h-3 w-3" />
+                    {isInstructionExpanded
+                      ? "Hide regenerate instructions"
+                      : "Show regenerate instructions"}
+                  </Button>
+                  {isInstructionExpanded && (
+                    <div className="rounded-md border border-slate-300 bg-card p-3 space-y-1">
+                      <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                        Regenerate instructions
+                      </p>
+                      <p
+                        className="text-sm text-foreground whitespace-pre-wrap"
+                        dir={textDirection}
+                      >
+                        {localResponse.additionalInstructions}
+                      </p>
+                    </div>
+                  )}
+                </div>
+              )}
 
             {/* Actions */}
             <div className="flex flex-wrap items-center gap-2">

--- a/tests/unit/api/reviews/regenerate.test.ts
+++ b/tests/unit/api/reviews/regenerate.test.ts
@@ -383,6 +383,32 @@ describe('POST /api/reviews/[id]/regenerate', () => {
     );
   });
 
+  // 5/26 — the route response payload must surface the persisted
+  // additionalInstructions so the ResponsePanel can refresh its live-
+  // response "Show regenerate instructions" reveal without a follow-up
+  // GET.
+  it('returns the persisted additionalInstructions in the route response payload', async () => {
+    mockPrisma.user.findUnique.mockResolvedValueOnce(baseUser);
+    mockPrisma.review.findFirst.mockResolvedValueOnce(reviewWithResponse);
+    mockPrisma.responseVersion.create.mockResolvedValueOnce({});
+    mockPrisma.reviewResponse.update.mockResolvedValueOnce({
+      ...existingResponse,
+      additionalInstructions: 'Mention the loyalty program',
+    });
+
+    const req = createRequest('/api/reviews/review-1/regenerate', {
+      method: 'POST',
+      body: { additionalInstructions: 'Mention the loyalty program' },
+    });
+    const res = await POST(req, routeParams({ id: 'review-1' }));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.data.response.additionalInstructions).toBe(
+      'Mention the loyalty program',
+    );
+  });
+
   it('writes null to the live row when no additionalInstructions was provided', async () => {
     mockPrisma.user.findUnique.mockResolvedValueOnce(baseUser);
     mockPrisma.review.findFirst.mockResolvedValueOnce(reviewWithResponse);

--- a/tests/unit/api/reviews/response-edit.test.ts
+++ b/tests/unit/api/reviews/response-edit.test.ts
@@ -336,4 +336,37 @@ describe('PUT /api/reviews/[id]/response', () => {
       }),
     );
   });
+
+  // 5/26 — manual edits clear additionalInstructions on the live row.
+  // The route response must surface that null so the client can collapse
+  // its live-response "Show regenerate instructions" reveal in one round
+  // trip instead of waiting for a follow-up GET.
+  it('returns null additionalInstructions in the route response payload after a manual edit', async () => {
+    mockPrisma.review.findFirst.mockResolvedValueOnce({
+      ...reviewWithResponse,
+      response: {
+        ...existingResponse,
+        additionalInstructions: 'Be more apologetic about the dessert',
+      },
+    });
+    mockPrisma.responseVersion.create.mockResolvedValueOnce({});
+    mockPrisma.reviewResponse.update.mockResolvedValueOnce({
+      ...existingResponse,
+      responseText: 'A hand-edited reply.',
+      isEdited: true,
+      editedAt: new Date(),
+      creditsUsed: 0,
+      additionalInstructions: null,
+    });
+
+    const req = createRequest('/api/reviews/review-1/response', {
+      method: 'PUT',
+      body: { responseText: 'A hand-edited reply.' },
+    });
+    const res = await PUT(req, routeParams({ id: 'review-1' }));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.data.response.additionalInstructions).toBeNull();
+  });
 });

--- a/tests/unit/api/reviews/review-detail.test.ts
+++ b/tests/unit/api/reviews/review-detail.test.ts
@@ -90,6 +90,10 @@ const reviewWithResponse = {
     generationModel: 'claude-sonnet-4-20250514',
     isPublished: false,
     publishedAt: null,
+    // 5/26 — persisted regenerate-instruction on the LIVE response.
+    // Default fixture is null (initial-generation / manual-edit / no-
+    // instruction-regen state).
+    additionalInstructions: null as string | null,
     createdAt: new Date('2026-01-15'),
     updatedAt: new Date('2026-01-15'),
     versions: [],
@@ -153,6 +157,41 @@ describe('GET /api/reviews/[id]', () => {
     expect(json.data.review.response).toBeDefined();
     expect(json.data.review.response.responseText).toBe('Thank you for your kind words!');
     expect(json.data.review.response.versions).toEqual([]);
+  });
+
+  // 5/26 — the live response must surface `additionalInstructions` so
+  // the ResponsePanel can render its "Show regenerate instructions"
+  // reveal without a follow-up fetch. Previously this field was only
+  // exposed on archived versions, not on the live row.
+  it('surfaces additionalInstructions on the live response object when present', async () => {
+    mockPrisma.review.findFirst.mockResolvedValueOnce({
+      ...reviewWithResponse,
+      response: {
+        ...reviewWithResponse.response,
+        additionalInstructions: 'Be more apologetic about the dessert',
+      },
+    });
+    const req = createRequest('/api/reviews/review-1');
+
+    const res = await GET(req, routeParams({ id: 'review-1' }));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.data.review.response.additionalInstructions).toBe(
+      'Be more apologetic about the dessert',
+    );
+  });
+
+  it('returns null additionalInstructions on the live response in the no-instruction state', async () => {
+    // Default fixture has additionalInstructions: null.
+    mockPrisma.review.findFirst.mockResolvedValueOnce(reviewWithResponse);
+    const req = createRequest('/api/reviews/review-1');
+
+    const res = await GET(req, routeParams({ id: 'review-1' }));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.data.review.response.additionalInstructions).toBeNull();
   });
 });
 

--- a/tests/unit/components/reviews/response-panel.test.tsx
+++ b/tests/unit/components/reviews/response-panel.test.tsx
@@ -212,6 +212,80 @@ describe("ResponsePanel", () => {
     });
   });
 
+  // 5/26 — regenerate-instructions reveal on the LIVE response. The
+  // button is collapsed by default and only renders when the live row
+  // carries a non-empty `additionalInstructions`. Mirrors the per-
+  // version pattern in ResponseVersionHistory.
+  describe("live-response regenerate-instructions reveal", () => {
+    it("does NOT render the button when the live response has no instruction", () => {
+      // mockResponse has `additionalInstructions` undefined.
+      render(<ResponsePanel reviewId="rev_1" response={mockResponse} />);
+
+      expect(
+        screen.queryByText(/show regenerate instructions/i),
+      ).not.toBeInTheDocument();
+    });
+
+    it("does NOT render the button when additionalInstructions is empty/whitespace", () => {
+      const withWhitespace = { ...mockResponse, additionalInstructions: "   " };
+      render(<ResponsePanel reviewId="rev_1" response={withWhitespace} />);
+
+      expect(
+        screen.queryByText(/show regenerate instructions/i),
+      ).not.toBeInTheDocument();
+    });
+
+    it("renders the collapsed button when the live response carries a non-empty instruction", () => {
+      const withInstruction = {
+        ...mockResponse,
+        additionalInstructions: "Mention the loyalty program",
+      };
+      render(<ResponsePanel reviewId="rev_1" response={withInstruction} />);
+
+      // Button visible, panel collapsed (instruction text NOT in the DOM yet).
+      expect(
+        screen.getByText(/show regenerate instructions/i),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText("Mention the loyalty program"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("expands to reveal the instruction text on click; toggles back to hidden", () => {
+      const withInstruction = {
+        ...mockResponse,
+        additionalInstructions: "Be more apologetic about the cold food",
+      };
+      render(<ResponsePanel reviewId="rev_1" response={withInstruction} />);
+
+      // Reveal
+      fireEvent.click(screen.getByText(/show regenerate instructions/i));
+      expect(
+        screen.getByText("Be more apologetic about the cold food"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/hide regenerate instructions/i),
+      ).toBeInTheDocument();
+
+      // Hide again
+      fireEvent.click(screen.getByText(/hide regenerate instructions/i));
+      expect(
+        screen.queryByText("Be more apologetic about the cold food"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("renders the section label 'Regenerate instructions' when expanded", () => {
+      const withInstruction = {
+        ...mockResponse,
+        additionalInstructions: "Mention loyalty",
+      };
+      render(<ResponsePanel reviewId="rev_1" response={withInstruction} />);
+      fireEvent.click(screen.getByText(/show regenerate instructions/i));
+
+      expect(screen.getByText("Regenerate instructions")).toBeInTheDocument();
+    });
+  });
+
   describe("version history", () => {
     it("does not render version history when versions is empty", () => {
       render(<ResponsePanel reviewId="rev_1" response={mockResponse} />);


### PR DESCRIPTION
## Summary

PR #148 added the "Show regenerate instructions" reveal to archived versions in the version-history list, but the same reveal was missing from the LIVE response card. After regenerating with an instruction, the field was correctly persisted on `ReviewResponse.additionalInstructions`, but two gaps kept it off the UI:

- `GET /api/reviews/[id]` omitted the field on the live response object (it was only emitted on the per-version array).
- The `regenerate` / `edit` / `generate` route response payloads didn't include it either, so optimistic local-state updates in `ResponsePanel` had no value to read.

This PR closes both gaps:

- Adds `additionalInstructions` to the live response projection in `GET /api/reviews/[id]` and to all three response-mutation route payloads.
- Extends the `Response` interface in `ResponsePanel` to include the field; threads it through every local-state setter (regenerate carries the new value, manual edit clears to `null` and collapses the panel, initial generate stays `null` for shape consistency).
- Renders the same collapsed "Show regenerate instructions" button beneath the live response text whenever the field is non-empty, with the same expand/collapse pattern as the per-version reveal.

## Test plan

- [x] `npm run lint:strict` clean
- [x] `npm run type-check` clean
- [x] `npm run test:unit` — 1104 passed, 0 failed (1100 → 1104; +4 new cases; +5 ResponsePanel cases)
- [ ] Manual on staging: regenerate a response with a custom instruction → live response card shows the collapsed "Show regenerate instructions" button → click to reveal the instruction text → click again to hide
- [ ] Manual on staging: manually edit a response that had an instruction → button disappears (instruction cleared on edit)
- [ ] Manual on staging: regenerate with empty textarea → button doesn't appear
- [ ] Manual on staging: initial generation → button never appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)