### PR TITLE
fix(api): archive response.updatedAt as version originalCreatedAt

### DIFF
--- a/src/app/api/reviews/[id]/regenerate/route.ts
+++ b/src/app/api/reviews/[id]/regenerate/route.ts
@@ -267,7 +267,15 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
           creditsUsed: review.response!.creditsUsed, // Credits used for the old generation
           isEdited: review.response!.isEdited, // Preserve edited status for history
           additionalInstructions: review.response!.additionalInstructions, // Snapshot the instruction that produced the OLD state
-          originalCreatedAt: review.response!.createdAt, // Preserve original creation timestamp
+          // Preserve the timestamp of the response state we're about
+          // to overwrite. We use `updatedAt`, not `createdAt`, because
+          // the live row's `createdAt` is fixed to the time of initial
+          // generation and never moves — `updatedAt` bumps on every
+          // regen/edit (Prisma `@updatedAt`), so it's the correct
+          // "when did this state originate" timestamp for any non-
+          // first archive. The version-history UI reads this value
+          // and displays it as the per-version "X minutes ago" label.
+          originalCreatedAt: review.response!.updatedAt,
         },
       });
 

--- a/src/app/api/reviews/[id]/response/route.ts
+++ b/src/app/api/reviews/[id]/response/route.ts
@@ -111,6 +111,18 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
             creditsUsed: review.response!.creditsUsed,
             isEdited: review.response!.isEdited,
             additionalInstructions: review.response!.additionalInstructions,
+            // Preserve the timestamp of the response state we're about
+            // to overwrite, so the version-history UI shows when the
+            // archived text was actually produced (last generated or
+            // edited) instead of "just now" when this archive row was
+            // created. We use `updatedAt` here, not `createdAt`,
+            // because the live row's `createdAt` is fixed to the time
+            // of initial generation and never moves — `updatedAt`
+            // bumps on every regen/edit (Prisma `@updatedAt`), so it's
+            // the correct "when did this state originate" timestamp
+            // for any non-first archive. Matches the regenerate
+            // route's archive contract.
+            originalCreatedAt: review.response!.updatedAt,
           },
         });
       }

--- a/tests/unit/api/reviews/regenerate.test.ts
+++ b/tests/unit/api/reviews/regenerate.test.ts
@@ -330,6 +330,53 @@ describe('POST /api/reviews/[id]/regenerate', () => {
     );
   });
 
+  // 5/26 — the archive must carry the response's `updatedAt` as the
+  // `originalCreatedAt`, NOT its `createdAt`. The live row's `createdAt`
+  // is fixed at initial generation and never moves; `updatedAt` bumps
+  // on every regen/edit, so it's the correct "when did this archived
+  // state originate" timestamp. Without this, the version-history UI
+  // shows the initial-generation time on every archive after the first
+  // regen, or worse, shows "just now" when the archive row itself
+  // was created.
+  it('archives the response.updatedAt as originalCreatedAt (not createdAt)', async () => {
+    const createdAt = new Date('2026-01-15T10:00:00Z');
+    const updatedAt = new Date('2026-01-15T10:05:00Z'); // 5 minutes later
+
+    mockPrisma.user.findUnique.mockResolvedValueOnce(baseUser);
+    mockPrisma.review.findFirst.mockResolvedValueOnce({
+      ...reviewWithResponse,
+      response: {
+        ...existingResponse,
+        createdAt,
+        updatedAt,
+      },
+    });
+    mockPrisma.responseVersion.create.mockResolvedValueOnce({});
+    mockPrisma.reviewResponse.update.mockResolvedValueOnce(existingResponse);
+
+    const req = createRequest('/api/reviews/review-1/regenerate', {
+      method: 'POST',
+      body: {},
+    });
+    await POST(req, routeParams({ id: 'review-1' }));
+
+    expect(mockPrisma.responseVersion.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          originalCreatedAt: updatedAt,
+        }),
+      }),
+    );
+    // Defensive: confirm we did NOT use createdAt.
+    expect(mockPrisma.responseVersion.create).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          originalCreatedAt: createdAt,
+        }),
+      }),
+    );
+  });
+
   // 5/26 — when the previous response was itself a regen (had an
   // instruction), that instruction must be archived to the new version.
   it('archives the previous additionalInstructions value into the new version row', async () => {

--- a/tests/unit/api/reviews/response-edit.test.ts
+++ b/tests/unit/api/reviews/response-edit.test.ts
@@ -311,6 +311,57 @@ describe('PUT /api/reviews/[id]/response', () => {
     );
   });
 
+  // 5/26 — same archive timestamp contract as the regenerate route.
+  // The archive must carry the response's `updatedAt` as
+  // `originalCreatedAt`, NOT its fixed `createdAt`, so the version-
+  // history UI shows when the archived state was actually produced
+  // (last regen/edit) rather than the initial-generation time.
+  // Reported symptom: latest live response "5 minutes ago" but the
+  // archive row that just moved into history showing "just now".
+  it('archives the response.updatedAt as originalCreatedAt (not createdAt)', async () => {
+    const createdAt = new Date('2026-01-15T10:00:00Z');
+    const updatedAt = new Date('2026-01-15T10:05:00Z');
+
+    mockPrisma.review.findFirst.mockResolvedValueOnce({
+      ...reviewWithResponse,
+      response: {
+        ...existingResponse,
+        createdAt,
+        updatedAt,
+      },
+    });
+    mockPrisma.responseVersion.create.mockResolvedValueOnce({});
+    mockPrisma.reviewResponse.update.mockResolvedValueOnce({
+      ...existingResponse,
+      responseText: 'A hand-edited reply.',
+      isEdited: true,
+      editedAt: new Date(),
+      creditsUsed: 0,
+    });
+
+    const req = createRequest('/api/reviews/review-1/response', {
+      method: 'PUT',
+      body: { responseText: 'A hand-edited reply.' },
+    });
+    await PUT(req, routeParams({ id: 'review-1' }));
+
+    expect(mockPrisma.responseVersion.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          originalCreatedAt: updatedAt,
+        }),
+      }),
+    );
+    // Defensive: confirm we did NOT use the stale createdAt.
+    expect(mockPrisma.responseVersion.create).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          originalCreatedAt: createdAt,
+        }),
+      }),
+    );
+  });
+
   it('archives the previous additionalInstructions into the new ResponseVersion row', async () => {
     mockPrisma.review.findFirst.mockResolvedValueOnce({
       ...reviewWithResponse,


### PR DESCRIPTION
## Summary

You spotted that the LIVE response card showed "5m ago" but the version that just moved into history showed "just now". Root cause is a two-part archive-timestamp bug:

1. **Manual-edit route never set `originalCreatedAt`.** The GET projection falls back to `v.createdAt` (the archive row's own creation time, i.e. "now") when the field is null, so every archive created by a manual edit displayed as "just now".
2. **Regenerate route used `review.response.createdAt`** as the archive's `originalCreatedAt`. But `ReviewResponse.createdAt` is fixed at initial generation and never moves on `update()`. So every archive after the first regen carried the initial-generation time rather than the actual state's age.

Fix: both routes now pass `review.response.updatedAt`. Prisma's `@updatedAt` bumps it on every update — after a regen, it's the time of that regen; after an edit, it's the time of that edit. Either way, it's the correct "when did this archived state originate" timestamp.

Two new unit tests, one per route, prove the archive carries `updatedAt` and explicitly NOT `createdAt` (sets the two to different times in the fixture and asserts on both).

## Test plan

- [x] `npm run lint:strict` clean
- [x] `npm run type-check` clean
- [x] `npm run test:unit` — 1106 passed (1104 → 1106; +2 cases)
- [ ] Manual on staging: generate → wait a few minutes → regenerate → confirm the archived version shows the time of the original generation, not "just now"
- [ ] Manual on staging: regenerate → wait a few minutes → manually edit → confirm the archived version shows the time of the regen, not "just now"
- [ ] Manual on staging: edit again → confirm the archived (edited) version shows the time of the previous edit, not "just now"

🤖 Generated with [Claude Code](https://claude.com/claude-code)