### PR TITLE
feat(ui): regenerate dialog states each regen runs against the original review

### DIFF
--- a/src/components/reviews/ToneModifier.tsx
+++ b/src/components/reviews/ToneModifier.tsx
@@ -108,6 +108,23 @@ export function ToneModifier({
         <DialogHeader>
           <DialogTitle>Regenerate response</DialogTitle>
           <DialogDescription>Apply just for this regeneration.</DialogDescription>
+          {/*
+            5/26 — UX honesty note. Users intuitively read "regenerate"
+            as "iterate on top of the current response", but every
+            regen runs as a fresh composition against the original
+            review (the current live response is NOT used as input).
+            Instructions from previous regens are also not carried
+            forward; only what the user types into the textarea below
+            applies. Without this note, users who fix one thing in
+            regen N and a different thing in regen N+1 see the first
+            fix silently undone — exactly the surprise the persisted-
+            instructions feature was meant to make visible.
+          */}
+          <p className="text-xs text-muted-foreground">
+            Each regeneration runs independently on the original review.
+            Earlier instructions from previous regens are not carried
+            forward.
+          </p>
         </DialogHeader>
 
         <div className="space-y-2">

--- a/tests/unit/components/reviews/tone-modifier.test.tsx
+++ b/tests/unit/components/reviews/tone-modifier.test.tsx
@@ -113,6 +113,31 @@ describe("ToneModifier", () => {
     expect(screen.queryByText(/pick a different tone, add specific instructions/i)).not.toBeInTheDocument();
   });
 
+  // 5/26 — UX honesty note. Users intuitively read "regenerate" as
+  // "iterate on top of the current response", but every regen runs as a
+  // fresh composition against the original review. Earlier additional
+  // instructions are not carried forward. Without this note, users who
+  // fix one thing in regen N and a different thing in regen N+1 see
+  // the first fix silently undone.
+  it("renders the independence-clarifying note in the dialog header", async () => {
+    render(<ToneModifier {...defaultProps} />);
+    fireEvent.click(screen.getByRole("button", { name: /regenerate/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Regenerate response")).toBeInTheDocument();
+    });
+
+    // Match across whitespace-normalised text — the copy is wrapped
+    // across multiple lines in the JSX for readability.
+    expect(
+      screen.getByText((_content, element) => {
+        const text = element?.textContent?.replace(/\s+/g, " ").trim() ?? "";
+        return text ===
+          "Each regeneration runs independently on the original review. Earlier instructions from previous regens are not carried forward.";
+      }),
+    ).toBeInTheDocument();
+  });
+
   it("autofocuses the Additional instructions textarea when the dialog opens", async () => {
     render(<ToneModifier {...defaultProps} />);
     fireEvent.click(screen.getByRole("button", { name: /regenerate/i }));


### PR DESCRIPTION
## Summary

Spreadsheet-review with the Italian undercooked-pizza review surfaced a UX surprise. A user fixed one thing in regen N (\"don't say 'completely unacceptable'\"), got the result they wanted, then in regen N+1 asked for a *different* fix (\"don't say 'properly prepared meal'\") — and the previous fix silently undid itself. The compensation language and the unacceptable-variant came back.

Root cause is intentional at the prompt-engineering layer: every regen runs as a fresh composition against the **original review**, with only the textarea's current contents as a directive. Earlier instructions are not carried forward, so successive regens can each undo each other's corrections.

This is the right design at the prompt layer (instruction stacking degrades quickly into contradiction — \"be more apologetic\" + \"don't apologize too much\" makes the model worse with each regen), but it's a UX surprise without disclosure. The additional-instructions field already empties between regens; the missing piece is telling the user *why*.

This PR adds a two-sentence muted-text note under the dialog description:

> Each regeneration runs independently on the original review.
> Earlier instructions from previous regens are not carried forward.

The phrasing was reviewed sentence by sentence:
- \"on the original review\" grounds the starting point — not the just-produced response, which is what \"iterative refinement\" would imply.
- The second sentence closes the specific surprise of disappearing prior instructions.

Together they let users build one combined instruction for the next regen instead of piecemeal corrections. No prompt change, no schema change.

## Test plan

- [x] \`npm run lint:strict\` clean
- [x] \`npm run type-check\` clean
- [x] \`npm run test:unit\` — 1138 passed, 0 failed (1137 → 1138; +1 case asserting the note copy is present in the dialog header)
- [ ] Manual on staging: open the regenerate dialog, confirm the two-sentence note is visible under the description, in muted-foreground type. Re-test the Italian pizza review with one combined instruction (\"don't say 'completely unacceptable', don't say 'properly prepared meal', don't mention compensation\") and confirm all three apply in one regen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)