### PR TITLE
feat(prompt): universal rule — do not promise the failed thing done correctly

### DIFF
--- a/src/lib/ai/structure-templates.ts
+++ b/src/lib/ai/structure-templates.ts
@@ -91,6 +91,13 @@ Avoid these AI-giveaway markers:
 - Do not use three-adjective lists for rhythm (e.g. "wonderful, memorable, delightful evening"). Pick one or two adjectives deliberately.
 - Do not reference the price the customer paid back to them, even if they mentioned it in the review. The dissatisfaction is what needs acknowledgment, not the amount they spent.
 
+Do not promise the failed thing done correctly:
+- This rule applies anywhere in the response — apology paragraph, internal commitment, close, or any other sentence. It is not limited to the closing.
+- If the reviewer raised a specific failure (e.g., an undercooked meal, a delayed delivery, a missed booking, a rude interaction, a faulty product), do NOT promise the negation of that failure as part of your reply.
+- Examples of what NOT to write: "a properly prepared meal", "an on-time delivery this time", "a booking that's actually honoured", "the warm service you should have received", "the experience that meets your expectations", "the standard our customers expect", "the kind of quality we usually deliver".
+- Refer to any future visit, return, or interaction generically. Acceptable substitutes include: "we'd love to welcome you back", "we hope to see you again", "we hope you'll give us another chance", "we'd be glad to host you again", "we hope to have the opportunity to serve you again". These work because they invite the customer back without itemising the corrected version of the failure.
+- Why this matters: promising the failure done correctly turns the apology into a sales pitch for the corrected version of the failed thing. It also implies the customer must give the business another try to find out whether the issue was fixed, which reduces the apology to a condition. Generic future-visit language avoids both.
+
 Precedence rule:
 - If a phrase listed in the Key phrases section above contains a word or phrase from this prohibition list, the Key phrases entry takes precedence — use it as the user has written it. The prohibitions apply only to words and phrases the model would otherwise introduce on its own.`;
 

--- a/tests/unit/lib/ai/structure-templates.test.ts
+++ b/tests/unit/lib/ai/structure-templates.test.ts
@@ -243,6 +243,84 @@ describe("UNIVERSAL_STRUCTURAL_RULES", () => {
     expect(UNIVERSAL_STRUCTURAL_RULES).toContain('Thank you for reaching out');
   });
 
+  // 5/30 prompt-tuning iter-9 / PR 2 — "Do not promise the failed thing
+  // done correctly". Observed in spreadsheet review: the model was
+  // closing a 1★ undercooked-pizza reply with "a properly prepared
+  // meal in the future" — re-naming the specific failure as part of
+  // the hopeful close. This reduces the apology to a sales pitch for
+  // the corrected version of the failed thing. The rule lives in the
+  // universal block (not the negative template) because the failure
+  // mode can surface anywhere: apology paragraph, internal commitment,
+  // close, or any other sentence. Same anywhere-in-response scope as
+  // the price-echo rule (Change B).
+  describe("Do not promise the failed thing done correctly (PR 2)", () => {
+    it("introduces the rule by name in the universal block", () => {
+      expect(UNIVERSAL_STRUCTURAL_RULES).toContain(
+        "Do not promise the failed thing done correctly",
+      );
+    });
+
+    it("scopes the rule explicitly to anywhere in the response (not close-only)", () => {
+      // Anchor on the phrase that makes the scope universal — the lower-
+      // case search keeps the test resilient to minor capitalisation
+      // edits in the prompt copy.
+      expect(UNIVERSAL_STRUCTURAL_RULES.toLowerCase()).toContain(
+        "apology paragraph, internal commitment, close",
+      );
+      expect(UNIVERSAL_STRUCTURAL_RULES.toLowerCase()).toContain(
+        "it is not limited to the closing",
+      );
+    });
+
+    it("names the canonical bad example from the spreadsheet-review symptom", () => {
+      // "a properly prepared meal" was the literal output that
+      // motivated the rule.
+      expect(UNIVERSAL_STRUCTURAL_RULES).toContain(
+        '"a properly prepared meal"',
+      );
+    });
+
+    it("names additional don't-promise-the-fix examples across business types", () => {
+      // The example list covers more than one failure shape so the
+      // model generalises rather than memorising a single hospitality
+      // phrase. Spot-check a representative range.
+      const badExamples = [
+        "an on-time delivery this time",
+        "a booking that's actually honoured",
+        "the warm service you should have received",
+        "the experience that meets your expectations",
+        "the standard our customers expect",
+      ];
+      for (const example of badExamples) {
+        expect(UNIVERSAL_STRUCTURAL_RULES).toContain(example);
+      }
+    });
+
+    it("names the generic-future-visit substitutes so the model has something to say instead", () => {
+      // Without positive substitutes, the model would either suppress
+      // the bad phrasing and leave a structural hole, or invent a
+      // worse one. The substitutes are the load-bearing other half of
+      // the rule.
+      const substitutes = [
+        "we'd love to welcome you back",
+        "we hope to see you again",
+        "we hope you'll give us another chance",
+      ];
+      for (const sub of substitutes) {
+        expect(UNIVERSAL_STRUCTURAL_RULES).toContain(sub);
+      }
+    });
+
+    it("explains why this matters (sales-pitch / apology-as-condition framing)", () => {
+      // The "why" lets the model judge edge cases instead of just
+      // pattern-matching the example list — same approach the multi-
+      // lingual blocklist took (Decision 94).
+      expect(UNIVERSAL_STRUCTURAL_RULES.toLowerCase()).toContain(
+        "sales pitch for the corrected version",
+      );
+    });
+  });
+
   it("includes the Key-phrases precedence rule", () => {
     expect(UNIVERSAL_STRUCTURAL_RULES).toContain("Key phrases entry takes precedence");
   });


### PR DESCRIPTION
## Summary

Spreadsheet-review symptom: a 1★ Italian undercooked-pizza review produced an English response (via the response-language override) that closed with *"we hope to have the opportunity to serve you a properly prepared meal in the future"*. The close re-references the specific failure being apologised for, reducing the apology to a sales pitch for the corrected version of the failed thing.

The failure mode is not close-specific — a body paragraph could just as easily say *"our usual service is much more attentive than what you experienced"* or *"next time you'll find our bread fresh"*. Both are the same pattern: acknowledge a specific failure → promise its negation. The right home for the rule is **universal**, not the negative template.

This PR adds one rule in \`UNIVERSAL_STRUCTURAL_RULES\`:

> **Do not promise the failed thing done correctly.**
> - This rule applies anywhere in the response — apology paragraph, internal commitment, close, or any other sentence. It is not limited to the closing.
> - Examples of what NOT to write: "a properly prepared meal", "an on-time delivery this time", "a booking that's actually honoured", "the warm service you should have received", "the experience that meets your expectations", "the standard our customers expect", "the kind of quality we usually deliver".
> - Refer to any future visit, return, or interaction generically. Acceptable substitutes: "we'd love to welcome you back", "we hope to see you again", "we hope you'll give us another chance", "we'd be glad to host you again", "we hope to have the opportunity to serve you again".
> - Why this matters: promising the failure done correctly turns the apology into a sales pitch for the corrected version of the failed thing. It also implies the customer must give the business another try to find out whether the issue was fixed, which reduces the apology to a condition. Generic future-visit language avoids both.

Same approach the multilingual blocklist took (Decision 94): concept-based, examples illustrative not exhaustive, positive substitutes named so the model has something to say instead.

The examples span hospitality (meal, service, quality), delivery, and bookings — so non-hospitality customers are covered without any further changes.

## What this does NOT change

- No schema, no UI, no API surface.
- No change to the Italian-via-Italian-native path's behaviour (it already follows this rule by default; the new rule formalises it as a floor).
- Doesn't change the structural rule about what kind of close is appropriate. Spec §9.5's "hopeful close on negative reviews" stays as-is. This rule is an orthogonal constraint on what the close (or any other sentence) must not do.

## Test plan

- [x] \`npm run lint:strict\` clean
- [x] \`npm run type-check\` clean
- [x] \`npm run test:unit\` — 1144 passed, 0 failed (1138 → 1144; +6 new cases asserting rule name, anywhere-in-response scope, canonical bad example, additional examples across business types, positive substitutes, and why-this-matters framing)
- [ ] Manual on staging: re-test the Italian undercooked-pizza review in English-via-override mode. Expected: no "properly prepared meal" in the close; closes generically (e.g., "we hope to see you again" or "we'd love to welcome you back").
- [ ] Manual on staging: re-test against a 2★ delayed-delivery review (any business). Expected: no "on-time delivery this time" in the body or close.
- [ ] Manual on staging: re-test a 5★ positive review unchanged. Expected: no regressions — the rule only fires when there's a failure to engage with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)