### PR TITLE
feat(prompt): iter-9 batch — substitution pairs, soft-flagellation, commitment cap, missing-service-recovery

### DIFF
--- a/src/lib/ai/sanitize.ts
+++ b/src/lib/ai/sanitize.ts
@@ -135,17 +135,24 @@ ${languageDirective}
 - Do NOT use em-dashes ("—"). Use commas, periods, or parentheses.
 - Do NOT generate a salutation or sign-off — those are added separately.
 
-DO NOT use corporate-apology register in any language. This register sounds like a legal statement, an HR document, or a press release rather than a manager apologising in person. In English, examples of phrases to avoid include:
-- "completely unacceptable"
-- "I take full responsibility"
-- "I take full ownership"
-- "take ownership of"
-- "implement corrective measures"
-- "comprehensive review"
-- "going forward"
-- "rest assured"
-- "we will be personally reviewing"
-When writing in a non-English language, do not use the direct or close-equivalent translations of these phrases either. The English list above is exemplary, not exhaustive — avoid the *register*, not just the *literal strings*. Write conversationally in the response's language. On a negative review, write as a manager apologising in person, not as a corporate statement. Acknowledge briefly, commit briefly, close hopefully. Do not theatrically self-flagellate.
+DO NOT use corporate-apology register in any language. This register sounds like a legal statement, an HR document, or a press release rather than a manager apologising in person. In English, instead of these phrases, use the substitutes shown — the substitutes fill the same slot in the sentence, which is why telling the model only what NOT to write tends to fail (the model reaches for the prohibited phrase because it's the easiest load-bearing apology word). Substitution pairs:
+- Instead of "completely unacceptable" → say "I'm so sorry this happened" or "this should never have happened to you".
+- Instead of "I take full responsibility" → say "I'm sorry — this is on us" or "we got this wrong".
+- Instead of "I take full ownership" / "take ownership of" → say "I'm sorry — this is on us" or "we got this wrong".
+- Instead of "implement corrective measures" → say "I'll look at this with our team" (do not describe the corrective action publicly).
+- Instead of "comprehensive review" → drop the phrase entirely. The apology does not need to describe an internal process.
+- Instead of "going forward" → drop the phrase entirely. The apology already implies "this won't happen again" without that filler.
+- Instead of "rest assured" → say "I want you to know..." or drop the construction entirely.
+- Instead of "we will be personally reviewing" → say "I'll share this with our team" (do not promise a specific internal-review process).
+
+Soft self-flagellation extensions (also avoid):
+- "the standard our customers deserve" / "what our customers deserve"
+- "the service you should have received" / "service that met your expectations"
+- "the quality you expect from us" / "the quality we provide" / "the standards we provide"
+- "the experience we strive to deliver" / "the experience we usually provide"
+These template-shaped concessions are the same corporate-apology register dressed up as humility. They make the brand sound like it's reading from a script. Apologise briefly for the actual failure; do not narrate what the customer was entitled to receive.
+
+When writing in a non-English language, do not use the direct or close-equivalent translations of any of these phrases either. The English lists above are exemplary, not exhaustive — avoid the *register*, not just the *literal strings*. Write conversationally in the response's language. On a negative review, write as a manager apologising in person, not as a corporate statement. Acknowledge briefly, commit briefly, close hopefully. Do not theatrically self-flagellate.
 
 PRECEDENCE:
 - If a phrase listed in the Key phrases section above contains a word from the prohibition list, the Key phrases entry takes precedence — use it as the user has written it.

--- a/src/lib/ai/structure-templates.ts
+++ b/src/lib/ai/structure-templates.ts
@@ -91,6 +91,13 @@ Avoid these AI-giveaway markers:
 - Do not use three-adjective lists for rhythm (e.g. "wonderful, memorable, delightful evening"). Pick one or two adjectives deliberately.
 - Do not reference the price the customer paid back to them, even if they mentioned it in the review. The dissatisfaction is what needs acknowledgment, not the amount they spent.
 
+Do not acknowledge missing service-recovery actions:
+- Compensation, refunds, discounts, complimentary items, comped meals, free replacements, store credit, anything else the customer says they did NOT receive as a remediation — do NOT acknowledge any of it in the public reply, do NOT apologise for it, do NOT confirm it should have been offered, do NOT promise it for next time.
+- These are private negotiations, not apology topics. The moment a public reply names a missing remediation ("we're sorry no compensation was offered"), every reader is anchored on that as a thing the business has now confessed to owing, and the brand has narrowed its legitimate range of responses.
+- Address the original failure (the meal, the stay, the service, the product, the appointment) and let any remediation happen off the public reply, through whatever private channel the business uses.
+- Examples of what NOT to write: "we're sorry no discount was offered", "you didn't receive the compensation you deserved", "we should have offered a replacement", "we apologise that no refund was provided", "we will make sure you receive proper compensation next time".
+- This rule applies even when the reviewer raised the missing remediation as a specific concrete grievance (the same kind of grievance the specificity rule would normally tell you to engage with). The specificity rule is about acknowledging WHAT WENT WRONG with the interaction itself — it does not extend to acknowledging missing recovery actions.
+
 Do not promise the failed thing done correctly:
 - This rule applies anywhere in the response — apology paragraph, internal commitment, close, or any other sentence. It is not limited to the closing.
 - If the reviewer raised a specific failure (e.g., an undercooked meal, a delayed delivery, a missed booking, a rude interaction, a faulty product), do NOT promise the negation of that failure as part of your reply.
@@ -127,7 +134,7 @@ Balance:
 // has to make to stay within the length target.
 const NEGATIVE_TEMPLATE = `Structure for this response:
 1. Opening paragraph: thank the reviewer briefly for taking time to share; offer a sincere apology; acknowledge the occasion if mentioned.
-2. Middle paragraph: reference one specific incident the reviewer mentioned (using their wording or a close paraphrase — NOT an abstract category summary). If the reviewer raised many issues, acknowledge "and several other concerns" alongside the one specific incident. Communicate an internal commitment to address what happened — phrases like "I'll share this with our team", "we'll discuss this with our [relevant department]", or "we'll look into what happened" are all appropriate. This commitment is universal — it does NOT depend on whether a contact channel is configured. The reviewer should always leave feeling the brand will act on what they raised.
+2. Middle paragraph: reference one specific incident the reviewer mentioned (using their wording or a close paraphrase — NOT an abstract category summary). If the reviewer raised many issues, acknowledge "and several other concerns" alongside the one specific incident. Communicate an internal commitment to address what happened — phrases like "I'll share this with our team", "we'll discuss this with our [relevant department]", or "we'll look into what happened" are all appropriate. The internal commitment must be ONE short clause and must NOT carry a trailing purpose clause (see the Internal commitment cap section below). This commitment is universal — it does NOT depend on whether a contact channel is configured. The reviewer should always leave feeling the brand will act on what they raised.
 3. Closing paragraph:
    - If a contact channel is configured in the brand voice (via the framing instruction above): close with an invitation to use that channel (e.g. "please email us at [your email] so we can investigate further").
    - If NO contact channel is configured: close with a hopeful forward-looking statement — express that we hope for the opportunity to serve them better in the future. Do NOT invent a generic "please reach out" or "contact us directly" close — there is no channel to direct them to.
@@ -138,6 +145,18 @@ Universal closing rule:
 
 Specificity is required, not optional:
 - Engage with one actual incident from the review. Abstractions like "concerns about cleanliness" or "issues with service" are not enough — name something concrete the reviewer wrote.
+
+Internal commitment cap:
+- The internal commitment ("I'll share this with our team", "we'll look into what happened", "we'll discuss this with our kitchen team") must be ONE short clause. Stop after the team/department reference.
+- Do NOT add a trailing purpose clause stating what we'll do, what we'll ensure, what we'll prevent, what standards we'll maintain, or how we'll fix it.
+- Examples of trailing clauses to AVOID (these are what the cap is for):
+  - "...to ensure this doesn't happen again"
+  - "...to ensure our cooking standards are properly maintained"
+  - "...so we can address what happened with the preparation"
+  - "...to make sure our team delivers the service our customers expect"
+  - "...to prevent this from recurring"
+- Acceptable forms: "I'll share this with our kitchen team." (full stop, no trailing clause). "We'll discuss this with our front-of-house team." (full stop, no trailing clause).
+- Why this matters: trailing purpose clauses turn the commitment into a public narration of internal process. A manager apologising in person says "I'll share this with the team" and moves on; they don't enumerate what the team will do. This pattern is a corporate-apology register tell, even when the substitute phrase ("I'll share this") was the right replacement.
 
 Register:
 - Write as a manager apologising in person, not as a corporate statement. Acknowledge briefly, commit briefly, close hopefully. Do not theatrically self-flagellate.

--- a/tests/unit/lib/ai/sanitize.test.ts
+++ b/tests/unit/lib/ai/sanitize.test.ts
@@ -275,8 +275,14 @@ describe("sanitize.ts", () => {
         expect(INSTRUCTION_REINFORCEMENT.toLowerCase()).toContain(
           "do not use corporate-apology register in any language",
         );
+        // 5/30 prompt-tuning iter-9 / PR 3 (Change A): the section now
+        // introduces the substitution pairs with "In English, instead of
+        // these phrases, use the substitutes shown" rather than the
+        // earlier "In English, examples of phrases to avoid include".
+        // Substance is the same — still English-anchored, still
+        // exemplary not exhaustive — but the wording is sharper.
         expect(INSTRUCTION_REINFORCEMENT.toLowerCase()).toContain(
-          "in english, examples",
+          "in english, instead of these phrases",
         );
         expect(INSTRUCTION_REINFORCEMENT.toLowerCase()).toContain(
           "exemplary, not exhaustive",
@@ -292,6 +298,114 @@ describe("sanitize.ts", () => {
         expect(INSTRUCTION_REINFORCEMENT.toLowerCase()).toContain(
           "acknowledge briefly, commit briefly, close hopefully",
         );
+      });
+
+      // 5/30 prompt-tuning iter-9 / PR 3 (Change A) — substitution pairs.
+      // The previous flat blocklist named what NOT to say but didn't give
+      // the model a load-bearing replacement, so the model kept reaching
+      // for the prohibited phrase or paraphrasing it ("inaccettabile" in
+      // Italian, "ensure this doesn't occur again" as a workaround in
+      // English). The substitution pairs name a phrase that fills the
+      // same slot in the sentence, which is the only reliable way to
+      // suppress the prohibited register.
+      describe("substitution pairs (PR 3 Change A)", () => {
+        it("explains WHY substitutions are needed (model reaches for the prohibited phrase otherwise)", () => {
+          expect(INSTRUCTION_REINFORCEMENT.toLowerCase()).toContain(
+            "the substitutes fill the same slot in the sentence",
+          );
+        });
+
+        it("pairs each banned phrase with its substitute via 'Instead of X → say Y' format", () => {
+          // Anchor on the "Instead of" + arrow construction so the rule
+          // form is enforceable. The actual phrase pairs are spot-
+          // checked individually below.
+          const arrowPairCount = (
+            INSTRUCTION_REINFORCEMENT.match(/Instead of "/g) || []
+          ).length;
+          // 8 substitution pairs covering: completely unacceptable, I take
+          // full responsibility, I take full ownership (incl. "take
+          // ownership of" via slash), implement corrective measures,
+          // comprehensive review, going forward, rest assured, we will
+          // be personally reviewing.
+          expect(arrowPairCount).toBeGreaterThanOrEqual(8);
+        });
+
+        it("provides 'I'm so sorry this happened' as a substitute for 'completely unacceptable'", () => {
+          expect(INSTRUCTION_REINFORCEMENT).toMatch(
+            /Instead of "completely unacceptable"[^.]*"I'm so sorry this happened"/,
+          );
+        });
+
+        it("provides 'I'm sorry — this is on us' as a substitute for the take-responsibility/ownership family", () => {
+          expect(INSTRUCTION_REINFORCEMENT).toMatch(
+            /Instead of "I take full responsibility"[^.]*"I'm sorry/,
+          );
+          expect(INSTRUCTION_REINFORCEMENT).toMatch(
+            /Instead of "I take full ownership"[^.]*"I'm sorry/,
+          );
+        });
+
+        it("instructs the model to DROP filler constructions (going forward, comprehensive review) rather than substitute", () => {
+          // Some prohibited phrases have no good substitute — the
+          // apology speaks for itself without them. The rule must say
+          // so explicitly or the model invents a substitute that's
+          // worse than what it replaced.
+          expect(INSTRUCTION_REINFORCEMENT).toMatch(
+            /Instead of "comprehensive review"[^.]*drop the phrase entirely/,
+          );
+          expect(INSTRUCTION_REINFORCEMENT).toMatch(
+            /Instead of "going forward"[^.]*drop the phrase entirely/,
+          );
+        });
+      });
+
+      // 5/30 prompt-tuning iter-9 / PR 3 (Change B) — soft self-flagellation
+      // extensions. These are the template-shaped concessions the model
+      // falls back to when the literal blocklist phrases are unavailable
+      // ("the standard our customers deserve", "service that met your
+      // expectations", etc.). Same corporate-apology register dressed up
+      // as humility.
+      describe("soft self-flagellation extensions (PR 3 Change B)", () => {
+        it("introduces the extensions as a labelled section in the reinforcement tail", () => {
+          expect(INSTRUCTION_REINFORCEMENT).toContain(
+            "Soft self-flagellation extensions",
+          );
+        });
+
+        it("names the customer-deserving family of concessions", () => {
+          // The model reaches for "deserve" / "expect" templates when
+          // the literal apology phrases are blocked. Without naming
+          // them here, the previous spreadsheet review showed the model
+          // produced "the quality our customers deserve" (Italian
+          // response) as an unintentional workaround.
+          expect(INSTRUCTION_REINFORCEMENT).toContain(
+            "the standard our customers deserve",
+          );
+          expect(INSTRUCTION_REINFORCEMENT).toContain(
+            "what our customers deserve",
+          );
+          expect(INSTRUCTION_REINFORCEMENT).toContain(
+            "the service you should have received",
+          );
+          expect(INSTRUCTION_REINFORCEMENT).toContain(
+            "service that met your expectations",
+          );
+        });
+
+        it("explains why these are the same corporate-apology register", () => {
+          expect(INSTRUCTION_REINFORCEMENT.toLowerCase()).toContain(
+            "same corporate-apology register dressed up as humility",
+          );
+        });
+
+        it("frames these extensions as multilingual too (don't translate them either)", () => {
+          // The "any of these phrases" wording in the multilingual
+          // paragraph must explicitly cover BOTH the substitution pair
+          // list AND the soft-self-flagellation list.
+          expect(INSTRUCTION_REINFORCEMENT.toLowerCase()).toContain(
+            "any of these phrases",
+          );
+        });
       });
     });
 

--- a/tests/unit/lib/ai/structure-templates.test.ts
+++ b/tests/unit/lib/ai/structure-templates.test.ts
@@ -183,6 +183,72 @@ describe("getStructureTemplate", () => {
     expect(out.toLowerCase()).toContain("must not end on the apology");
   });
 
+  // 5/30 prompt-tuning iter-9 / PR 3 (Change C) — internal-commitment cap.
+  // Spreadsheet review symptom: the model honoured the "I'll share this
+  // with our team" substitute but kept appending a trailing purpose
+  // clause ("to ensure this doesn't happen again", "per assicurarci che
+  // una situazione del genere non si ripeta"). The trailing clause turns
+  // the commitment into a public narration of internal process, which is
+  // the corporate-apology register even when the substitute phrase was
+  // the right replacement.
+  describe("internal commitment cap (PR 3 Change C)", () => {
+    it("introduces the cap as a labelled sub-section", () => {
+      const out = getStructureTemplate({ rating: 1, sentiment: null });
+      expect(out).toContain("Internal commitment cap:");
+    });
+
+    it("requires the commitment to be ONE short clause", () => {
+      const out = getStructureTemplate({ rating: 1, sentiment: null });
+      expect(out.toLowerCase()).toContain("must be one short clause");
+    });
+
+    it("bans the trailing purpose clause explicitly", () => {
+      const out = getStructureTemplate({ rating: 1, sentiment: null });
+      expect(out.toLowerCase()).toContain(
+        "do not add a trailing purpose clause",
+      );
+    });
+
+    it("names the specific trailing-clause patterns observed in spreadsheet review", () => {
+      const out = getStructureTemplate({ rating: 1, sentiment: null });
+      // These are the literal patterns the model produced across the
+      // pizza-review iterations. Naming them gives the model concrete
+      // anchors, same approach as Change A's substitution pairs.
+      const badTrailingClauses = [
+        "to ensure this doesn't happen again",
+        "to ensure our cooking standards are properly maintained",
+        "so we can address what happened with the preparation",
+        "to prevent this from recurring",
+      ];
+      for (const clause of badTrailingClauses) {
+        expect(out).toContain(clause);
+      }
+    });
+
+    it("gives the model an acceptable form to mirror", () => {
+      const out = getStructureTemplate({ rating: 1, sentiment: null });
+      expect(out).toContain("I'll share this with our kitchen team.");
+      expect(out.toLowerCase()).toContain("full stop, no trailing clause");
+    });
+
+    it("explains why this matters (public narration of internal process)", () => {
+      const out = getStructureTemplate({ rating: 1, sentiment: null });
+      expect(out.toLowerCase()).toContain(
+        "public narration of internal process",
+      );
+    });
+
+    it("cross-references the cap from step 2 of the template", () => {
+      // Step 2's internal-commitment instruction must point at the cap
+      // section so the model is told to look for the constraint at the
+      // moment it's deciding what to write.
+      const out = getStructureTemplate({ rating: 1, sentiment: null });
+      expect(out).toContain(
+        "see the Internal commitment cap section below",
+      );
+    });
+  });
+
   // 5/25 prompt-tuning iter-2 follow-up — register-aware contractions.
   // The apology paragraph specifically leans slightly more formal than
   // the brand's usual tone, even when the brand's tone allows
@@ -241,6 +307,94 @@ describe("UNIVERSAL_STRUCTURAL_RULES", () => {
   it("forbids the opening AI-cliche phrases", () => {
     expect(UNIVERSAL_STRUCTURAL_RULES).toContain('I hope this finds you well');
     expect(UNIVERSAL_STRUCTURAL_RULES).toContain('Thank you for reaching out');
+  });
+
+  // 5/30 prompt-tuning iter-9 / PR 3 (Change D) — universal rule against
+  // acknowledging missing service-recovery actions (compensation,
+  // refunds, discounts, complimentary items). Spreadsheet symptom: the
+  // Italian-via-English-override response surfaced "we appreciate your
+  // feedback about the lack of compensation offered" — itemising the
+  // service-recovery failure as a separate confessed wrong. This
+  // anchors the reader (and the reviewer) on the missing remediation
+  // and narrows the business's legitimate range of responses. The
+  // specificity rule (engage with what went wrong) doesn't extend to
+  // engaging with missing remediations — those are private
+  // negotiations, not apology topics. Adjacent to the price-echo rule
+  // since both are "don't engage with sensitive negotiation topics".
+  describe("Do not acknowledge missing service-recovery actions (PR 3 Change D)", () => {
+    it("introduces the rule by name in the universal block", () => {
+      expect(UNIVERSAL_STRUCTURAL_RULES).toContain(
+        "Do not acknowledge missing service-recovery actions",
+      );
+    });
+
+    it("names compensation, refunds, discounts, and complimentary items as covered categories", () => {
+      // Concrete category enumeration so the model doesn't try to
+      // wriggle around with one of the variants.
+      const covered = [
+        "Compensation",
+        "refunds",
+        "discounts",
+        "complimentary items",
+        "comped meals",
+        "free replacements",
+        "store credit",
+      ];
+      for (const item of covered) {
+        expect(UNIVERSAL_STRUCTURAL_RULES).toContain(item);
+      }
+    });
+
+    it("bans the four engagement modes the model might reach for", () => {
+      // do NOT acknowledge / apologise for / confirm should have been
+      // offered / promise for next time — all four must be explicitly
+      // banned because each is a distinct phrasing the model defaults
+      // to.
+      const lower = UNIVERSAL_STRUCTURAL_RULES.toLowerCase();
+      expect(lower).toContain("do not acknowledge any of it");
+      expect(lower).toContain("do not apologise for it");
+      expect(lower).toContain("do not confirm it should have been offered");
+      expect(lower).toContain("do not promise it for next time");
+    });
+
+    it("frames this as private negotiation, not an apology topic", () => {
+      expect(UNIVERSAL_STRUCTURAL_RULES.toLowerCase()).toContain(
+        "private negotiations, not apology topics",
+      );
+    });
+
+    it("explains the public-anchoring why so the model judges edge cases instead of pattern-matching", () => {
+      expect(UNIVERSAL_STRUCTURAL_RULES.toLowerCase()).toContain(
+        "every reader is anchored on that as a thing the business has now confessed to owing",
+      );
+    });
+
+    it("names canonical bad examples from the spreadsheet review", () => {
+      const badExamples = [
+        '"we\'re sorry no discount was offered"',
+        '"you didn\'t receive the compensation you deserved"',
+        '"we should have offered a replacement"',
+        '"we apologise that no refund was provided"',
+        '"we will make sure you receive proper compensation next time"',
+      ];
+      for (const example of badExamples) {
+        expect(UNIVERSAL_STRUCTURAL_RULES).toContain(example);
+      }
+    });
+
+    it("explicitly carves out the conflict with the specificity rule", () => {
+      // The specificity rule (engage with one concrete incident) would,
+      // naively, tell the model to engage with "no compensation" the
+      // same way it engages with "undercooked pizza". The cap must
+      // explicitly say: specificity is about the interaction itself,
+      // not about missing recovery actions.
+      expect(UNIVERSAL_STRUCTURAL_RULES.toLowerCase()).toContain(
+        "this rule applies even when the reviewer raised the missing remediation",
+      );
+      expect(UNIVERSAL_STRUCTURAL_RULES.toLowerCase()).toContain(
+        "does not extend to acknowledging missing recovery actions",
+      );
+    });
   });
 
   // 5/30 prompt-tuning iter-9 / PR 2 — "Do not promise the failed thing


### PR DESCRIPTION
## Summary

Iter-9 prompt-tuning batch, motivated by the iterative spreadsheet review of the 1★ Italian undercooked-pizza review across both Italian-native and English-via-override paths. Four changes across two files. No schema, no UI, no API surface.

### Change A — substitution pairs (\`sanitize.ts\`)

The previous flat blocklist named what NOT to write but didn't give the model a load-bearing replacement, so across regen experiments the model kept reaching for the prohibited phrase or paraphrasing it (\"completely unacceptable\" → \"I'll be discussing what happened with our kitchen team to ensure this doesn't occur again\"). The substitution pairs give the model a phrase that fills the same slot:

| Instead of | Say |
|---|---|
| completely unacceptable | I'm so sorry this happened |
| I take full responsibility/ownership | I'm sorry — this is on us |
| implement corrective measures | I'll look at this with our team |
| comprehensive review | drop the phrase entirely |
| going forward | drop the phrase entirely |
| rest assured | I want you to know... or drop |
| we will be personally reviewing | I'll share this with our team |

Three of the pairs are explicit \"drop entirely\" rules — some prohibited phrases have no good substitute, and without the explicit drop instruction the model invents a worse one.

### Change B — soft self-flagellation extensions (\`sanitize.ts\`)

New labelled section covering the template-shaped concessions the model falls back to when the literal blocklist phrases are unavailable: \"what our customers deserve\", \"the service you should have received\", \"the quality you expect from us\", \"the standards we provide\". These are the same corporate-apology register dressed up as humility. The Italian response produced \"la qualità che i nostri clienti meritano\" (the quality our customers deserve) as an unintentional workaround.

Multilingual framing extended so non-English responses honour both lists.

### Change C — internal-commitment cap (\`structure-templates.ts\`, negative template)

The model honoured the iter-8 \"I'll share this with our team\" substitute but kept appending a trailing purpose clause (\"to ensure this doesn't happen again\", \"to ensure our cooking standards are properly maintained\"). The trailing clause turns the commitment into a public narration of internal process — exactly the corporate-apology register the substitute was meant to escape.

New labelled \"Internal commitment cap\" sub-section in the negative template names the bad patterns and gives an acceptable form to mirror (\"I'll share this with our kitchen team.\" — full stop, no trailing clause). Step 2's commitment language cross-references the cap so the model is told to look for the constraint at the moment it's deciding what to write.

### Change D — don't acknowledge missing service-recovery actions (\`structure-templates.ts\`, universal block)

Spreadsheet symptom: \"we appreciate your feedback about the lack of compensation offered\". Once a public reply names a missing remediation, every reader is anchored on that as a thing the business has confessed to owing — narrowing the brand's legitimate range of responses.

The rule lives in the universal block alongside the price-echo rule (both are \"don't engage with sensitive negotiation topics the customer raised\"). Covers compensation, refunds, discounts, complimentary items, comped meals, free replacements, store credit. Four engagement modes explicitly banned (acknowledge / apologise for / confirm should have been offered / promise for next time).

The rule explicitly carves out the conflict with the iter-8 specificity rule: specificity is about engaging with what went wrong with the interaction itself — it does NOT extend to acknowledging missing recovery actions.

## Test plan

- [x] \`npm run lint:strict\` clean
- [x] \`npm run type-check\` clean
- [x] \`npm run test:unit\` — 1167 passed, 0 failed (1144 → 1167; +23 new cases, 1 modified existing test for new section intro phrasing)
- [ ] Manual on staging: re-test the Italian undercooked-pizza review in English-via-override mode. Expected: no \"completely unacceptable\" or its paraphrases, no trailing purpose clause after the internal commitment, no acknowledgement of missing compensation. Close should be generic, no \"properly prepared meal\" (already enforced by PR 2's universal rule).
- [ ] Manual on staging: re-test in Italian-native mode. Expected: no \"inaccettabile\", no \"per assicurarci che una situazione del genere non si ripeta\", no acknowledgement of missing \"sconto\", no \"la qualità che i nostri clienti meritano\".
- [ ] Manual on staging: re-test a 2★ delayed-delivery review for any business. Expected: no acknowledgement of missing refund/store credit/replacement; internal commitment caps cleanly.
- [ ] Manual on staging: re-test a 5★ positive review. Expected: no regressions — these rules only fire when there's a failure to engage with or a missing remediation mentioned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)