### PR TITLE
feat(walkin): broaden subhead + brand-outline contact buttons

### DIFF
--- a/docs/MVP_Phase-1/WALKIN_LANDING_PAGE.md
+++ b/docs/MVP_Phase-1/WALKIN_LANDING_PAGE.md
@@ -43,10 +43,10 @@ The page should render correctly with or without UTM parameters (don't break if 
 ### Section 1 — Hero (above the fold on mobile, ~640px viewport)
 
 - **Headline (H1):** Reply to your reviews in seconds, in your brand voice.
-- **Subhead (paragraph):** AI review replies for restaurants, hotels, and cafés. Built in Berlin.
+- **Subhead (paragraph):** AI review replies for hospitality, retail, and local businesses. Built in Berlin. (Broadened from the original food-and-beverage-only list so the page reflects the product's full industry coverage, not just F&B.)
 - **Primary CTA button:** Start free beta
   - Links to `/auth/signup?utm_source=walkin` (the existing signup route; `utm_source` carries the walk-in attribution forward, see Section 6)
-- **Secondary text link (below CTA):** Or message me directly, links to WhatsApp deep link `https://wa.me/491776910899`
+- **Secondary text link (below CTA):** "WhatsApp me directly" with a message icon, links to WhatsApp deep link `https://wa.me/491776910899`
 
 ### Section 2 — Welcome Line
 
@@ -78,14 +78,14 @@ Personal block to reinforce the founder-led trust signal:
 - **Monogram avatar:** a circle (~80px diameter, `bg-brand-100` indigo fill) with the letter "P" centred inside (`text-brand-600`, ~32px, weight medium). Uses the app's indigo brand tokens (see Section 5 colour note). (If a headshot is added in the future, it would slot into this same position with circular crop.)
 - Name and title: "Prajeen Vijayan, Founder, Berlin"
 - Quote: "I'm building this in Berlin. If you'd like to chat through how it works on your reviews, ping me directly — happy to set up 15 minutes."
-- Two buttons side by side:
-  - WhatsApp (`https://wa.me/491776910899`)
+- Two outlined brand buttons (visible indigo border) side by side, equal weight:
+  - WhatsApp (`https://wa.me/491776910899`), with a message icon
   - Email (`mailto:prajeen@brandsiq.app`)
 
 ### Section 6 — Bottom CTA (repeat the primary action)
 
 - Primary button: Start your free beta → `/auth/signup?utm_source=walkin`
-- Secondary text link: Or message me on WhatsApp → `https://wa.me/491776910899`
+- (No secondary WhatsApp link here: it would duplicate the WhatsApp button in the founder block directly above.)
 
 ---
 

--- a/src/app/walkin/page.tsx
+++ b/src/app/walkin/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { Check } from "lucide-react";
+import { Check, MessageCircle } from "lucide-react";
 
 // Contact details surfaced on this page, kept as single constants.
 const WHATSAPP_URL = "https://wa.me/491776910899";
@@ -14,7 +14,7 @@ const SIGNUP_HREF = "/auth/signup?utm_source=walkin";
 export const metadata: Metadata = {
   title: "Try BrandsIQ, AI review replies for hospitality",
   description:
-    "Reply to your reviews in seconds, in your brand voice. AI review replies for restaurants, hotels, and cafes. Built in Berlin.",
+    "Reply to your reviews in seconds, in your brand voice. AI review replies for hospitality, retail, and local businesses. Built in Berlin.",
 };
 
 const VALUE_POINTS = [
@@ -42,10 +42,16 @@ const HOW_IT_WORKS = [
 const primaryButtonClass =
   "inline-flex h-12 items-center justify-center rounded-md bg-brand-500 px-6 text-base font-medium text-white hover:bg-brand-600 transition-colors";
 
+// Outlined brand button: visible indigo border, used for the founder-block
+// contact pair (WhatsApp + Email) so they read as a balanced, equal-weight
+// pair rather than solid-vs-faint-grey.
+const outlineButtonClass =
+  "inline-flex h-12 items-center justify-center gap-2 rounded-md border border-brand-500 bg-background px-6 text-base font-medium text-brand-600 hover:bg-brand-50 transition-colors";
+
 // min-h-[44px] keeps the tappable area at the 44px touch-target floor (spec
 // §7) while preserving the plain text-link look.
 const secondaryLinkClass =
-  "inline-flex min-h-[44px] items-center text-sm font-medium text-brand-600 underline-offset-4 hover:underline";
+  "inline-flex min-h-[44px] items-center gap-1.5 text-sm font-medium text-brand-600 underline-offset-4 hover:underline";
 
 export default function WalkinPage() {
   return (
@@ -57,8 +63,8 @@ export default function WalkinPage() {
             Reply to your reviews in seconds, in your brand voice.
           </h1>
           <p className="text-lg text-muted-foreground">
-            AI review replies for restaurants, hotels, and cafes. Built in
-            Berlin.
+            AI review replies for hospitality, retail, and local businesses.
+            Built in Berlin.
           </p>
           <div className="flex flex-col items-center gap-3">
             <Link href={SIGNUP_HREF} className={primaryButtonClass}>
@@ -70,7 +76,8 @@ export default function WalkinPage() {
               rel="noopener noreferrer"
               className={secondaryLinkClass}
             >
-              Or message me directly
+              <MessageCircle aria-hidden="true" className="h-4 w-4" />
+              WhatsApp me directly
             </a>
           </div>
         </section>
@@ -147,14 +154,12 @@ export default function WalkinPage() {
                 href={WHATSAPP_URL}
                 target="_blank"
                 rel="noopener noreferrer"
-                className={primaryButtonClass}
+                className={outlineButtonClass}
               >
+                <MessageCircle aria-hidden="true" className="h-4 w-4" />
                 WhatsApp
               </a>
-              <a
-                href={`mailto:${FOUNDER_EMAIL}`}
-                className="inline-flex h-12 items-center justify-center rounded-md border border-input bg-background px-6 text-base font-medium text-foreground hover:bg-accent hover:text-accent-foreground transition-colors"
-              >
+              <a href={`mailto:${FOUNDER_EMAIL}`} className={outlineButtonClass}>
                 Email
               </a>
             </div>
@@ -167,14 +172,6 @@ export default function WalkinPage() {
             <Link href={SIGNUP_HREF} className={primaryButtonClass}>
               Start your free beta
             </Link>
-            <a
-              href={WHATSAPP_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-              className={secondaryLinkClass}
-            >
-              Or message me on WhatsApp
-            </a>
           </div>
         </section>
       </main>


### PR DESCRIPTION
## What

Follow-up UI polish on the `/walkin` landing page (PR #159), addressing review feedback. No logic changes; copy + button styling only.

## Changes

- **Subhead broadened** from "restaurants, hotels, and cafés" (F&B-only) to **"hospitality, retail, and local businesses"**, reflecting the product's full industry coverage (the `INDUSTRIES` list spans 8 industries, not just food & beverage). Metadata description updated to match.
- **Hero secondary link** now reads **"WhatsApp me directly"** (was "Or message me directly") with a `MessageCircle` icon.
- **Founder contact buttons** (WhatsApp + Email) are now **equal-weight outlined buttons with a visible indigo brand border** (`border-brand-500`), replacing the previous solid-WhatsApp-vs-faint-grey-Email pairing that read as asymmetric. WhatsApp also gets the message icon.
- **Removed the redundant bottom-CTA "Or message me on WhatsApp" link** — the founder block directly above already has a WhatsApp button.
- `docs/MVP_Phase-1/WALKIN_LANDING_PAGE.md` updated to match all of the above.

Note: lucide-react ships no WhatsApp brand glyph, so `MessageCircle` is used as the messaging icon.

## Verification

- `npm run type-check` clean
- `npm run lint:strict` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
