### PR TITLE
fix(auth): make logo link back to home on signup and signin

### DIFF
--- a/src/app/(auth)/auth/signin/page.tsx
+++ b/src/app/(auth)/auth/signin/page.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from "react";
 import { Metadata } from "next";
+import Link from "next/link";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { LoginForm } from "@/components/auth";
 
@@ -17,9 +18,13 @@ export default function SignInPage() {
     <Card>
       <CardHeader className="space-y-1 text-center">
         <div className="flex justify-center mb-4">
-          <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-primary text-primary-foreground text-xl font-bold">
+          <Link
+            href="/"
+            aria-label="Go to BrandsIQ home"
+            className="flex h-12 w-12 items-center justify-center rounded-lg bg-primary text-primary-foreground text-xl font-bold transition-opacity hover:opacity-90"
+          >
             R
-          </div>
+          </Link>
         </div>
         <CardTitle className="text-2xl font-bold">Welcome back</CardTitle>
         <CardDescription>

--- a/src/app/(auth)/auth/signup/page.tsx
+++ b/src/app/(auth)/auth/signup/page.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from "react";
 import { Metadata } from "next";
+import Link from "next/link";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { SignupForm } from "@/components/auth";
 
@@ -17,9 +18,13 @@ export default function SignUpPage() {
     <Card>
       <CardHeader className="space-y-1 text-center">
         <div className="flex justify-center mb-4">
-          <div className="flex h-12 items-center justify-center rounded-lg bg-primary text-primary-foreground text-xl font-bold px-3">
+          <Link
+            href="/"
+            aria-label="Go to BrandsIQ home"
+            className="flex h-12 items-center justify-center rounded-lg bg-primary text-primary-foreground text-xl font-bold px-3 transition-opacity hover:opacity-90"
+          >
             IQ
-          </div>
+          </Link>
         </div>
         <CardTitle className="text-2xl font-bold">Create an account</CardTitle>
         <CardDescription>


### PR DESCRIPTION
## What

The auth screens (signup, signin) had no way back to the marketing home page. The logo badge in the card header was a static `<div>`, not a link. A user arriving at signup, including via the `/walkin` QR CTA, was stuck on the form if they wanted to browse the site before committing.

## Fix

Wrap the logo badge in a `next/link` to `/` on both `signup` and `signin`, with `aria-label="Go to BrandsIQ home"` and a subtle hover affordance. This is the standard "logo links home" convention and keeps the focused auth screen otherwise unchanged (no extra nav clutter).

- `src/app/(auth)/auth/signup/page.tsx`
- `src/app/(auth)/auth/signin/page.tsx`

## Out of scope (deliberately)

The signin logo currently renders **"R"** (a leftover from the pre-BrandsIQ "ReviewFlow" name) rather than "IQ". This PR does **not** change the badge content/styling — the logo appearance is being handled separately. Only the click-to-home behaviour is added here.

## Verification

- `npm run type-check` clean
- `npm run lint:strict` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
