### PR TITLE
fix(e2e): update core-flow rating locator for renamed "Rating *" label

### DIFF
--- a/tests/e2e/core-flow.spec.ts
+++ b/tests/e2e/core-flow.spec.ts
@@ -43,9 +43,9 @@ test.describe("Core User Flow", () => {
     const reviewText = `E2E test review ${Date.now()}: Great product, excellent customer service and fast delivery!`;
     await page.locator("#reviewText").fill(reviewText);
 
-    // Click the 5th star for a 5-star rating.
-    // The star buttons are inside a flex container after the "Rating (optional)" label.
-    const ratingSection = page.locator("text=Rating (optional)").locator("..");
+    // Click the 5th star for a 5-star rating (rating is required on create).
+    // The star buttons are inside a flex container after the "Rating *" label.
+    const ratingSection = page.getByText("Rating *", { exact: true }).locator("..");
     const stars = ratingSection.locator('button[type="button"]');
     await stars.nth(4).click();
 


### PR DESCRIPTION
## What

Fixes the failing **E2E Tests Against Staging** run (`tests/e2e/core-flow.spec.ts:29`, the full login → add review → generate → edit → approve → delete journey).

## Why it broke

PR #169 (star-only reviews) made **rating required** and renamed the form label from **"Rating (optional)"** to **"Rating *"**. The core-flow spec located the star buttons relative to the old label:

```js
const ratingSection = page.locator("text=Rating (optional)").locator("..");
```

That text no longer exists, so the locator matched nothing, `stars.nth(4).click()` was a no-op, no rating was selected, the now-required-rating validation blocked submit, and the journey stalled before the detail-page redirect (cascading into the retry failures shown in the run).

This E2E spec is the counterpart to the unit-test label updates in #169 — it should have been updated there; this catches the miss.

## Fix

Anchor on the new label, exact match:

```js
const ratingSection = page.getByText("Rating *", { exact: true }).locator("..");
```

The star buttons remain `button[type="button"]` siblings under the same `space-y-2` container (the `Controller` wrapper renders them in a `flex` div that's still a child of the label's parent), so the relative locator is otherwise unchanged. No product code touched.

## Verification

This runs against staging via the `e2e-staging` workflow. Local `tsc`/`lint` unaffected (test-only, single-file). Once merged, the workflow re-runs the core flow against the staging deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)