### PR TITLE
fix(reviews): drop "(optional)" from add-review field labels

### DIFF
--- a/src/components/reviews/ReviewForm.tsx
+++ b/src/components/reviews/ReviewForm.tsx
@@ -197,7 +197,7 @@ export function ReviewForm({ initialData, mode = "create" }: ReviewFormProps) {
 
           {/* Review text */}
           <div className="space-y-2">
-            <Label htmlFor="reviewText">Review Text (optional)</Label>
+            <Label htmlFor="reviewText">Review Text</Label>
             <Textarea
               id="reviewText"
               placeholder="Paste or type the customer review here..."
@@ -323,7 +323,7 @@ export function ReviewForm({ initialData, mode = "create" }: ReviewFormProps) {
 
           {/* Reviewer name */}
           <div className="space-y-2">
-            <Label htmlFor="reviewerName">Reviewer Name (optional)</Label>
+            <Label htmlFor="reviewerName">Reviewer Name</Label>
             <Input
               id="reviewerName"
               placeholder="e.g., John D."
@@ -333,7 +333,7 @@ export function ReviewForm({ initialData, mode = "create" }: ReviewFormProps) {
 
           {/* Review date */}
           <div className="space-y-2">
-            <Label htmlFor="reviewDate">Review Date (optional)</Label>
+            <Label htmlFor="reviewDate">Review Date</Label>
             <Input
               id="reviewDate"
               type="date"

--- a/tests/unit/components/reviews/review-form.test.tsx
+++ b/tests/unit/components/reviews/review-form.test.tsx
@@ -45,7 +45,7 @@ describe("ReviewForm", () => {
     it("renders review text textarea", () => {
       render(<ReviewForm />);
 
-      expect(screen.getByText("Review Text (optional)")).toBeInTheDocument();
+      expect(screen.getByText("Review Text")).toBeInTheDocument();
       expect(
         screen.getByPlaceholderText(
           "Paste or type the customer review here..."
@@ -68,14 +68,14 @@ describe("ReviewForm", () => {
     it("renders reviewer name input", () => {
       render(<ReviewForm />);
 
-      expect(screen.getByText("Reviewer Name (optional)")).toBeInTheDocument();
+      expect(screen.getByText("Reviewer Name")).toBeInTheDocument();
       expect(screen.getByPlaceholderText("e.g., John D.")).toBeInTheDocument();
     });
 
     it("renders review date input", () => {
       render(<ReviewForm />);
 
-      expect(screen.getByText("Review Date (optional)")).toBeInTheDocument();
+      expect(screen.getByText("Review Date")).toBeInTheDocument();
     });
 
     it("renders Add Review submit button", () => {


### PR DESCRIPTION
## What

Removes the `(optional)` suffix from three Add Review field labels:
- `Review Text (optional)` → **Review Text**
- `Reviewer Name (optional)` → **Reviewer Name**
- `Review Date (optional)` → **Review Date**

`Rating *` and `Platform` are unchanged.

## Why

Standard form-design convention (NN/g, most design systems) is to **mark the required field, not the optional ones**. When a form is mostly optional — as this one is (one required: Rating; the rest optional) — repeating "(optional)" on each field adds visual noise and ironically makes the form feel more burdensome. The `*` on Rating already tells the user which field is mandatory; everything else is optional by implication.

(The competing convention — mark optional fields — only wins when *most* fields are required, which is the opposite of this form.)

## Changes

- `src/components/reviews/ReviewForm.tsx` — 3 label text changes
- `tests/unit/components/reviews/review-form.test.tsx` — 3 matching assertion updates

No behaviour change; labels only.

## Verification

- `npm run lint` clean
- `npx tsc --noEmit` clean
- `npx vitest run tests/unit/components/reviews/review-form.test.tsx` — 18 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)