### PR TITLE
feat(auth): "Sign in with Google" hint on OAuth-only password reset

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -2237,6 +2237,7 @@ Verification: `npm run lint:strict` clean; `npm run type-check` clean; `npm run 
 | 108 | Free tier allocation lowered 15/35 → 5/25 — single `TIER_LIMITS.FREE` constant edit cascades to signup/cron/landing/pricing via `getEffectiveAllocation`; Prisma column defaults + additive migration, no backfill (no real users); `CreditsProvider` + dev reset-credits defaults rewired to the constant; Starter/Growth/Beta unchanged | Free tier allocation | Jun 3 | Low ✅ | ✅ Implemented |
 | 109 | Add-review requiredness inverted — rating REQUIRED, reviewText OPTIONAL — supports star-only reviews (e.g. Google "5 stars, no comment"). Additive nullable migration on `Review.reviewText` (no backfill); route normalizes empty text → null, skips dedupe + sentiment + language detection for star-only; no-text AI prompt path responds to the rating without inventing specifics (templates kept pure); platform `*` label dropped; rating wired via RHF `Controller`; null-text placeholder in list + detail views | Add-review fields | Jun 4 | Low ✅ | ✅ Implemented |
 | 110 | Walk-in "Start free beta" routes through a new `/auth/get-started` gateway offering request-beta-access (`FounderInquiryForm type=beta_request`) alongside a regular-signup fallback, mirroring the expired-link page. Phase-aware server component: `phase_2` redirects to `/auth/signup` preserving `utm_source`. New `signup_gateway` value in `FOUNDER_INQUIRY_SOURCES` (+ the hardcoded `posthog-events` union) for attribution. Walk-in `SIGNUP_HREF` re-pointed; landing page untouched | Walk-in signup gateway | Jun 5 | Low ✅ | ✅ Implemented |
+| 111 | OAuth-only "Forgot password" now emails a "Sign in with Google" hint instead of silently sending nothing. Gated on `password === null` AND an actually-linked `provider==='google'` account (a password-less account with no Google link stays silent). On-page HTTP response is byte-identical across all branches, so anti-enumeration is preserved — the differentiation lives only in the owner's inbox. New `sendOAuthSignInHintEmail` (no token); request route adds `include: { accounts: true }` + an if/else branch | OAuth reset hint | Jun 6 | Low ✅ | ✅ Implemented |
 
 *Table will grow as decisions are made*
 
@@ -2316,7 +2317,30 @@ Verification: `npm run lint:strict` clean; `npm run type-check` clean; `npm run 
 - **GDPR posture:** unchanged. The page is unauthenticated like `beta-link-expired`/`signup` and posts to the existing rate-limited `POST /api/founder-inquiries`. No new auth surface or PII handling.
 - **Risk:** Low ✅. Purely additive: one new page, one enum value (+ its duplicated union), one constant re-point. No schema/migration. Reversible.
 
+---
+
+## OAuth-only "Forgot password" → "Sign in with Google" hint email
+
+**Context.** A user whose account was created via **Google sign-in only** (no password) who clicks "Forgot password" got **nothing**: the request route only sent a reset email `if (user && user.password)`, and an OAuth-only account has `password === null`. The page still showed the generic "if an account exists, a link has been sent" message (deliberate anti-enumeration), so the real owner waited for an email that never arrived, with no explanation. No user complained, but it's a genuine communication gap. The founder chose the email-based hint (keep the page generic; tell the real owner via their inbox).
+
+#### Decision 111: Email a "Sign in with Google" hint for OAuth-only reset requests, gated on an actually-linked Google account; on-page response unchanged.
+
+- **Decision (new email):** `sendOAuthSignInHintEmail(email)` in `src/lib/email.ts`, mirroring `sendPasswordResetEmail` (same `emailHeader` shell, same `{ success, error }` return inside try/catch, never throws). Heading "Sign in with Google", CTA → `/auth/signin` (the page with the Google button). **No token** — it's a navigational hint, not a reset.
+- **Decision (detection):** fire the hint only when `user.password === null` AND `user.accounts.some(a => a.provider === "google")`. The request route adds `include: { accounts: true }` to the lookup. A password-less account with **no** linked Google (e.g. an invite-created user who never set a password or linked OAuth) keeps the **existing silent no-email** behavior — we never tell someone to "use Google" when they may not have it. This was the key correctness call: `password === null` alone is NOT the same as "has Google".
+- **Decision (anti-enumeration preserved):** the route's HTTP 200 response is **byte-identical** across all branches (password / google-hint / silent). The only differentiation lives in the email that reaches the genuine owner's inbox, never in the response a form-prober can observe. Email-send failures are caught + logged in the helper, so they can't alter the response either.
+- **Alternatives considered:** (a) on-page message "this account uses Google sign-in" — rejected, it leaks account-existence + sign-in-method to anyone probing the forgot-password form (a real enumeration regression). (b) any-password-null account gets the hint — rejected, would mislead the no-Google edge population. (c) generic "this account has no password" copy — rejected as vaguer; the founder chose the Google-specific hint gated on an actual Google link.
+- **What this does NOT change:** the credentials login guard (`if (!user.password) return null`) and the confirm route are untouched. If a Google user later genuinely wants a password, that's a separate "set a password" feature, not built here.
+- **Risk:** Low ✅. Additive: one new email helper, one route branch, one extra `include`. No schema change. Reversible. The anti-enumeration contract is the thing to guard — the response stays identical.
+
 ## Change Log
+
+**June 6, 2026** — OAuth-only "Forgot password" → "Sign in with Google" hint email (Decision 111)
+- Branch `feat/oauth-reset-hint-email` (off main). A Google-only user (no password) who requests a password reset now receives an email hinting them to sign in with Google, instead of silently getting nothing. Closes a communication gap; no user had complained.
+- `src/lib/email.ts`: new `sendOAuthSignInHintEmail(email)` — mirrors `sendPasswordResetEmail` but CTA → `/auth/signin`, no token.
+- `src/app/api/auth/password-reset/request/route.ts`: lookup gains `include: { accounts: true }`; the single `if (user && user.password)` becomes a branch — password user → reset email (unchanged); OAuth-only + linked Google → hint email; password-less + no Google → silent (unchanged). The generic 200 response is identical across all branches (anti-enumeration).
+- Tests: `email.test.ts` gains a `sendOAuthSignInHintEmail` block (subject/recipient, signin link present, no reset-password link, success + error result shapes); `password-reset-request.test.ts` — the old "OAuth-only sends nothing" case flips to "linked-Google sends the hint", a new "no-Google stays silent" case, and the password case asserts the hint does NOT fire. `accounts` added to the route-test fixtures.
+- Docs: DECISIONS (this entry + Decision 111), PROGRESS, SECURITY_AUTH.md (password-reset anti-enumeration + OAuth-only hint subsection).
+- Verification: `npx tsc --noEmit` clean, `npm run lint` clean, affected unit tests green.
 
 **June 5, 2026** — Walk-in "Start free beta" → /auth/get-started gateway (Decision 110)
 - Branch `feat/walkin-get-started-gateway` (off main). The walk-in page's "Start free beta" CTA now routes to a new `/auth/get-started` page that offers request-beta-access alongside a regular-signup fallback, since BrandsIQ is invite-only. Built by reusing `FounderInquiryForm`, the founder-inquiries API, and the `getCurrentPhase()` server pattern.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1632,5 +1632,24 @@ The walk-in page's "Start free beta" CTA dropped a just-met visitor straight int
 
 ---
 
-**Last Updated:** June 5, 2026
-**Status:** Walk-in "Start free beta" now routes through a new `/auth/get-started` gateway offering request-beta-access + regular-signup fallback (Decision 110), on `feat/walkin-get-started-gateway` branch. 103 numbered decisions logged. Decision 109 (star-only reviews) merged to main.
+## OAuth-only "Forgot password" → "Sign in with Google" hint email
+
+**Started + completed:** June 6, 2026. **Branch:** `feat/oauth-reset-hint-email` (off main).
+
+A Google-only user (account created via Google sign-in, no password) who clicked "Forgot password" previously got nothing — the request route only sent a reset email when the account had a password, and the page showed the generic "check your email" message either way. Now such users receive an email hinting them to sign in with Google. No user had complained; this closes a communication gap.
+
+**What shipped:**
+- **`src/lib/email.ts`:** new `sendOAuthSignInHintEmail(email)` mirroring `sendPasswordResetEmail` (same branded shell + `{success,error}` return), CTA "Sign in with Google" → `/auth/signin`, **no token**.
+- **`src/app/api/auth/password-reset/request/route.ts`:** lookup gains `include: { accounts: true }`; the `if (user && user.password)` becomes a branch — password user → reset email (unchanged); OAuth-only with a linked Google account → hint email; password-less with no Google → silent (unchanged). The generic 200 response is **identical** across all branches (anti-enumeration preserved — the differentiation lives only in the inbox).
+- **Detection gate:** `password === null` AND `accounts.some(a => a.provider === "google")`. A password-less account with no Google link keeps today's silent behavior, so we never tell someone to "use Google" when they may not have it.
+
+**Tests:** `email.test.ts` gains a `sendOAuthSignInHintEmail` block (4 cases); `password-reset-request.test.ts` — old "OAuth-only sends nothing" flips to "linked-Google sends the hint", plus a new "no-Google stays silent" case and a "password user, hint not fired" assertion. 33 tests across the two files pass.
+
+**Verification:** `npx tsc --noEmit` clean, `npm run lint` clean, affected unit tests green.
+
+**Decisions:** cross-reference DECISIONS.md "OAuth-only 'Forgot password' → 'Sign in with Google' hint email" — Decision 111.
+
+---
+
+**Last Updated:** June 6, 2026
+**Status:** OAuth-only "Forgot password" now sends a "Sign in with Google" hint email instead of silently nothing, gated on an actually-linked Google account, with the on-page response unchanged (anti-enumeration preserved) — Decision 111, on `feat/oauth-reset-hint-email` branch. 104 numbered decisions logged. Decision 110 (walk-in gateway) merged to main.

--- a/docs/phase-0/SECURITY_AUTH.md
+++ b/docs/phase-0/SECURITY_AUTH.md
@@ -330,6 +330,17 @@ export async function sendPasswordResetEmail(email: string, token: string) {
 }
 ```
 
+### Password-reset request: anti-enumeration + OAuth-only hint
+
+`POST /api/auth/password-reset/request` always returns the **same generic 200** ("If an account exists with this email, a password reset link has been sent.") regardless of whether the email exists, doesn't exist, or belongs to an OAuth-only account. This is deliberate anti-enumeration: a form-prober cannot use the HTTP response to discover which emails have accounts or which sign-in method they use.
+
+Branch behavior (all return the identical 200):
+- **Password account** (`user.password` set) → create a reset token + send the reset email.
+- **Google sign-in account, no password** (`user.password === null` AND a linked `provider === "google"` account) → send a **sign-in-method hint email** (`sendOAuthSignInHintEmail`) pointing the owner to "Sign in with Google" at `/auth/signin`. **No token.** This closes a UX gap where such users previously got nothing and no explanation. The differentiation lives only in the inbox of the genuine owner, never in the response, so it does not leak enumeration.
+- **Password-less account with no linked Google** (e.g. an invite-created user who never set a password or linked OAuth) → no email (existing silent behavior; we never claim a sign-in method the account may not have).
+
+Email-send failures in any branch are caught and logged inside the email helper, so they can never alter the response. See DECISIONS.md.
+
 ---
 
 ## Security Implementation

--- a/src/app/api/auth/password-reset/request/route.ts
+++ b/src/app/api/auth/password-reset/request/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { sendPasswordResetEmail } from "@/lib/email";
+import { sendPasswordResetEmail, sendOAuthSignInHintEmail } from "@/lib/email";
 import { createPasswordResetToken } from "@/lib/tokens";
 import { loginRateLimit, getClientIP, checkRateLimit } from "@/lib/rate-limit";
 import { forgotPasswordSchema } from "@/lib/validations";
@@ -40,18 +40,21 @@ export async function POST(request: Request) {
 
     const { email } = validation.data;
 
-    // Find user
+    // Find user. Include accounts so we can tell a genuine Google-linked
+    // account (no password, but a linked Google provider) apart from a
+    // password-less account with no OAuth link at all.
     const user = await prisma.user.findUnique({
       where: { email: email.toLowerCase() },
+      include: { accounts: true },
     });
 
-    // Always return success to prevent email enumeration
-    // But only send email if user exists and has a password (not OAuth-only)
+    // The HTTP response below is ALWAYS the same generic 200, regardless of
+    // which branch runs here — this is the anti-enumeration contract. The only
+    // differentiation lives in the email that lands in the real owner's inbox,
+    // never in the response a form-prober can observe.
     if (user && user.password) {
-      // Create password reset token
+      // Password account: send the normal reset link.
       const resetToken = await createPasswordResetToken(email.toLowerCase());
-
-      // Send password reset email
       const emailResult = await sendPasswordResetEmail(
         email.toLowerCase(),
         resetToken
@@ -59,6 +62,24 @@ export async function POST(request: Request) {
 
       if (!emailResult.success) {
         console.error("Failed to send password reset email:", emailResult.error);
+      }
+    } else if (
+      user &&
+      !user.password &&
+      user.accounts.some((acc) => acc.provider === "google")
+    ) {
+      // Google sign-in account with no password: there is nothing to reset, so
+      // hint the owner to use Google instead. Gated on an actually-linked
+      // Google account so we never tell a password-less, non-Google account
+      // (e.g. an invite-created user who never linked anything) to "use Google"
+      // — that population keeps the existing silent no-email behavior.
+      const emailResult = await sendOAuthSignInHintEmail(email.toLowerCase());
+
+      if (!emailResult.success) {
+        console.error(
+          "Failed to send OAuth sign-in hint email:",
+          emailResult.error
+        );
       }
     }
 

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -137,6 +137,69 @@ export async function sendPasswordResetEmail(email: string, token: string) {
 }
 
 /**
+ * Sent when a password-reset is requested for an account that has NO password
+ * because it was created via Google sign-in (and a Google account is actually
+ * linked). There is nothing to reset, so instead of silently sending nothing
+ * we email the real owner a hint to sign in with Google.
+ *
+ * Anti-enumeration: the password-reset request route returns the SAME generic
+ * response whether or not this email is sent. The differentiation lives only
+ * in the inbox of the genuine account owner, never in the HTTP response, so a
+ * form-prober cannot use it to discover which emails have Google accounts.
+ *
+ * No token is created or included — this is a navigational hint, not a reset.
+ */
+export async function sendOAuthSignInHintEmail(email: string) {
+  const signInUrl = `${process.env.NEXTAUTH_URL}/auth/signin`;
+
+  try {
+    const { data, error } = await resend.emails.send({
+      from: FROM_EMAIL,
+      to: email,
+      subject: "Use Google to sign in - BrandsIQ",
+      html: `
+        <!DOCTYPE html>
+        <html>
+          <head>
+            <meta charset="utf-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            <title>Use Google to sign in</title>
+          </head>
+          <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+            ${emailHeader("Sign in with Google")}
+            <div style="background: #ffffff; padding: 30px; border: 1px solid #e5e7eb; border-top: none; border-radius: 0 0 12px 12px;">
+              <p style="margin-top: 0;">You asked to reset your password, but this account was created with Google sign-in. It does not have a password to reset.</p>
+              <p>To get back in, use the "Continue with Google" button on the sign-in page:</p>
+              <div style="text-align: center; margin: 30px 0;">
+                <a href="${signInUrl}" style="background: #4f46e5; color: white; padding: 12px 30px; border-radius: 6px; text-decoration: none; font-weight: 600; display: inline-block;">
+                  Sign in with Google
+                </a>
+              </div>
+              <p style="color: #666; font-size: 14px;">Or copy and paste this link into your browser:</p>
+              <p style="color: #4f46e5; font-size: 14px; word-break: break-all;">${signInUrl}</p>
+              <hr style="border: none; border-top: 1px solid #e5e7eb; margin: 30px 0;">
+              <p style="color: #999; font-size: 12px; margin-bottom: 0;">
+                If you didn't request this, you can safely ignore this email. Your account is unchanged.
+              </p>
+            </div>
+          </body>
+        </html>
+      `,
+    });
+
+    if (error) {
+      console.error("Failed to send OAuth sign-in hint email:", error);
+      return { success: false, error };
+    }
+
+    return { success: true, data };
+  } catch (error) {
+    console.error("Error sending OAuth sign-in hint email:", error);
+    return { success: false, error };
+  }
+}
+
+/**
  * Plan-specific copy block rendered inside the welcome email.
  * Numbers and framing come from BETA_PLAN / TIER_LIMITS.FREE so a future
  * change to the allocation propagates here automatically.

--- a/tests/unit/api/auth/password-reset-request.test.ts
+++ b/tests/unit/api/auth/password-reset-request.test.ts
@@ -26,6 +26,7 @@ const mockPrisma = vi.hoisted(() => {
 const mockEmail = vi.hoisted(() => ({
   sendVerificationEmail: vi.fn().mockResolvedValue({ success: true }),
   sendPasswordResetEmail: vi.fn().mockResolvedValue({ success: true }),
+  sendOAuthSignInHintEmail: vi.fn().mockResolvedValue({ success: true }),
   sendWelcomeEmail: vi.fn().mockResolvedValue({ success: true }),
 }));
 
@@ -142,12 +143,13 @@ describe('POST /api/auth/password-reset/request', () => {
     expect(mockEmail.sendPasswordResetEmail).not.toHaveBeenCalled();
   });
 
-  it('does not send email for OAuth-only user (password is null)', async () => {
+  it('sends the Google sign-in hint (not a reset) for an OAuth-only user with a linked Google account', async () => {
     mockPrisma.user.findUnique.mockResolvedValue({
       id: 'oauth-user',
       email: 'oauth@example.com',
       password: null,
       emailVerified: new Date(),
+      accounts: [{ provider: 'google' }],
     });
 
     const req = createRequest('/api/auth/password-reset/request', {
@@ -156,21 +158,53 @@ describe('POST /api/auth/password-reset/request', () => {
     });
     const response = await POST(req);
 
+    // Response stays the generic 200 (anti-enumeration).
     expect(response.status).toBe(200);
     const json = await response.json();
     expect(json.success).toBe(true);
 
-    // Should NOT create token or send email for OAuth-only users
+    // No reset token + no reset email; instead the Google hint email fires.
     expect(mockTokens.createPasswordResetToken).not.toHaveBeenCalled();
     expect(mockEmail.sendPasswordResetEmail).not.toHaveBeenCalled();
+    expect(mockEmail.sendOAuthSignInHintEmail).toHaveBeenCalledWith(
+      'oauth@example.com'
+    );
   });
 
-  it('creates token and sends email for password user', async () => {
+  it('stays silent for a password-less account with NO linked Google account', async () => {
+    // e.g. an invite-created user who never set a password and never linked
+    // Google — we must not tell them to "use Google".
+    mockPrisma.user.findUnique.mockResolvedValue({
+      id: 'no-auth-user',
+      email: 'noauth@example.com',
+      password: null,
+      emailVerified: new Date(),
+      accounts: [],
+    });
+
+    const req = createRequest('/api/auth/password-reset/request', {
+      method: 'POST',
+      body: { email: 'noauth@example.com' },
+    });
+    const response = await POST(req);
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.success).toBe(true);
+
+    // Neither email fires; existing silent behavior preserved.
+    expect(mockTokens.createPasswordResetToken).not.toHaveBeenCalled();
+    expect(mockEmail.sendPasswordResetEmail).not.toHaveBeenCalled();
+    expect(mockEmail.sendOAuthSignInHintEmail).not.toHaveBeenCalled();
+  });
+
+  it('creates token and sends the reset email for a password user', async () => {
     mockPrisma.user.findUnique.mockResolvedValue({
       id: 'user-123',
       email: 'user@example.com',
       password: '$2a$12$hashedpassword',
       emailVerified: new Date(),
+      accounts: [],
     });
 
     const req = createRequest('/api/auth/password-reset/request', {
@@ -190,5 +224,7 @@ describe('POST /api/auth/password-reset/request', () => {
       'user@example.com',
       'reset-token-123'
     );
+    // The hint email must not fire for a password user.
+    expect(mockEmail.sendOAuthSignInHintEmail).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/lib/email.test.ts
+++ b/tests/unit/lib/email.test.ts
@@ -14,6 +14,7 @@ vi.mock('resend', () => ({
 import {
   sendVerificationEmail,
   sendPasswordResetEmail,
+  sendOAuthSignInHintEmail,
   sendWelcomeEmail,
   sendFounderInquiryNotification,
 } from '@/lib/email';
@@ -102,6 +103,40 @@ describe('email.ts', () => {
       expect(result).toEqual(
         expect.objectContaining({ success: true }),
       );
+    });
+  });
+
+  describe('sendOAuthSignInHintEmail', () => {
+    it('sends a Google sign-in hint with the right subject and recipient', async () => {
+      await sendOAuthSignInHintEmail('oauth@example.com');
+
+      expect(mockSend).toHaveBeenCalledTimes(1);
+      const callArgs = mockSend.mock.calls[0][0];
+      expect(callArgs.to).toBe('oauth@example.com');
+      expect(callArgs.subject).toContain('Google');
+    });
+
+    it('links to the sign-in page and carries no reset token', async () => {
+      await sendOAuthSignInHintEmail('oauth@example.com');
+
+      const callArgs = mockSend.mock.calls[0][0];
+      expect(callArgs.html).toContain('/auth/signin');
+      // It is a navigational hint, not a reset — no reset-password link.
+      expect(callArgs.html).not.toContain('/auth/reset-password');
+    });
+
+    it('returns success on successful send', async () => {
+      const result = await sendOAuthSignInHintEmail('oauth@example.com');
+
+      expect(result).toEqual(expect.objectContaining({ success: true }));
+    });
+
+    it('returns error result when the send fails', async () => {
+      mockSend.mockResolvedValueOnce({ data: null, error: { message: 'boom' } });
+
+      const result = await sendOAuthSignInHintEmail('oauth@example.com');
+
+      expect(result).toEqual(expect.objectContaining({ success: false }));
     });
   });
 


### PR DESCRIPTION
## What & why

A user whose account was created via **Google sign-in only** (no password) who clicks **"Forgot password"** got **nothing**: the request route only sent a reset email when the account had a password, and the page showed the generic *"check your email"* message either way. They'd wait for an email that never arrived, with no explanation.

Now such users receive an email hinting them to **sign in with Google**. Nobody had complained — this closes a communication gap, not a reported bug.

## Anti-enumeration is preserved

The forgot-password page deliberately returns the **same generic 200** for every email (existing / non-existent / OAuth-only) so a form-prober can't discover which emails have accounts or which sign-in method they use. This PR keeps that contract: the HTTP response is **byte-identical across all branches** — the differentiation lives **only in the email** that reaches the real owner's inbox. Email-send failures are caught + logged in the helper, so they can't alter the response either.

## Branch behavior (all return the identical generic 200)

| Account | Behavior |
|---|---|
| Has a password | Reset token + reset email (**unchanged**) |
| `password === null` **and** a linked `provider==='google'` account | New **"Sign in with Google" hint email** (no token) |
| `password === null` and **no** Google link (e.g. invite-created, never linked) | No email (**unchanged silent behavior**) |

The detection is gated on an **actually-linked Google account**, not just `password === null` — so we never tell a non-Google account to "use Google". That edge population keeps today's silent behavior (no regression).

## Changes

- `src/lib/email.ts` — new `sendOAuthSignInHintEmail(email)` mirroring `sendPasswordResetEmail` (branded shell, `{success,error}` return, never throws), CTA → `/auth/signin`, **no token**.
- `src/app/api/auth/password-reset/request/route.ts` — lookup gains `include: { accounts: true }`; the single `if (user && user.password)` becomes an if/else branch.
- Tests — `email.test.ts` gains a `sendOAuthSignInHintEmail` block; `password-reset-request.test.ts` flips the OAuth-only case to "linked-Google sends the hint", adds "no-Google stays silent" + "password user, hint not fired".
- Docs — DECISIONS (#111), PROGRESS, SECURITY_AUTH (password-reset anti-enumeration + OAuth-only hint subsection).

The credentials login guard and the confirm route are **untouched**. If a Google user genuinely wants to *add* a password, that's a separate "set a password" feature, not built here.

## Verification

- `npx tsc --noEmit` clean
- `npm run lint` clean
- `npm run test:unit` **1285 passed / 0 failed** (66 files)

**Manual smoke (needs RESEND_API_KEY + a Google-only test account):** create an account via Google sign-in only → "Forgot password" with that email → page shows the generic message, inbox receives the "Sign in with Google" email → /auth/signin. Control: a normal password account still gets the reset email; a non-existent email gets nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)