### PR TITLE
feat(ui): add "Add Review" CTA to the review-detail page top bar

### DIFF
--- a/src/app/(dashboard)/dashboard/reviews/[id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/reviews/[id]/page.tsx
@@ -7,6 +7,7 @@ import { useSession } from "next-auth/react";
 import { toast } from "sonner";
 import {
   ArrowLeft,
+  Plus,
   ArrowRight,
   Star,
   Globe,
@@ -282,13 +283,25 @@ export default function ReviewDetailPage() {
 
   return (
     <div className="space-y-6">
-      {/* Back button */}
-      <Button variant="ghost" size="sm" asChild>
-        <Link href="/dashboard/reviews">
-          <ArrowLeft className="mr-2 h-4 w-4" />
-          Back to Reviews
-        </Link>
-      </Button>
+      {/* Top bar: back link on the left, Add Review on the right.
+          The Add Review CTA mirrors the one on the reviews-list and
+          dashboard pages (same Plus icon + label + href) so the
+          affordance is consistent across surfaces. Lets users bulk-add
+          without round-tripping through the list page. */}
+      <div className="flex items-center justify-between gap-3">
+        <Button variant="ghost" size="sm" asChild>
+          <Link href="/dashboard/reviews">
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            Back to Reviews
+          </Link>
+        </Button>
+        <Button asChild>
+          <Link href="/dashboard/reviews/new">
+            <Plus className="mr-2 h-4 w-4" />
+            Add Review
+          </Link>
+        </Button>
+      </div>
 
       {/* Sentiment skipped alert */}
       {showSentimentAlert && (() => {


### PR DESCRIPTION
## Summary

Bulk-adding reviews currently requires a round-trip through the reviews-list page each time, which is real friction during a session of ingesting many reviews at once.

This PR adds an **Add Review** button to the top bar of the review-detail page, mirroring the existing CTA from the reviews-list and dashboard pages (same `Plus` icon + label + `href="/dashboard/reviews/new"`). The lone "Back to Reviews" ghost button is now wrapped in a flex/justify-between row with the new button on the right — the back link stays in place so the return path is preserved.

No logic change, no schema, no API surface. Pure layout addition.

## What I'd test

- [x] `npm run lint:strict` clean
- [x] `npm run type-check` clean
- [ ] Manual on staging: open any review detail page, confirm the Add Review button appears on the right of the back link. Click it → routes to the add-review form. After saving, the new review's detail page also has the Add Review button so you can keep bulk-adding without round-tripping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)