### PR TITLE
feat(mailer): scaffold One-Pager Mailer Google Apps Script engine

### DIFF
--- a/scripts/one-pager-mailer/Brandsiq.gs
+++ b/scripts/one-pager-mailer/Brandsiq.gs
@@ -1,0 +1,171 @@
+/**
+ * Brandsiq.gs — the BrandsIQ generate-response call.
+ *
+ * POST {BRANDSIQ_BASE_URL}/api/integrations/generate-response
+ *   Authorization: Bearer {INTEGRATIONS_API_KEY}
+ *   body: { reviewText, rating?, platform: "Google" }
+ *   200 success → data.responseText (the generated reply, body only)
+ *
+ * The reply follows the review's detected language (BrandsIQ default), so a
+ * German review yields a German reply — no language parameter is sent.
+ *
+ * Spec: docs/MVP_Phase-1/ONE_PAGER_MAILER_DESIGN.md Section 10.
+ */
+
+/**
+ * Ensure the row's "Generated Response" cell is populated. Reuses an existing
+ * value with NO API call (idempotency); otherwise calls BrandsIQ, writes the
+ * result immediately, and returns it.
+ *
+ * Throws (→ row marked Error by the caller's guard) when the Review is blank or
+ * longer than REVIEW_MAX, because the endpoint would reject it with a 400.
+ *
+ * @param {Sheet} sheet
+ * @param {number} rowNumber 1-based
+ * @param {Array} rowValues
+ * @param {Object} headerMap
+ * @return {string} the generated response text
+ */
+function ensureGeneratedResponse(sheet, rowNumber, rowValues, headerMap) {
+  var existing = trim_(getCell(rowValues, headerMap, "Generated Response"));
+  if (existing !== "") {
+    return existing; // reuse — no re-call, no credit/rate-limit hit
+  }
+
+  var reviewText = trim_(getCell(rowValues, headerMap, "Review"));
+  if (reviewText === "") {
+    throw new Error("Review is empty; cannot generate a response.");
+  }
+  if (reviewText.length > REVIEW_MAX) {
+    throw new Error(
+      "Review is " + reviewText.length + " chars; exceeds the " + REVIEW_MAX + "-char limit."
+    );
+  }
+
+  var rating = parseRating_(getCell(rowValues, headerMap, "Ratings"));
+  var responseText = callBrandsiq(reviewText, rating);
+
+  // Write immediately so a crash after the (paid) call doesn't lose the result.
+  setCell(sheet, rowNumber, headerMap, "Generated Response", responseText);
+  return responseText;
+}
+
+/**
+ * Call the BrandsIQ endpoint. Reads BRANDSIQ_BASE_URL + INTEGRATIONS_API_KEY
+ * from Script Properties. Retries on 429 with exponential backoff.
+ *
+ * @param {string} reviewText  1–REVIEW_MAX chars (caller guarantees).
+ * @param {number|null} rating  1–5 or null (omitted from the body when null).
+ * @return {string} data.responseText
+ */
+function callBrandsiq(reviewText, rating) {
+  var props = PropertiesService.getScriptProperties();
+  var baseUrl = props.getProperty(PROP_BASE_URL);
+  var apiKey = props.getProperty(PROP_API_KEY);
+
+  if (!baseUrl) {
+    throw new Error("Script Property " + PROP_BASE_URL + " is not set.");
+  }
+  if (!apiKey) {
+    throw new Error("Script Property " + PROP_API_KEY + " is not set.");
+  }
+
+  var url = baseUrl.replace(/\/+$/, "") + BRANDSIQ_GENERATE_PATH;
+  var body = { reviewText: reviewText, platform: PLATFORM };
+  if (rating !== null) {
+    body.rating = rating;
+  }
+
+  var options = {
+    method: "post",
+    contentType: "application/json",
+    headers: { Authorization: "Bearer " + apiKey },
+    payload: JSON.stringify(body),
+    muteHttpExceptions: true, // mandatory: handle 4xx/5xx ourselves
+  };
+
+  var attempt = 0;
+  while (true) {
+    var response = UrlFetchApp.fetch(url, options);
+    var code = response.getResponseCode();
+    var text = response.getContentText();
+
+    if (code === 200) {
+      var json = parseJsonOrThrow_(text, code);
+      if (json && json.success && json.data && json.data.responseText) {
+        return json.data.responseText;
+      }
+      throw new Error("BrandsIQ returned 200 but no responseText.");
+    }
+
+    if (code === 429) {
+      if (attempt < MAX_RETRIES) {
+        var waitMs =
+          BASE_BACKOFF_MS * Math.pow(2, attempt) +
+          Math.floor(Math.random() * MAX_JITTER_MS);
+        Utilities.sleep(waitMs);
+        attempt++;
+        continue;
+      }
+      throw new Error("BrandsIQ rate limit (429) exceeded after retries.");
+    }
+
+    // 401 / 503 are operator-actionable config faults — surface clearly. Every
+    // row failing with the same message makes a misconfiguration obvious.
+    if (code === 401) {
+      throw new Error(
+        "BrandsIQ auth failed (401). Check " + PROP_API_KEY + " matches the server."
+      );
+    }
+    if (code === 503) {
+      throw new Error("BrandsIQ not configured (503). " + errorMessageFrom_(text));
+    }
+    if (code === 400) {
+      throw new Error("BrandsIQ rejected the request (400). " + errorMessageFrom_(text));
+    }
+    // 500 / anything else.
+    throw new Error("BrandsIQ error (" + code + "). " + errorMessageFrom_(text));
+  }
+}
+
+/**
+ * Parse a "Ratings" cell into an integer 1–5, or null if absent/out of range.
+ * @private
+ */
+function parseRating_(value) {
+  if (value === null || value === undefined || value === "") return null;
+  var n = parseInt(value, 10);
+  if (isNaN(n) || n < 1 || n > 5) return null;
+  return n;
+}
+
+/**
+ * Parse a JSON string; throw a clear error if it isn't JSON (a 500 may return
+ * a non-JSON body).
+ * @private
+ */
+function parseJsonOrThrow_(text, code) {
+  try {
+    return JSON.parse(text);
+  } catch (e) {
+    throw new Error("BrandsIQ returned a non-JSON response (HTTP " + code + ").");
+  }
+}
+
+/**
+ * Best-effort extraction of error.message from an error envelope; falls back to
+ * a trimmed snippet of the raw body.
+ * @private
+ */
+function errorMessageFrom_(text) {
+  try {
+    var json = JSON.parse(text);
+    if (json && json.error && json.error.message) {
+      return json.error.message;
+    }
+  } catch (e) {
+    // not JSON — fall through
+  }
+  var snippet = String(text || "").substring(0, 200);
+  return snippet;
+}

--- a/scripts/one-pager-mailer/Config.gs
+++ b/scripts/one-pager-mailer/Config.gs
@@ -1,0 +1,123 @@
+/**
+ * Config.gs — constants shared by every other file.
+ *
+ * Apps Script merges all .gs files in a project into one global scope, so the
+ * names declared here are visible everywhere. Keep this file free of logic.
+ *
+ * Spec: docs/MVP_Phase-1/ONE_PAGER_MAILER_DESIGN.md (Sections 4, 5, 10).
+ */
+
+// Tab in the bound "Marketing Profiles" registry spreadsheet that holds one row
+// per campaign. The registry spreadsheet ID is NOT hardcoded — the script is
+// bound to it and reads its own active spreadsheet (Section 3).
+var PROFILES_TAB = "Profiles";
+
+// Menu shown in the spreadsheet UI.
+var MENU_TITLE = "BrandsIQ Mailer";
+
+// ── Registry columns (Marketing Profiles → Profiles tab) ──────────────────
+// Only the fields the engine actually uses are validated as required. The
+// "label only" columns (SpreadsheetName, SlideTemplateName, FolderName) are
+// ignored. FolderId is intentionally NOT in this list — it may be blank and
+// falls back to DEFAULT_FOLDER_ID (Section 4 note + Section 7).
+var PROFILE_REQUIRED_FIELDS = [
+  "ProfileName",
+  "SpreadsheetId",
+  "TabName",
+  "SlideTemplateId",
+  "EmailSubject",
+  "EmailBody",
+];
+
+// All registry columns the script reads into a profile object (required +
+// optional). FolderId is read but allowed blank.
+var PROFILE_FIELDS = PROFILE_REQUIRED_FIELDS.concat(["FolderId"]);
+
+// ── Prospect-sheet columns ────────────────────────────────────────────────
+// Columns the tool READS, by exact header name (Section 5.1).
+var PROSPECT_READ_HEADERS = [
+  "Business Name",
+  "Num of reviews per month",
+  "Ratings",
+  "Address",
+  "Review",
+  "Email",
+];
+
+// Working columns the tool WRITES (Section 5.2). These must exist in the
+// prospect sheet so the script has somewhere to record state.
+var PROSPECT_WRITE_HEADERS = [
+  "Generated Response",
+  "One Pager Link",
+  "Status",
+  "First Contact Date",
+  "Follow-up 1 Date",
+];
+
+// Every header that must be present, exact, and unique before processing.
+var REQUIRED_PROSPECT_HEADERS = PROSPECT_READ_HEADERS.concat(PROSPECT_WRITE_HEADERS);
+
+// ── Token → source-column mapping (Section 5.3) ───────────────────────────
+// Each token maps to a prospect-sheet column header. {{Generated Response}}
+// is populated by the BrandsIQ call first, then read from its column like any
+// other. Tokens are matched case-sensitively, braces included (Section 5.4),
+// in BOTH the slide deck and the email subject/body.
+var TOKEN_TO_COLUMN = {
+  "{{Business Name}}": "Business Name",
+  "{{Address}}": "Address",
+  "{{NRPM}}": "Num of reviews per month",
+  "{{Ratings}}": "Ratings",
+  "{{Review}}": "Review",
+  "{{Generated Response}}": "Generated Response",
+};
+
+// ── File naming (Section 5.5) ─────────────────────────────────────────────
+// {name} is the Business Name.
+function deckName(businessName) {
+  return "One Pager_" + businessName;
+}
+function pdfName(businessName) {
+  return "One Pager_" + businessName + ".pdf";
+}
+
+// ── Status lifecycle (Section 13) ─────────────────────────────────────────
+var STATUS_GENERATED = "Generated";
+var STATUS_APPROVED = "Approved";
+var STATUS_DRAFT = "Draft";
+var STATUS_ERROR_PREFIX = "Error";
+
+// ── Output folder fallback (Section 3 / Section 4) ────────────────────────
+// Used when a profile's FolderId is blank. This is the "ColdEmails" parent
+// folder from the design doc's Resources table.
+var DEFAULT_FOLDER_ID = "1ZDtlh49nW7HMX9TC1Bi80ni_eN2j8ofL";
+
+// ── Script Properties keys (Section 10 / 11) ──────────────────────────────
+// Set via the Apps Script editor: Project Settings (gear) → Script Properties.
+// Never hardcode the values here.
+var PROP_BASE_URL = "BRANDSIQ_BASE_URL";
+var PROP_API_KEY = "INTEGRATIONS_API_KEY";
+
+// BrandsIQ endpoint path appended to BRANDSIQ_BASE_URL.
+var BRANDSIQ_GENERATE_PATH = "/api/integrations/generate-response";
+
+// ── BrandsIQ request limits (mirrors integrationGenerateSchema) ───────────
+// reviewText must be 1–4000 chars or the endpoint returns 400. The script
+// errors such rows rather than calling (operator decision).
+var REVIEW_MAX = 4000;
+var PLATFORM = "Google";
+
+// ── 429 backoff tuning (Section 12: 6-min execution ceiling) ──────────────
+// Up to MAX_RETRIES retries on a 429, sleeping BASE_BACKOFF_MS * 2^attempt
+// (plus jitter). Worst case ~14s of sleep per call — well under 6 minutes.
+var MAX_RETRIES = 3;
+var BASE_BACKOFF_MS = 2000;
+var MAX_JITTER_MS = 500;
+
+// ── Timezone (Section 9 / 16) ─────────────────────────────────────────────
+// Authoritative copy is in appsscript.json ("timeZone"). Used for the dated
+// subfolder name and the date columns so "today" matches the local day.
+var TIMEZONE = "Europe/Berlin";
+
+// Max length of an error message written into the Status cell (keeps the cell
+// readable; full errors still go to the execution log).
+var STATUS_ERROR_MAX_LEN = 250;

--- a/scripts/one-pager-mailer/Drive.gs
+++ b/scripts/one-pager-mailer/Drive.gs
@@ -1,0 +1,43 @@
+/**
+ * Drive.gs — output-folder operations.
+ *
+ * Spec: docs/MVP_Phase-1/ONE_PAGER_MAILER_DESIGN.md (Sections 9, 16).
+ */
+
+/**
+ * Find-or-create a subfolder of `parent` named `dateStr` (YYYY-MM-DD). Drive
+ * allows same-named folders, so this is an explicit find-then-create — a blind
+ * create would spawn a duplicate dated folder for the second row of the day.
+ *
+ * @param {Folder} parent
+ * @param {string} dateStr  e.g. "2026-06-19"
+ * @return {Folder}
+ */
+function findOrCreateDatedSubfolder(parent, dateStr) {
+  var existing = parent.getFoldersByName(dateStr); // scoped to direct children
+  if (existing.hasNext()) {
+    return existing.next();
+  }
+  return parent.createFolder(dateStr);
+}
+
+/**
+ * Move a deck into a destination folder. Uses File.moveTo (current Drive API) —
+ * the old addFile/removeFile pattern is deprecated and leaves multi-parented
+ * files. Moving does NOT change the file's ID/URL, so "One Pager Link" stays
+ * valid (Section 9).
+ *
+ * @param {string} deckId
+ * @param {Folder} destFolder
+ */
+function moveDeckToFolder(deckId, destFolder) {
+  DriveApp.getFileById(deckId).moveTo(destFolder);
+}
+
+/**
+ * The fallback parent folder used when a profile's FolderId is blank.
+ * @return {string}
+ */
+function defaultFolderId() {
+  return DEFAULT_FOLDER_ID;
+}

--- a/scripts/one-pager-mailer/Engine.gs
+++ b/scripts/one-pager-mailer/Engine.gs
@@ -1,0 +1,278 @@
+/**
+ * Engine.gs — the profile-agnostic two-phase engine.
+ *
+ * Phase 1: generate a one-pager deck per eligible prospect row.
+ * Phase 2: for approved rows, export the PDF and draft the cold email.
+ *
+ * The engine receives a ProfileName (chosen via the menu picker) and resolves
+ * everything else from that profile. Per-row work is wrapped so one bad row
+ * never aborts the batch. Per-row writes are immediate, so a 6-minute timeout
+ * mid-batch leaves completed rows recorded and the run is simply re-run to
+ * continue (Sections 7, 9, 12, 13, 14).
+ *
+ * Spec: docs/MVP_Phase-1/ONE_PAGER_MAILER_DESIGN.md.
+ */
+
+/**
+ * Phase 1 — generate one-pagers for a profile.
+ * @param {string} profileName
+ */
+function runPhase1(profileName) {
+  var profile = loadProfile(profileName);
+  var sheet = openProspectSheet(profile);
+  var headerMap = buildHeaderMap(sheet); // fails fast on bad headers
+
+  var range = sheet.getDataRange();
+  var values = range.getValues();
+  var processed = 0;
+  var skipped = 0;
+  var errored = 0;
+
+  for (var r = 1; r < values.length; r++) {
+    var rowValues = values[r];
+    var rowNumber = r + 1; // 1-based sheet row
+
+    if (isBlankRow_(rowValues)) {
+      continue;
+    }
+    if (shouldSkipPhase1_(rowValues, headerMap)) {
+      skipped++;
+      continue;
+    }
+
+    var ok = withRowGuard(sheet, rowNumber, headerMap, function () {
+      processPhase1Row(profile, sheet, rowNumber, rowValues, headerMap);
+    });
+    if (ok) {
+      processed++;
+    } else {
+      errored++;
+    }
+  }
+
+  toast_(
+    "Phase 1 (" + profileName + "): " + processed + " generated, " +
+      skipped + " skipped, " + errored + " errored."
+  );
+}
+
+/**
+ * Process one Phase-1 row: ensure the BrandsIQ response, copy + tokenize the
+ * deck, record the link and status.
+ * @private
+ */
+function processPhase1Row(profile, sheet, rowNumber, rowValues, headerMap) {
+  var businessName = trim_(getCell(rowValues, headerMap, "Business Name"));
+  if (businessName === "") {
+    throw new Error("Business Name is empty.");
+  }
+
+  // 1. Ensure the response (writes the cell before we copy the deck, so a
+  //    crash after the paid call still preserves the result).
+  var generatedResponse = ensureGeneratedResponse(sheet, rowNumber, rowValues, headerMap);
+
+  // 2. Copy the template into the parent folder.
+  var deck = copyTemplate(profile.SlideTemplateId, profile.FolderId, deckName(businessName));
+  var deckId = deck.getId();
+
+  // 3. Substitute tokens, then save.
+  var tokenMap = buildTokenMap(rowValues, headerMap, generatedResponse);
+  substituteTokensInDeck(deckId, tokenMap);
+
+  // 4. Record state.
+  setCell(sheet, rowNumber, headerMap, "One Pager Link", deck.getUrl());
+  setCell(sheet, rowNumber, headerMap, "Status", STATUS_GENERATED);
+}
+
+/**
+ * Phase 2 — draft cold emails for approved rows of a profile.
+ * @param {string} profileName
+ */
+function runPhase2(profileName) {
+  var profile = loadProfile(profileName);
+  var sheet = openProspectSheet(profile);
+  var headerMap = buildHeaderMap(sheet);
+
+  var parentFolder = DriveApp.getFolderById(profile.FolderId);
+
+  var values = sheet.getDataRange().getValues();
+  var drafted = 0;
+  var skipped = 0;
+  var errored = 0;
+
+  for (var r = 1; r < values.length; r++) {
+    var rowValues = values[r];
+    var rowNumber = r + 1;
+
+    if (isBlankRow_(rowValues)) {
+      continue;
+    }
+    var status = trim_(getCell(rowValues, headerMap, "Status"));
+    if (status !== STATUS_APPROVED) {
+      skipped++;
+      continue;
+    }
+
+    var ok = withRowGuard(sheet, rowNumber, headerMap, function () {
+      processPhase2Row(profile, parentFolder, sheet, rowNumber, rowValues, headerMap);
+    });
+    if (ok) {
+      drafted++;
+    } else {
+      errored++;
+    }
+  }
+
+  toast_(
+    "Phase 2 (" + profileName + "): " + drafted + " drafted, " +
+      skipped + " skipped, " + errored + " errored."
+  );
+}
+
+/**
+ * Process one approved Phase-2 row: dated subfolder, PDF, move deck, draft.
+ * @private
+ */
+function processPhase2Row(profile, parentFolder, sheet, rowNumber, rowValues, headerMap) {
+  var email = trim_(getCell(rowValues, headerMap, "Email"));
+  var onePagerLink = trim_(getCell(rowValues, headerMap, "One Pager Link"));
+  if (email === "") {
+    throw new Error("Email is missing.");
+  }
+  if (onePagerLink === "") {
+    throw new Error("One Pager Link is missing.");
+  }
+
+  var businessName = trim_(getCell(rowValues, headerMap, "Business Name"));
+  var deckId = deckIdFromUrl_(onePagerLink);
+
+  // Compute "today" ONCE so the subfolder name and First Contact Date stay
+  // identical even across a midnight boundary.
+  var now = new Date();
+  var dateStr = Utilities.formatDate(now, TIMEZONE, "yyyy-MM-dd");
+
+  // 1. Find-or-create the dated subfolder.
+  var subFolder = findOrCreateDatedSubfolder(parentFolder, dateStr);
+
+  // 2. Export the PDF into the subfolder (reuse the blob for the attachment).
+  var exported = exportDeckToPdf(deckId, subFolder, pdfName(businessName));
+
+  // 3. Move the deck into the same subfolder (preserves ID/URL).
+  moveDeckToFolder(deckId, subFolder);
+
+  // 4. Build the email from the profile templates.
+  var generatedResponse = trim_(getCell(rowValues, headerMap, "Generated Response"));
+  var tokenMap = buildTokenMap(rowValues, headerMap, generatedResponse);
+  var subject = substituteTokensInString(profile.EmailSubject, tokenMap);
+  var emailBody = substituteTokensInString(profile.EmailBody, tokenMap);
+
+  // 5. Create the Gmail draft (never sends).
+  createGmailDraft(email, subject, emailBody, exported.blob);
+
+  // 6. Record state — only after the draft succeeds.
+  var followUp = new Date(now);
+  followUp.setDate(followUp.getDate() + 7); // +7 calendar days (DST-safe)
+
+  setDateCell(sheet, rowNumber, headerMap, "First Contact Date", now);
+  setDateCell(sheet, rowNumber, headerMap, "Follow-up 1 Date", followUp);
+  setCell(sheet, rowNumber, headerMap, "Status", STATUS_DRAFT);
+}
+
+// ── Skip logic ────────────────────────────────────────────────────────────
+
+/**
+ * Phase 1 skip rule (Section 7): skip a row that already has a One Pager Link,
+ * OR whose Status is non-blank and not an Error. Blank or "Error[: ...]" rows
+ * remain eligible so genuine retries work.
+ * @private
+ */
+function shouldSkipPhase1_(rowValues, headerMap) {
+  var link = trim_(getCell(rowValues, headerMap, "One Pager Link"));
+  if (link !== "") {
+    return true;
+  }
+  var status = trim_(getCell(rowValues, headerMap, "Status"));
+  if (status === "") {
+    return false; // eligible
+  }
+  return !isErrorStatus_(status); // non-blank, non-Error → skip
+}
+
+/**
+ * True for "Error" and "Error: <message>" (case-sensitive prefix per Section 13).
+ * @private
+ */
+function isErrorStatus_(status) {
+  return status === STATUS_ERROR_PREFIX || status.indexOf(STATUS_ERROR_PREFIX + ":") === 0;
+}
+
+// ── Per-row error guard ─────────────────────────────────────────────────────
+
+/**
+ * Run `fn` for one row; on throw, set Status = "Error: <message>" and continue.
+ * Never lets the guard itself throw (a failed Status write is logged, swallowed).
+ *
+ * @return {boolean} true on success, false if the row errored.
+ * @private
+ */
+function withRowGuard(sheet, rowNumber, headerMap, fn) {
+  try {
+    fn();
+    return true;
+  } catch (e) {
+    var message = e && e.message ? e.message : String(e);
+    if (message.length > STATUS_ERROR_MAX_LEN) {
+      message = message.substring(0, STATUS_ERROR_MAX_LEN);
+    }
+    try {
+      setCell(sheet, rowNumber, headerMap, "Status", STATUS_ERROR_PREFIX + ": " + message);
+    } catch (writeErr) {
+      // Swallow a secondary failure so the batch keeps going.
+      Logger.log("Failed to write Error status on row " + rowNumber + ": " + writeErr);
+    }
+    Logger.log("Row " + rowNumber + " error: " + (e && e.stack ? e.stack : message));
+    return false;
+  }
+}
+
+// ── Small helpers ───────────────────────────────────────────────────────────
+
+/**
+ * A row is "blank" if every cell trims to empty. Lets us ignore trailing empty
+ * rows that getDataRange may include.
+ * @private
+ */
+function isBlankRow_(rowValues) {
+  for (var i = 0; i < rowValues.length; i++) {
+    if (trim_(rowValues[i]) !== "") {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Extract a Slides/Drive file ID from a deck URL like
+ * https://docs.google.com/presentation/d/<ID>/edit
+ * @private
+ */
+function deckIdFromUrl_(url) {
+  var match = String(url).match(/\/d\/([a-zA-Z0-9_-]+)/);
+  if (match && match[1]) {
+    return match[1];
+  }
+  throw new Error("Could not parse a deck ID from One Pager Link: " + url);
+}
+
+/**
+ * Show a transient toast in the active spreadsheet. Best-effort (no-op if the
+ * UI isn't available, e.g. an unattended run).
+ * @private
+ */
+function toast_(message) {
+  try {
+    SpreadsheetApp.getActiveSpreadsheet().toast(message, MENU_TITLE, 8);
+  } catch (e) {
+    Logger.log(message);
+  }
+}

--- a/scripts/one-pager-mailer/Gmail.gs
+++ b/scripts/one-pager-mailer/Gmail.gs
@@ -1,0 +1,23 @@
+/**
+ * Gmail.gs — draft creation.
+ *
+ * v1 is DRAFT-ONLY. The script never sends. Drafts do not consume the daily
+ * send quota (Section 9 / 12).
+ *
+ * Spec: docs/MVP_Phase-1/ONE_PAGER_MAILER_DESIGN.md Section 9.
+ */
+
+/**
+ * Create a Gmail draft to `to` with the PDF attached.
+ *
+ * @param {string} to       recipient (the row's Email)
+ * @param {string} subject  token-substituted subject
+ * @param {string} body     token-substituted body (plain text; line breaks in
+ *                          the EmailBody cell are preserved)
+ * @param {Blob} pdfBlob    the exported one-pager PDF
+ * @return {GmailDraft}
+ */
+function createGmailDraft(to, subject, body, pdfBlob) {
+  // createDraft — NOT sendEmail. v1 never sends directly.
+  return GmailApp.createDraft(to, subject, body, { attachments: [pdfBlob] });
+}

--- a/scripts/one-pager-mailer/Menu.gs
+++ b/scripts/one-pager-mailer/Menu.gs
@@ -1,0 +1,96 @@
+/**
+ * Menu.gs — custom menu + profile picker.
+ *
+ * Apps Script menu callbacks are fresh, ZERO-ARGUMENT executions — a clicked
+ * item can't be handed the profile name, and dynamically-generated per-profile
+ * handlers don't survive between the menu build (onOpen) and the click. So the
+ * menu has two FIXED items; each pops a picker that lists profiles read LIVE
+ * from the registry and dispatches the chosen one into the engine. This honors
+ * the doc's data-driven intent (adding a registry row needs no code change) and
+ * is more robust — the picker reads the registry at click time, not just on
+ * reopen.
+ *
+ * Spec: docs/MVP_Phase-1/ONE_PAGER_MAILER_DESIGN.md Section 6.
+ */
+
+/**
+ * Build the custom menu on spreadsheet open. Wrapped so a registry error here
+ * can't suppress the entire menu.
+ */
+function onOpen() {
+  try {
+    SpreadsheetApp.getUi()
+      .createMenu(MENU_TITLE)
+      .addItem("Generate one-pagers…", "menuGenerateOnePagers")
+      .addItem("Draft approved…", "menuDraftApproved")
+      .addToUi();
+  } catch (e) {
+    Logger.log("onOpen failed to build the menu: " + e);
+  }
+}
+
+/** Menu item → Phase 1. Picks a profile, then runs. */
+function menuGenerateOnePagers() {
+  var profileName = promptForProfile_("Generate one-pagers");
+  if (profileName === null) {
+    return; // cancelled or invalid
+  }
+  runPhase1(profileName);
+}
+
+/** Menu item → Phase 2. Picks a profile, then runs. */
+function menuDraftApproved() {
+  var profileName = promptForProfile_("Draft approved");
+  if (profileName === null) {
+    return;
+  }
+  runPhase2(profileName);
+}
+
+/**
+ * Show a numbered picker of the live profiles and return the chosen
+ * ProfileName, or null on cancel / invalid input.
+ *
+ * @param {string} action  label shown in the prompt title
+ * @return {string|null}
+ * @private
+ */
+function promptForProfile_(action) {
+  var ui = SpreadsheetApp.getUi();
+
+  var profiles;
+  try {
+    profiles = getProfiles();
+  } catch (e) {
+    ui.alert(MENU_TITLE, "Could not read the registry: " + e.message, ui.ButtonSet.OK);
+    return null;
+  }
+
+  if (profiles.length === 0) {
+    ui.alert(MENU_TITLE, "No profiles found in the registry.", ui.ButtonSet.OK);
+    return null;
+  }
+
+  var lines = [];
+  for (var i = 0; i < profiles.length; i++) {
+    lines.push((i + 1) + ") " + profiles[i].ProfileName);
+  }
+
+  var response = ui.prompt(
+    MENU_TITLE + " — " + action,
+    "Enter the number of the profile to run:\n\n" + lines.join("\n"),
+    ui.ButtonSet.OK_CANCEL
+  );
+
+  if (response.getSelectedButton() !== ui.Button.OK) {
+    return null; // cancelled
+  }
+
+  var raw = response.getResponseText().trim();
+  var choice = parseInt(raw, 10);
+  if (isNaN(choice) || choice < 1 || choice > profiles.length) {
+    ui.alert(MENU_TITLE, "Invalid selection: " + raw, ui.ButtonSet.OK);
+    return null;
+  }
+  return profiles[choice - 1].ProfileName;
+}

--- a/scripts/one-pager-mailer/README.md
+++ b/scripts/one-pager-mailer/README.md
@@ -1,0 +1,126 @@
+# One-Pager Mailer — Google Apps Script
+
+A bound Google Apps Script that turns rows of prospect data into personalized
+BrandsIQ "one-pager" flyers (Google Slides → PDF) and drafts a cold email with
+the flyer attached.
+
+> **This is not part of the Next.js build.** These `.gs` files are pasted into
+> the Google Apps Script editor. They are version-controlled here for review and
+> history only — nothing imports, compiles, or lints them as part of the app.
+
+**Authoritative spec:** [`docs/MVP_Phase-1/ONE_PAGER_MAILER_DESIGN.md`](../../docs/MVP_Phase-1/ONE_PAGER_MAILER_DESIGN.md)
+
+---
+
+## What it does
+
+Two manually-run phases with a human review step between:
+
+1. **Generate one-pagers** — for each eligible prospect row: call BrandsIQ for an
+   AI reply to the prospect's own review, copy the slide template, substitute
+   tokens, and record the deck link. Decks sit loose in the parent folder.
+2. **(You) review** — open each generated deck, confirm the text fits, set
+   `Status = Approved` on the rows that are ready.
+3. **Draft approved** — for each approved row: export the deck to PDF into a
+   dated subfolder, move the deck there, and create a Gmail **draft** (never
+   sent) to the prospect with the PDF attached.
+
+It is **profile-driven**: one row per campaign in the bound `Marketing Profiles`
+registry. Adding a campaign is pure data entry — no code change.
+
+---
+
+## Files
+
+| File | Responsibility |
+| --- | --- |
+| `appsscript.json` | Manifest: timezone (`Europe/Berlin`), V8, OAuth scopes |
+| `Config.gs` | Constants: headers, token map, property keys, defaults |
+| `Menu.gs` | `onOpen` menu + the two handlers + the profile picker |
+| `Engine.gs` | `runPhase1` / `runPhase2`, row loops, skip logic, error guard |
+| `Brandsiq.gs` | The generate-response call + 429 backoff |
+| `Sheets.gs` | Registry/profile loading, header map, by-header cell access |
+| `Slides.gs` | Template copy, token substitution, PDF export |
+| `Drive.gs` | Dated subfolder find-or-create, deck move |
+| `Gmail.gs` | Draft creation |
+
+Apps Script merges all `.gs` files into one global scope, so the split is purely
+for readability — function names are globally unique.
+
+---
+
+## Install
+
+1. **Open the editor under the right account.** Open the `Marketing Profiles`
+   spreadsheet, then **Extensions → Apps Script**. If you have multiple Google
+   accounts signed in and it fails to open, use an **Incognito window signed into
+   only the account that owns the spreadsheet**.
+2. **Paste the files.** In the editor, create one script file per `.gs` above
+   (the `+` next to "Files") and paste each file's contents. Replace the default
+   `Code.gs` or leave it empty.
+3. **Set the manifest.** In **Project Settings**, tick *"Show appsscript.json
+   manifest file in editor"*, then open `appsscript.json` and replace it with
+   this folder's `appsscript.json` (sets the timezone and OAuth scopes).
+4. **Confirm the timezone** is `Europe/Berlin` (Project Settings → Time zone, or
+   the manifest above).
+5. **Set Script Properties** (Project Settings → Script Properties → Add):
+   - `BRANDSIQ_BASE_URL` — the deployed BrandsIQ URL, no trailing slash
+     (e.g. `https://brandsiq.app`).
+   - `INTEGRATIONS_API_KEY` — the same key set on the BrandsIQ server
+     (Vercel env var `INTEGRATIONS_API_KEY`). They must match exactly.
+6. **Authorize.** Reload the spreadsheet; the **BrandsIQ Mailer** menu appears.
+   The first run triggers Google's OAuth consent screen — approve the requested
+   scopes (Sheets, Slides, Drive, Gmail compose, external requests).
+
+---
+
+## Operate
+
+- **BrandsIQ Mailer → Generate one-pagers…** → pick a profile → Phase 1 runs.
+  A toast reports how many were generated / skipped / errored.
+- Open each generated deck from its `One Pager Link`, confirm the text fits
+  (see the autofit note below), and set `Status = Approved`.
+- **BrandsIQ Mailer → Draft approved…** → pick a profile → Phase 2 runs.
+  Check Gmail → Drafts.
+
+### Registry (`Marketing Profiles` → `Profiles` tab)
+
+One row per campaign. Required: `ProfileName`, `SpreadsheetId`, `TabName`,
+`SlideTemplateId`, `EmailSubject`, `EmailBody`. `FolderId` may be blank (falls
+back to the default ColdEmails folder). The rest are human-readable labels.
+
+### Prospect sheet
+
+Read columns (exact header names): `Business Name`, `Num of reviews per month`,
+`Ratings`, `Address`, `Review`, `Email`. Written columns: `Generated Response`,
+`One Pager Link`, `Status`, `First Contact Date`, `Follow-up 1 Date`. These
+written columns **must exist** (the script validates headers before processing).
+
+### Tokens
+
+`{{Business Name}}`, `{{Address}}`, `{{NRPM}}`, `{{Ratings}}`, `{{Review}}`,
+`{{Generated Response}}` — usable in the slide template and the email
+subject/body. Exact, case-sensitive match (braces included). A mismatch leaves
+the literal token visible.
+
+---
+
+## Things to know
+
+- **Draft-only.** v1 never sends email. It creates Gmail drafts.
+- **Idempotent + resumable.** Phase 1 skips rows that already have a
+  `One Pager Link` or a completed `Status`, and reuses an existing
+  `Generated Response` (no re-call). If a run hits Apps Script's 6-minute limit,
+  just **run it again** — it continues from where it stopped.
+- **Autofit caveat.** The Review/response text boxes use "shrink text on
+  overflow". The script saves the deck but a server-side save does **not**
+  recompute autofit — only opening the deck in the editor does. **Open each deck
+  during review**; approving without opening risks clipped text in the PDF.
+- **Bad reviews.** An empty or >4000-char `Review` is marked
+  `Status = Error: …` and skipped (the API would reject it).
+- **Errors don't stop the batch.** Any per-row failure sets
+  `Status = Error: <message>` and the run continues. Fix and re-run; `Error`
+  rows are eligible again.
+- **Status lifecycle:** `(empty)` → `Generated` → `Approved` (you) → `Draft`.
+  To exclude historical rows, set their `Status` to a terminal value like
+  `Sent` (avoid `Generated` / `Approved` / `Draft`).

--- a/scripts/one-pager-mailer/Sheets.gs
+++ b/scripts/one-pager-mailer/Sheets.gs
@@ -1,0 +1,237 @@
+/**
+ * Sheets.gs — registry/profile loading + header-mapped cell access.
+ *
+ * All spreadsheet reads/writes go through here so the rest of the engine can
+ * address columns by header NAME, never by position (Section 5.1 / 16).
+ *
+ * Spec: docs/MVP_Phase-1/ONE_PAGER_MAILER_DESIGN.md (Sections 3, 4, 5).
+ */
+
+/**
+ * Read the registry (bound spreadsheet → Profiles tab) into an array of
+ * profile objects. The registry spreadsheet ID is never hardcoded — being a
+ * bound script, we read our own active spreadsheet (Section 3).
+ *
+ * @return {Array<Object>} one object per non-blank registry row, keyed by the
+ *   registry column headers. Blank rows (no ProfileName) are skipped.
+ */
+function getProfiles() {
+  var ss = SpreadsheetApp.getActiveSpreadsheet();
+  var sheet = ss.getSheetByName(PROFILES_TAB);
+  if (!sheet) {
+    throw new Error(
+      'Registry tab "' + PROFILES_TAB + '" not found in the active spreadsheet.'
+    );
+  }
+
+  var values = sheet.getDataRange().getValues();
+  if (values.length < 2) {
+    return []; // header row only, or empty
+  }
+
+  var headerMap = buildHeaderMapFromRow_(values[0]);
+
+  // Validate the registry has the columns we need at all.
+  var missing = [];
+  for (var f = 0; f < PROFILE_FIELDS.length; f++) {
+    if (!(PROFILE_FIELDS[f] in headerMap)) {
+      missing.push(PROFILE_FIELDS[f]);
+    }
+  }
+  if (missing.length > 0) {
+    throw new Error(
+      'Registry "' + PROFILES_TAB + '" is missing column(s): ' + missing.join(", ")
+    );
+  }
+
+  var profiles = [];
+  var seenNames = {};
+  for (var r = 1; r < values.length; r++) {
+    var row = values[r];
+    var name = trim_(row[headerMap.ProfileName]);
+    if (name === "") {
+      continue; // skip blank rows
+    }
+    if (seenNames[name]) {
+      throw new Error('Duplicate ProfileName in registry: "' + name + '".');
+    }
+    seenNames[name] = true;
+
+    var profile = {};
+    for (var i = 0; i < PROFILE_FIELDS.length; i++) {
+      var field = PROFILE_FIELDS[i];
+      profile[field] = trim_(row[headerMap[field]]);
+    }
+    profiles.push(profile);
+  }
+  return profiles;
+}
+
+/**
+ * Load one profile by ProfileName, validate its required fields, and apply the
+ * FolderId default. IDs are trimmed (stray spaces/newlines break openById).
+ *
+ * @param {string} name
+ * @return {Object} the validated profile (FolderId guaranteed non-empty).
+ */
+function loadProfile(name) {
+  var profiles = getProfiles();
+  var found = null;
+  for (var i = 0; i < profiles.length; i++) {
+    if (profiles[i].ProfileName === name) {
+      found = profiles[i];
+      break;
+    }
+  }
+  if (!found) {
+    throw new Error('Profile "' + name + '" not found in the registry.');
+  }
+
+  // Fail fast on any blank required field, naming it.
+  for (var f = 0; f < PROFILE_REQUIRED_FIELDS.length; f++) {
+    var field = PROFILE_REQUIRED_FIELDS[f];
+    if (!found[field] || found[field] === "") {
+      throw new Error(
+        'Profile "' + name + '" is missing required field "' + field + '".'
+      );
+    }
+  }
+
+  // FolderId may be blank → fall back to the default ColdEmails folder.
+  if (!found.FolderId || found.FolderId === "") {
+    found.FolderId = defaultFolderId();
+  }
+  return found;
+}
+
+/**
+ * Open a prospect sheet (by SpreadsheetId + TabName from a profile) and return
+ * its Sheet object.
+ *
+ * @param {Object} profile
+ * @return {Sheet}
+ */
+function openProspectSheet(profile) {
+  var ss = SpreadsheetApp.openById(profile.SpreadsheetId);
+  var sheet = ss.getSheetByName(profile.TabName);
+  if (!sheet) {
+    throw new Error(
+      'Tab "' + profile.TabName + '" not found in spreadsheet ' + profile.SpreadsheetId + "."
+    );
+  }
+  return sheet;
+}
+
+/**
+ * Build a header → 0-based column index map for a prospect sheet, validating
+ * that every REQUIRED header is present, exact, and unique. Fails fast BEFORE
+ * any row is processed (Section 14).
+ *
+ * @param {Sheet} sheet
+ * @return {Object} { headerName: zeroBasedColumnIndex }
+ */
+function buildHeaderMap(sheet) {
+  var lastCol = sheet.getLastColumn();
+  if (lastCol < 1) {
+    throw new Error("Prospect sheet has no columns.");
+  }
+  var headerRow = sheet.getRange(1, 1, 1, lastCol).getValues()[0];
+  var map = buildHeaderMapFromRow_(headerRow);
+
+  // Detect duplicate required headers (ambiguous → fail). buildHeaderMapFromRow_
+  // keeps the FIRST occurrence; we re-scan to catch duplicates explicitly.
+  var counts = {};
+  for (var c = 0; c < headerRow.length; c++) {
+    var h = trim_(headerRow[c]);
+    if (h === "") continue;
+    counts[h] = (counts[h] || 0) + 1;
+  }
+
+  var missing = [];
+  var duplicated = [];
+  for (var i = 0; i < REQUIRED_PROSPECT_HEADERS.length; i++) {
+    var req = REQUIRED_PROSPECT_HEADERS[i];
+    if (!(req in map)) {
+      missing.push(req);
+    } else if (counts[req] > 1) {
+      duplicated.push(req);
+    }
+  }
+  if (missing.length > 0) {
+    throw new Error("Prospect sheet is missing required column(s): " + missing.join(", "));
+  }
+  if (duplicated.length > 0) {
+    throw new Error(
+      "Prospect sheet has duplicate column header(s): " + duplicated.join(", ")
+    );
+  }
+  return map;
+}
+
+/**
+ * Internal: header row → { trimmedHeader: firstColumnIndex }.
+ * Trims trailing/leading whitespace on header cells; case and internal spaces
+ * stay significant (exact-match token rules, Section 5.4).
+ * @private
+ */
+function buildHeaderMapFromRow_(headerRow) {
+  var map = {};
+  for (var c = 0; c < headerRow.length; c++) {
+    var h = trim_(headerRow[c]);
+    if (h === "") continue;
+    if (!(h in map)) {
+      map[h] = c; // keep first occurrence
+    }
+  }
+  return map;
+}
+
+// ── By-header cell access ─────────────────────────────────────────────────
+// rowValues is a 0-based array for a single row (as returned by getValues()).
+// rowNumber is the 1-based sheet row for writes.
+
+/**
+ * Read a cell value from a row-values array by header name.
+ * @return {*} raw cell value (may be number/Date/string/"").
+ */
+function getCell(rowValues, headerMap, header) {
+  var idx = headerMap[header];
+  if (idx === undefined) {
+    throw new Error('Unknown column "' + header + '".');
+  }
+  return rowValues[idx];
+}
+
+/**
+ * Write a string value into a cell immediately (not batched), so a 6-minute
+ * timeout mid-batch still records completed rows (Section 12).
+ */
+function setCell(sheet, rowNumber, headerMap, header, value) {
+  var idx = headerMap[header];
+  if (idx === undefined) {
+    throw new Error('Unknown column "' + header + '".');
+  }
+  sheet.getRange(rowNumber, idx + 1).setValue(value);
+}
+
+/**
+ * Write a real Date value into a cell (Sheets date serial, not text), so it
+ * sorts/filters correctly (Section 9).
+ */
+function setDateCell(sheet, rowNumber, headerMap, header, dateValue) {
+  var idx = headerMap[header];
+  if (idx === undefined) {
+    throw new Error('Unknown column "' + header + '".');
+  }
+  sheet.getRange(rowNumber, idx + 1).setValue(dateValue);
+}
+
+/**
+ * Trim a cell value to a string. Numbers/Dates/blank cells are coerced to a
+ * string first so callers always get a string back.
+ * @private
+ */
+function trim_(value) {
+  if (value === null || value === undefined) return "";
+  return String(value).trim();
+}

--- a/scripts/one-pager-mailer/Slides.gs
+++ b/scripts/one-pager-mailer/Slides.gs
@@ -1,0 +1,114 @@
+/**
+ * Slides.gs — template copy, token substitution, and PDF export.
+ *
+ * Spec: docs/MVP_Phase-1/ONE_PAGER_MAILER_DESIGN.md (Sections 5, 7, 9, 16).
+ */
+
+/**
+ * Build the token → string-value map for one prospect row. Covers every token
+ * used in EITHER the slide deck or the email (Section 5.3). Values are
+ * stringified because replaceAllText / string replace require strings, and
+ * Sheets cells may hold numbers or dates.
+ *
+ * @param {Array} rowValues
+ * @param {Object} headerMap
+ * @param {string} generatedResponse  the just-ensured Generated Response text
+ * @return {Object} { "{{Token}}": "value" }
+ */
+function buildTokenMap(rowValues, headerMap, generatedResponse) {
+  var map = {};
+  for (var token in TOKEN_TO_COLUMN) {
+    if (!TOKEN_TO_COLUMN.hasOwnProperty(token)) continue;
+    var column = TOKEN_TO_COLUMN[token];
+    var value;
+    if (column === "Generated Response") {
+      // Prefer the freshly-ensured value over re-reading the cell.
+      value = generatedResponse;
+    } else {
+      value = getCell(rowValues, headerMap, column);
+    }
+    map[token] = stringify_(value);
+  }
+  return map;
+}
+
+/**
+ * Copy the slide template directly into the parent output folder, named
+ * "One Pager_{Business Name}".
+ *
+ * @param {string} templateId
+ * @param {string} folderId
+ * @param {string} name
+ * @return {File} the new deck file
+ */
+function copyTemplate(templateId, folderId, name) {
+  var templateFile = DriveApp.getFileById(templateId);
+  var folder = DriveApp.getFolderById(folderId);
+  return templateFile.makeCopy(name, folder);
+}
+
+/**
+ * Substitute every mapped token in the deck and save. Unmapped tokens (if any)
+ * are left untouched; a token absent from the deck is a no-op.
+ *
+ * @param {string} deckId
+ * @param {Object} tokenMap
+ */
+function substituteTokensInDeck(deckId, tokenMap) {
+  var presentation = SlidesApp.openById(deckId);
+  for (var token in tokenMap) {
+    if (!tokenMap.hasOwnProperty(token)) continue;
+    // Plain-text find form (not RegExp) so literal {{...}} needs no escaping.
+    // matchCase=true so {{Ratings}} never matches {{ratings}} (Section 5.4).
+    presentation.replaceAllText(token, tokenMap[token], true);
+  }
+  // Save AFTER all replaces and BEFORE exporting to PDF (Section 16).
+  // NOTE: this is a server-side save, not an editor render, so "shrink text on
+  // overflow" autofit is NOT recomputed here — that's the manual review step
+  // (Section 8). Long content may overflow the PDF unless a human opens the
+  // deck in the editor first.
+  presentation.saveAndClose();
+}
+
+/**
+ * Substitute every mapped token in a plain string (email subject/body).
+ * Unmapped tokens are left as-is. Tokens are disjoint, so order is irrelevant.
+ *
+ * @param {string} template
+ * @param {Object} tokenMap
+ * @return {string}
+ */
+function substituteTokensInString(template, tokenMap) {
+  var result = String(template);
+  for (var token in tokenMap) {
+    if (!tokenMap.hasOwnProperty(token)) continue;
+    result = result.split(token).join(tokenMap[token]); // literal global replace
+  }
+  return result;
+}
+
+/**
+ * Export a deck to a single multi-page PDF (all slides) and write it into the
+ * destination folder. Returns both the created file and the blob, so the same
+ * blob can be attached to the Gmail draft without re-exporting.
+ *
+ * @param {string} deckId
+ * @param {Folder} destFolder
+ * @param {string} pdfFileName
+ * @return {{file: File, blob: Blob}}
+ */
+function exportDeckToPdf(deckId, destFolder, pdfFileName) {
+  // getAs(PDF) exports ALL slides as one multi-page PDF — no per-slide loop.
+  var blob = DriveApp.getFileById(deckId).getAs(MimeType.PDF).setName(pdfFileName);
+  var file = destFolder.createFile(blob);
+  return { file: file, blob: blob };
+}
+
+/**
+ * Coerce a cell value to a string for token replacement. null/undefined → "".
+ * @private
+ */
+function stringify_(value) {
+  if (value === null || value === undefined) return "";
+  return String(value);
+}

--- a/scripts/one-pager-mailer/appsscript.json
+++ b/scripts/one-pager-mailer/appsscript.json
@@ -1,0 +1,13 @@
+{
+  "timeZone": "Europe/Berlin",
+  "runtimeVersion": "V8",
+  "exceptionLogging": "STACKDRIVER",
+  "oauthScopes": [
+    "https://www.googleapis.com/auth/spreadsheets",
+    "https://www.googleapis.com/auth/presentations",
+    "https://www.googleapis.com/auth/drive",
+    "https://www.googleapis.com/auth/gmail.compose",
+    "https://www.googleapis.com/auth/script.external_request",
+    "https://www.googleapis.com/auth/script.container.ui"
+  ]
+}


### PR DESCRIPTION
## What

Scaffolds the **Google Apps Script engine** for the One-Pager Mailer — the operator-facing half that drives the whole workflow. Implements `docs/MVP_Phase-1/ONE_PAGER_MAILER_DESIGN.md` end to end. Pairs with the already-merged BrandsIQ endpoint (#178).

For each prospect row: call BrandsIQ for an AI reply to the prospect's own review, copy a Slides template and substitute tokens (**Phase 1**) → operator reviews and approves → export a PDF into a dated subfolder and draft a cold email with it attached (**Phase 2**).

## Where it lives

`scripts/one-pager-mailer/` — version-controlled for review/history, but **not part of the Next.js build** (`.gs` is not matched by `tsconfig` `include`, `pageExtensions`, or `next` lint; a standalone `appsscript.json` is inert). These files are pasted into the Google Apps Script editor (bound to the `Marketing Profiles` spreadsheet). Includes a README with install + operate steps.

## Design points worth a look

- **Menu = two fixed items + a live profile picker.** Apps Script menu clicks are fresh zero-arg executions and can't be passed a profile name, and dynamically-generated per-profile handlers don't survive between menu-build and click. The picker reads profiles live from the registry, so adding a campaign is still pure data entry (honors the doc's intent; picker is also more current than a reopen-only menu).
- **Endpoint call** (`Brandsiq.gs`): `POST /api/integrations/generate-response` with a Bearer key read from **Script Properties** (never embedded). 429 exponential backoff (≤3 retries, capped well under the 6-min limit). Reply follows the review's detected language (no override). Empty/>4000-char reviews are errored (the endpoint would 400).
- **Idempotent + resumable**: Phase 1 skips rows with a `One Pager Link` or completed `Status` and reuses an existing `Generated Response`. A run that hits Apps Script's 6-minute ceiling is simply re-run to continue — per-row writes are immediate.
- **Per-row error guard**: any failure → `Status = "Error: <msg>"` and the batch continues; `Error` rows stay retry-eligible.
- **Phase 2**: draft-only (`createDraft`, never `sendEmail`); dated subfolder via explicit find-then-create; deck moved with `File.moveTo` (ID/URL preserved, so `One Pager Link` stays valid); real `Date` values written for `First Contact Date` / `Follow-up 1 Date` (+7 calendar days, DST-safe).

## Files

`appsscript.json` (manifest: Europe/Berlin TZ, V8, OAuth scopes) + `Config` / `Menu` / `Engine` / `Brandsiq` / `Sheets` / `Slides` / `Drive` / `Gmail` `.gs` + `README.md`.

## Verification

This is Apps Script — it can't run in this repo. Verified by self-review (call graph resolves; the per-row callbacks run synchronously inside the guard, so no deferred-closure bug; the 429 loop always returns/throws/continues-with-increment). `tsc --noEmit` confirms the `.gs` files are excluded from the app build.

End-to-end test is manual in Google (in the README): paste files → set Script Properties → Phase 1 on a `DE-Berlin` row (expect a German `Generated Response`, a deck, `Status=Generated`) → review/approve → Phase 2 (expect a dated subfolder, PDF, moved deck, a Gmail **draft** with the PDF, and real dates written).

## Scope

No changes to the Next.js app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
