### PR TITLE
fix(mailer): bound row loops by Business Name, not blank-row detection

### DIFF
--- a/scripts/one-pager-mailer/Engine.gs
+++ b/scripts/one-pager-mailer/Engine.gs
@@ -32,7 +32,13 @@ function runPhase1(profileName) {
     var rowValues = values[r];
     var rowNumber = r + 1; // 1-based sheet row
 
-    if (isBlankRow_(rowValues)) {
+    // Not a real prospect row (no Business Name) → skip SILENTLY. Business Name
+    // is the identifying column, so its absence is the true end-of-data signal.
+    // getDataRange() can extend past the last prospect when unrelated columns
+    // hold stray content (notes, leftover sample text, formatting), and we must
+    // never write an Error into such a row: doing so makes it non-blank and it
+    // would then be reprocessed on every subsequent run.
+    if (!hasBusinessName_(rowValues, headerMap)) {
       continue;
     }
     if (shouldSkipPhase1_(rowValues, headerMap)) {
@@ -104,7 +110,10 @@ function runPhase2(profileName) {
     var rowValues = values[r];
     var rowNumber = r + 1;
 
-    if (isBlankRow_(rowValues)) {
+    // Not a real prospect row (no Business Name) → skip silently, same as
+    // Phase 1. Prevents stray content in unrelated columns from being treated
+    // as a data row.
+    if (!hasBusinessName_(rowValues, headerMap)) {
       continue;
     }
     var status = trim_(getCell(rowValues, headerMap, "Status"));
@@ -238,17 +247,16 @@ function withRowGuard(sheet, rowNumber, headerMap, fn) {
 // ── Small helpers ───────────────────────────────────────────────────────────
 
 /**
- * A row is "blank" if every cell trims to empty. Lets us ignore trailing empty
- * rows that getDataRange may include.
+ * True if the row has a non-empty Business Name. This is the "is this a real
+ * prospect row?" test used to bound both phase loops: getDataRange() can extend
+ * past the last prospect (stray content in unrelated columns, trailing
+ * formatting), so we key on the identifying column rather than on "every cell
+ * is empty". A row without a Business Name is skipped silently — never
+ * processed, never stamped with an Error.
  * @private
  */
-function isBlankRow_(rowValues) {
-  for (var i = 0; i < rowValues.length; i++) {
-    if (trim_(rowValues[i]) !== "") {
-      return false;
-    }
-  }
-  return true;
+function hasBusinessName_(rowValues, headerMap) {
+  return trim_(getCell(rowValues, headerMap, "Business Name")) !== "";
 }
 
 /**


### PR DESCRIPTION
## What

Fixes a row-bounding bug in the One-Pager Mailer Apps Script found during the first real Phase 1 run.

## The bug

Both phase loops used `isBlankRow_` (every cell trims to empty) to detect the end of the prospect data. But `getDataRange()` extends past the last real prospect whenever unrelated columns hold stray content (leftover sample text, notes, trailing formatting). Those rows were then treated as data:

- Phase 1 ran `processPhase1Row` on them → threw `Business Name is empty` → `withRowGuard` stamped `Error: …` into each.
- **Self-perpetuating:** once an `Error` was written, the row was no longer blank, so every subsequent run reprocessed it — overwriting `Status` on rows the operator never meant to touch.

Observed live: a sheet with sample text in irrelevant columns down to row ~125 produced `Error: Business Name is empty` on rows 110–125, past the last real prospect (row 109).

## The fix

Key the "is this a real prospect row?" test on the **identifying column** instead of blank-detection. New `hasBusinessName_(rowValues, headerMap)` replaces `isBlankRow_`; a row with no `Business Name` is **skipped silently** in both phases — never processed, never stamped with an `Error`, never reprocessed. Robust to junk in unrelated columns on any sheet.

No behavior change for real prospect rows.

## Scope

`scripts/one-pager-mailer/Engine.gs` only. Apps Script — no Next.js app changes, nothing to build/test in CI.

## Verification

Re-paste `Engine.gs` into the bound Apps Script; run Phase 1. Rows below the last prospect (no `Business Name`) are skipped with no `Status` written; only real rows are processed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
